### PR TITLE
Create client runtime plugins once at client construction

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -321,7 +321,7 @@ class AwsPresignedFluentBuilderMethod(
             #{alternate_presigning_serializer}
 
             let runtime_plugins = #{Operation}::operation_runtime_plugins(
-                self.handle.runtime_plugins,
+                self.handle.runtime_plugins.clone(),
                 self.config_override
             )
                 .with_client_plugin(#{SigV4PresigningRuntimePlugin}::new(presigning_config, #{payload_override}))

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -320,9 +320,8 @@ class AwsPresignedFluentBuilderMethod(
             """
             #{alternate_presigning_serializer}
 
-            let runtime_plugins = #{Operation}::register_runtime_plugins(
-                #{RuntimePlugins}::new(),
-                self.handle.clone(),
+            let runtime_plugins = #{Operation}::operation_runtime_plugins(
+                self.handle.runtime_plugins,
                 self.config_override
             )
                 .with_client_plugin(#{SigV4PresigningRuntimePlugin}::new(presigning_config, #{payload_override}))
@@ -344,8 +343,7 @@ class AwsPresignedFluentBuilderMethod(
             *codegenScope,
             "Operation" to codegenContext.symbolProvider.toSymbol(section.operationShape),
             "OperationError" to section.operationErrorType,
-            "RuntimePlugins" to RuntimeType.smithyRuntimeApi(runtimeConfig)
-                .resolve("client::runtime_plugin::RuntimePlugins"),
+            "RuntimePlugins" to RuntimeType.runtimePlugins(runtimeConfig),
             "SharedInterceptor" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::interceptors")
                 .resolve("SharedInterceptor"),
             "SigV4PresigningRuntimePlugin" to AwsRuntimeType.presigningInterceptor(runtimeConfig)

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -139,7 +139,7 @@ class CredentialsIdentityResolverRegistration(
     override fun section(section: ServiceRuntimePluginSection): Writable = writable {
         when (section) {
             is ServiceRuntimePluginSection.AdditionalConfig -> {
-                rustBlockTemplate("if let Some(credentials_cache) = self.handle.conf.credentials_cache()") {
+                rustBlockTemplate("if let Some(credentials_cache) = ${section.serviceConfigName}.credentials_cache()") {
                     section.registerIdentityResolver(this, runtimeConfig) {
                         rustTemplate(
                             """

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGenerator.kt
@@ -240,15 +240,13 @@ class PaginatorGenerator private constructor(
                 if (codegenContext.smithyRuntimeMode.defaultToOrchestrator) {
                     rustTemplate(
                         """
-                        let runtime_plugins = #{operation}::register_runtime_plugins(
-                            #{RuntimePlugins}::new(),
-                            handle,
-                            None
+                        let runtime_plugins = #{operation}::operation_runtime_plugins(
+                            handle.runtime_plugins.clone(),
+                            None,
                         );
                         """,
                         *codegenScope,
-                        "RuntimePlugins" to RuntimeType.smithyRuntimeApi(runtimeConfig)
-                            .resolve("client::runtime_plugin::RuntimePlugins"),
+                        "RuntimePlugins" to RuntimeType.runtimePlugins(runtimeConfig),
                     )
                 }
             },

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -31,7 +31,7 @@ sealed class ServiceRuntimePluginSection(name: String) : Section(name) {
     /**
      * Hook for adding additional things to config inside service runtime plugins.
      */
-    data class AdditionalConfig(val newLayerName: String) : ServiceRuntimePluginSection("AdditionalConfig") {
+    data class AdditionalConfig(val newLayerName: String, val serviceConfigName: String) : ServiceRuntimePluginSection("AdditionalConfig") {
         /** Adds a value to the config bag */
         fun putConfigValue(writer: RustWriter, value: Writable) {
             writer.rust("$newLayerName.store_put(#T);", value)
@@ -107,27 +107,28 @@ class ServiceRuntimePluginGenerator(
         customizations: List<ServiceRuntimePluginCustomization>,
     ) {
         val additionalConfig = writable {
-            writeCustomizations(customizations, ServiceRuntimePluginSection.AdditionalConfig("cfg"))
+            writeCustomizations(customizations, ServiceRuntimePluginSection.AdditionalConfig("cfg", "_service_config"))
         }
         writer.rustTemplate(
             """
-            // TODO(enableNewSmithyRuntimeLaunch) Remove `allow(dead_code)` as well as a field `handle` when
-            //  the field is no longer used.
-            ##[allow(dead_code)]
             ##[derive(Debug)]
             pub(crate) struct ServiceRuntimePlugin {
-                handle: #{Arc}<crate::client::Handle>,
+                config: #{Option}<#{FrozenLayer}>,
             }
 
             impl ServiceRuntimePlugin {
-                pub fn new(handle: #{Arc}<crate::client::Handle>) -> Self {
-                    Self { handle }
+                pub fn new(_service_config: crate::config::Config) -> Self {
+                    Self {
+                        config: {
+                            #{config}
+                        },
+                    }
                 }
             }
 
             impl #{RuntimePlugin} for ServiceRuntimePlugin {
                 fn config(&self) -> #{Option}<#{FrozenLayer}> {
-                    #{config}
+                    self.config.clone()
                 }
 
                 fn interceptors(&self, interceptors: &mut #{InterceptorRegistrar}) {
@@ -145,13 +146,7 @@ class ServiceRuntimePluginGenerator(
                     rustTemplate(
                         """
                         let mut cfg = #{Layer}::new(${codegenContext.serviceShape.id.name.dq()});
-
-                        // TODO(enableNewSmithyRuntimeLaunch): Make it possible to set retry classifiers at the service level.
-                        //     Retry classifiers can also be set at the operation level and those should be added to the
-                        //     list of classifiers defined here, rather than replacing them.
-
                         #{additional_config}
-
                         Some(cfg.freeze())
                         """,
                         *codegenScope,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -41,6 +41,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTypeParameters
 import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
@@ -125,6 +126,7 @@ class FluentClientGenerator(
                         }
                     },
                 "RetryConfig" to RuntimeType.smithyTypes(runtimeConfig).resolve("retry::RetryConfig"),
+                "RuntimePlugins" to RuntimeType.runtimePlugins(runtimeConfig),
                 "TimeoutConfig" to RuntimeType.smithyTypes(runtimeConfig).resolve("timeout::TimeoutConfig"),
                 // TODO(enableNewSmithyRuntimeCleanup): Delete the generics when cleaning up middleware
                 "generics_decl" to generics.decl,
@@ -182,18 +184,13 @@ class FluentClientGenerator(
                     ##[derive(Debug)]
                     pub(crate) struct Handle {
                         pub(crate) conf: crate::Config,
+                        pub(crate) runtime_plugins: #{RuntimePlugins},
                     }
 
                     #{client_docs:W}
-                    ##[derive(::std::fmt::Debug)]
+                    ##[derive(#{Clone}, ::std::fmt::Debug)]
                     pub struct Client {
-                        handle: #{Arc}<Handle>
-                    }
-
-                    impl #{Clone} for Client {
-                        fn clone(&self) -> Self {
-                            Self { handle: self.handle.clone() }
-                        }
+                        handle: #{Arc}<Handle>,
                     }
 
                     impl Client {
@@ -215,7 +212,12 @@ class FluentClientGenerator(
                             }
 
                             Self {
-                                handle: #{Arc}::new(Handle { conf })
+                                handle: #{Arc}::new(
+                                    Handle {
+                                        conf: conf.clone(),
+                                        runtime_plugins: #{base_client_runtime_plugins}(conf),
+                                    }
+                                )
                             }
                         }
 
@@ -229,9 +231,7 @@ class FluentClientGenerator(
                         // This is currently kept around so the tests still compile in both modes
                         /// Creates a client with the given service configuration.
                         pub fn with_config<C, M, R>(_client: #{client}::Client<C, M, R>, conf: crate::Config) -> Self {
-                            Self {
-                                handle: #{Arc}::new(Handle { conf })
-                            }
+                            Self::from_conf(conf)
                         }
 
                         ##[doc(hidden)]
@@ -244,6 +244,7 @@ class FluentClientGenerator(
                     }
                     """,
                     *clientScope,
+                    "base_client_runtime_plugins" to baseClientRuntimePluginsFn(runtimeConfig),
                 )
             }
         }
@@ -505,8 +506,7 @@ class FluentClientGenerator(
                     "Operation" to operationSymbol,
                     "OperationError" to errorType,
                     "OperationOutput" to outputType,
-                    "RuntimePlugins" to RuntimeType.smithyRuntimeApi(runtimeConfig)
-                        .resolve("client::runtime_plugin::RuntimePlugins"),
+                    "RuntimePlugins" to RuntimeType.runtimePlugins(runtimeConfig),
                     "SendResult" to ClientRustModule.Client.customize.toType()
                         .resolve("internal::SendResult"),
                     "SdkError" to RuntimeType.sdkError(runtimeConfig),
@@ -516,9 +516,8 @@ class FluentClientGenerator(
                     ##[doc(hidden)]
                     pub async fn send_orchestrator(self) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}, #{HttpResponse}>> {
                         let input = self.inner.build().map_err(#{SdkError}::construction_failure)?;
-                        let runtime_plugins = #{Operation}::register_runtime_plugins(
-                            #{RuntimePlugins}::new(),
-                            self.handle,
+                        let runtime_plugins = #{Operation}::operation_runtime_plugins(
+                            self.handle.runtime_plugins.clone(),
                             self.config_override
                         );
                         #{Operation}::orchestrate(&runtime_plugins, input).await
@@ -646,6 +645,26 @@ class FluentClientGenerator(
         }
     }
 }
+
+private fun baseClientRuntimePluginsFn(runtimeConfig: RuntimeConfig): RuntimeType =
+    RuntimeType.forInlineFun("base_client_runtime_plugins", ClientRustModule.config) {
+        rustTemplate(
+            """
+            pub(crate) fn base_client_runtime_plugins(
+                config: crate::Config,
+            ) -> #{RuntimePlugins} {
+                #{RuntimePlugins}::new()
+                    .with_client_plugin(config.clone())
+                    .with_client_plugin(crate::config::ServiceRuntimePlugin::new(config))
+                    .with_client_plugin(#{NoAuthRuntimePlugin}::new())
+            }
+            """,
+            *preludeScope,
+            "RuntimePlugins" to RuntimeType.runtimePlugins(runtimeConfig),
+            "NoAuthRuntimePlugin" to RuntimeType.smithyRuntime(runtimeConfig)
+                .resolve("client::auth::no_auth::NoAuthRuntimePlugin"),
+        )
+    }
 
 /**
  * For a given `operation` shape, return a list of strings where each string describes the name and input type of one of

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -338,6 +338,8 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
             smithyTypes(runtimeConfig).resolve("config_bag::ConfigBag")
         fun configBagAccessors(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyRuntimeApi(runtimeConfig).resolve("client::config_bag_accessors::ConfigBagAccessors")
+        fun runtimePlugins(runtimeConfig: RuntimeConfig): RuntimeType =
+            smithyRuntimeApi(runtimeConfig).resolve("client::runtime_plugin::RuntimePlugins")
         fun boxError(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyRuntimeApi(runtimeConfig).resolve("box_error::BoxError")
         fun interceptor(runtimeConfig: RuntimeConfig): RuntimeType =


### PR DESCRIPTION
This PR refactors the fluent client so that the client runtime plugins are created exactly once at client creation time, and reused thereafter.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
