### PR TITLE
Bifurcate the expected error message based on runtime mode

### DIFF
--- a/aws/sdk/integration-tests/s3/tests/endpoints.rs
+++ b/aws/sdk/integration-tests/s3/tests/endpoints.rs
@@ -62,6 +62,29 @@ async fn dual_stack() {
     );
 }
 
+#[cfg(aws_sdk_orchestrator_mode)]
+#[tokio::test]
+async fn multi_region_access_points() {
+    let (_captured_request, client) = test_client(|b| b);
+    let response = client
+        .get_object()
+        .bucket("arn:aws:s3::123456789012:accesspoint/mfzwi23gnjvgw.mrap")
+        .key("blah")
+        .send()
+        .await;
+    let error = response.expect_err("should fail—sigv4a is not supported");
+    assert!(
+        dbg!(format!(
+            "{}",
+            aws_smithy_types::error::display::DisplayErrorContext(&error)
+        ))
+        .contains("selected auth scheme / endpoint config mismatch"),
+        "message should contain the correct error, found: {:?}",
+        error
+    );
+}
+
+#[cfg(not(aws_sdk_orchestrator_mode))]
 #[tokio::test]
 async fn multi_region_access_points() {
     let (_captured_request, client) = test_client(|b| b);


### PR DESCRIPTION
## Motivation and Context
Makes a failing test `multi_region_access_points` pass in the orchestrator

## Description
The orchestrator has already an `AwsAuthStage` counterpart implemented (which is where the expected error for `multi_region_access_points` comes from in the middleware mode).

This PR just updates the expected error message in the test for the orchestrator to make it pass.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
