### PR TITLE
Python: Make sure to log errors from async handlers

### DIFF
--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerOperationHandlerGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerOperationHandlerGenerator.kt
@@ -115,7 +115,7 @@ class PythonServerOperationHandlerGenerator(
                     };
                     #{pyo3_asyncio}::tokio::into_future(coroutine)
                 })?;
-                result.await.map(|r| #{pyo3}::Python::with_gil(|py| r.extract::<$output>(py)))?
+                result.await.and_then(|r| #{pyo3}::Python::with_gil(|py| r.extract::<$output>(py)))
                 """,
                 *codegenScope,
             )


### PR DESCRIPTION
## Motivation and Context
We were skipping logging of the errors occurred during execution of asynchronous Python handlers due to the question mark at the end:
```
result.await.map(|r| #{pyo3}::Python::with_gil(|py| r.extract::<$output>(py)))? // <-
```

Any exception thrown in asynchronous Python handlers will be logged properly with this change.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
