### PR TITLE
Better distinguish model and HTTP plugins

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -210,7 +210,7 @@ message = """The middleware system has been reworked as we push for a unified, s
 
 - A `ServiceShape` trait has been added.
 - The `Plugin` trait has been simplified.
-- The `HttpPlugin` and `ModelPlugin` marker traits have been added to better distinguish when plugins run and what they have access to.
+- The `HttpMarker` and `ModelPlugin` marker traits have been added to better distinguish when plugins run and what they have access to.
 - The `Operation` structure has been removed.
 - A `Scoped` `Plugin` has been added.
 
@@ -373,7 +373,7 @@ where
     }
 }
 
-impl HttpPlugin for PrintPlugin { }
+impl HttpMarker for PrintPlugin { }
 ```
 
 Alternatively, using the new `ServiceShape`, implemented on `Ser`:
@@ -400,7 +400,7 @@ let app = PokemonService::builder_with_plugins(/* HTTP plugins */, /* model plug
     .unwrap();
 ```
 
-To better distinguish when a plugin runs and what it has access to, `Plugin`s now have to additionally implement the `HttpPlugin` marker trait, the `ModelPlugin` marker trait, or both:
+To better distinguish when a plugin runs and what it has access to, `Plugin`s now have to additionally implement the `HttpMarker` marker trait, the `ModelPlugin` marker trait, or both:
 
 - A HTTP plugin acts on the HTTP request before it is deserialized, and acts on the HTTP response after it is serialized.
 - A model plugin acts on the modeled operation input after it is deserialized, and acts on the modeled operation output or the modeled operation error before it is serialized.
@@ -423,7 +423,7 @@ let layer = LayerPlugin::new::<SomeProtocol, SomeOperation>(plugin);
 
 ## Removal of `PluginPipeline`
 
-Since plugins now come in two flavors (`HttpPlugin` and `ModelPlugin`) that shouldn't be mixed in a collection of plugins, the primary way of concatenating plugins, `PluginPipeline` has been removed in favor of the `HttpPlugins` and `ModelPlugins` types, which eagerly check that whenever a plugin is pushed, it is of the expected type.
+Since plugins now come in two flavors (those marked with `HttpMarker` and those marked with `ModelPlugin`) that shouldn't be mixed in a collection of plugins, the primary way of concatenating plugins, `PluginPipeline` has been removed in favor of the `HttpPlugins` and `ModelPlugins` types, which eagerly check that whenever a plugin is pushed, it is of the expected type.
 
 This worked before, but you wouldn't be able to do apply this collection of plugins anywhere; if you tried to, the compilation error messages would not be very helpful:
 
@@ -447,7 +447,7 @@ let model_plugins = ModelPlugins::new()
     .push(&http_and_model_plugin);
 ```
 
-In the above example, `&http_and_model_plugin` implements both `HttpPlugin` and `ModelPlugin`, so we can add it to both collections.
+In the above example, `&http_and_model_plugin` implements both `HttpMarker` and `ModelPlugin`, so we can add it to both collections.
 
 ## Removal of `Operation`
 

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -586,3 +586,9 @@ message = "The naming `make_token` for fields and the API of `IdempotencyTokenPr
 references = ["smithy-rs#2783"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "ysaito1001"
+
+[[smithy-rs]]
+message = "Server `Plugin`s now need to be marked as a `HttpPlugin`, a `ModelPlugin`, or both. Check out the `plugin` module documentation for more information."
+references = ["smithy-rs#2827"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
+author = "david-perez"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -210,7 +210,7 @@ message = """The middleware system has been reworked as we push for a unified, s
 
 - A `ServiceShape` trait has been added.
 - The `Plugin` trait has been simplified.
-- The `HttpMarker` and `ModelPlugin` marker traits have been added to better distinguish when plugins run and what they have access to.
+- The `HttpMarker` and `ModelMarker` marker traits have been added to better distinguish when plugins run and what they have access to.
 - The `Operation` structure has been removed.
 - A `Scoped` `Plugin` has been added.
 
@@ -400,7 +400,7 @@ let app = PokemonService::builder_with_plugins(/* HTTP plugins */, /* model plug
     .unwrap();
 ```
 
-To better distinguish when a plugin runs and what it has access to, `Plugin`s now have to additionally implement the `HttpMarker` marker trait, the `ModelPlugin` marker trait, or both:
+To better distinguish when a plugin runs and what it has access to, `Plugin`s now have to additionally implement the `HttpMarker` marker trait, the `ModelMarker` marker trait, or both:
 
 - A HTTP plugin acts on the HTTP request before it is deserialized, and acts on the HTTP response after it is serialized.
 - A model plugin acts on the modeled operation input after it is deserialized, and acts on the modeled operation output or the modeled operation error before it is serialized.
@@ -423,7 +423,7 @@ let layer = LayerPlugin::new::<SomeProtocol, SomeOperation>(plugin);
 
 ## Removal of `PluginPipeline`
 
-Since plugins now come in two flavors (those marked with `HttpMarker` and those marked with `ModelPlugin`) that shouldn't be mixed in a collection of plugins, the primary way of concatenating plugins, `PluginPipeline` has been removed in favor of the `HttpPlugins` and `ModelPlugins` types, which eagerly check that whenever a plugin is pushed, it is of the expected type.
+Since plugins now come in two flavors (those marked with `HttpMarker` and those marked with `ModelMarker`) that shouldn't be mixed in a collection of plugins, the primary way of concatenating plugins, `PluginPipeline` has been removed in favor of the `HttpPlugins` and `ModelPlugins` types, which eagerly check that whenever a plugin is pushed, it is of the expected type.
 
 This worked before, but you wouldn't be able to do apply this collection of plugins anywhere; if you tried to, the compilation error messages would not be very helpful:
 
@@ -447,7 +447,7 @@ let model_plugins = ModelPlugins::new()
     .push(&http_and_model_plugin);
 ```
 
-In the above example, `&http_and_model_plugin` implements both `HttpMarker` and `ModelPlugin`, so we can add it to both collections.
+In the above example, `&http_and_model_plugin` implements both `HttpMarker` and `ModelMarker`, so we can add it to both collections.
 
 ## Removal of `Operation`
 

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -210,6 +210,7 @@ message = """The middleware system has been reworked as we push for a unified, s
 
 - A `ServiceShape` trait has been added.
 - The `Plugin` trait has been simplified.
+- The `HttpPlugin` and `ModelPlugin` marker traits have been added to better distinguish when plugins run and what they have access to.
 - The `Operation` structure has been removed.
 - A `Scoped` `Plugin` has been added.
 
@@ -371,6 +372,8 @@ where
         PrintService { inner, name: Op::ID.name() }
     }
 }
+
+impl HttpPlugin for PrintPlugin { }
 ```
 
 Alternatively, using the new `ServiceShape`, implemented on `Ser`:
@@ -397,6 +400,11 @@ let app = PokemonService::builder_with_plugins(/* HTTP plugins */, /* model plug
     .unwrap();
 ```
 
+To better distinguish when a plugin runs and what it has access to, `Plugin`s now have to additionally implement the `HttpPlugin` marker trait, the `ModelPlugin` marker trait, or both:
+
+- A HTTP plugin acts on the HTTP request before it is deserialized, and acts on the HTTP response after it is serialized.
+- A model plugin acts on the modeled operation input after it is deserialized, and acts on the modeled operation output or the modeled operation error before it is serialized.
+
 The motivation behind this change is to simplify the job of middleware authors, separate concerns, accomodate common cases better, and to improve composition internally.
 
 Because `Plugin` is now closer to `tower::Layer` we have two canonical converters:
@@ -412,6 +420,34 @@ let plugin = PluginLayer(layer);
 let plugin = /* some plugin */;
 let layer = LayerPlugin::new::<SomeProtocol, SomeOperation>(plugin);
 ```
+
+## Removal of `PluginPipeline`
+
+Since plugins now come in two flavors (`HttpPlugin` and `ModelPlugin`) that shouldn't be mixed in a collection of plugins, the primary way of concatenating plugins, `PluginPipeline` has been removed in favor of the `HttpPlugins` and `ModelPlugins` types, which eagerly check that whenever a plugin is pushed, it is of the expected type.
+
+This worked before, but you wouldn't be able to do apply this collection of plugins anywhere; if you tried to, the compilation error messages would not be very helpful:
+
+```rust
+use aws_smithy_http_server::plugin::PluginPipeline;
+
+let pipeline = PluginPipeline::new().push(http_plugin).push(model_plugin);
+```
+
+Now collections of plugins must contain plugins of the same flavor:
+
+```rust
+use aws_smithy_http_server::plugin::{HttpPlugins, ModelPlugins};
+
+let http_plugins = HttpPlugins::new()
+    .push(http_plugin)
+    // .push(model_plugin) // This fails to compile with a helpful error message.
+    .push(&http_and_model_plugin);
+let model_plugins = ModelPlugins::new()
+    .push(model_plugin)
+    .push(&http_and_model_plugin);
+```
+
+In the above example, `&http_and_model_plugin` implements both `HttpPlugin` and `ModelPlugin`, so we can add it to both collections.
 
 ## Removal of `Operation`
 
@@ -495,8 +531,8 @@ let scoped_plugin = Scoped::new::<SomeScope>(plugin);
 ```
 
 """
-references = ["smithy-rs#2740", "smithy-rs#2759", "smithy-rs#2779"]
-meta = { "breaking" = true, "tada" = false, "bug" = false }
+references = ["smithy-rs#2740", "smithy-rs#2759", "smithy-rs#2779", "smithy-rs#2827"]
+meta = { "breaking" = true, "tada" = true, "bug" = false }
 author = "hlbarber"
 
 [[smithy-rs]]
@@ -586,9 +622,3 @@ message = "The naming `make_token` for fields and the API of `IdempotencyTokenPr
 references = ["smithy-rs#2783"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "ysaito1001"
-
-[[smithy-rs]]
-message = "Server `Plugin`s now need to be marked as a `HttpPlugin`, a `ModelPlugin`, or both. Check out the `plugin` module documentation for more information."
-references = ["smithy-rs#2827"]
-meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
-author = "david-perez"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRootGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRootGenerator.kt
@@ -107,7 +107,7 @@ open class ServerRootGenerator(
             //!
             //! The [`$serviceName::builder_with_plugins`] method, returning [`$builderName`],
             //! accepts a plugin marked with [`HttpMarker`](aws_smithy_http_server::plugin::HttpMarker) and a 
-            //! plugin marked with [`ModelPlugin`](aws_smithy_http_server::plugin::ModelMarker).
+            //! plugin marked with [`ModelMarker`](aws_smithy_http_server::plugin::ModelMarker).
             //! Plugins allow you to build middleware which is aware of the operation it is being applied to.
             //!
             //! ```rust

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRootGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRootGenerator.kt
@@ -106,8 +106,8 @@ open class ServerRootGenerator(
             //! #### Plugins
             //!
             //! The [`$serviceName::builder_with_plugins`] method, returning [`$builderName`],
-            //! accepts a [`HttpPlugin`](aws_smithy_http_server::plugin::HttpPlugin) and a 
-            //! [`ModelPlugin`](aws_smithy_http_server::plugin::HttpPlugin).
+            //! accepts a plugin marked with [`HttpMarker`](aws_smithy_http_server::plugin::HttpMarker) and a 
+            //! plugin marked with [`ModelPlugin`](aws_smithy_http_server::plugin::ModelMarker).
             //! Plugins allow you to build middleware which is aware of the operation it is being applied to.
             //!
             //! ```rust

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRootGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRootGenerator.kt
@@ -106,7 +106,8 @@ open class ServerRootGenerator(
             //! #### Plugins
             //!
             //! The [`$serviceName::builder_with_plugins`] method, returning [`$builderName`],
-            //! accepts a [`Plugin`](aws_smithy_http_server::plugin::Plugin).
+            //! accepts a [`HttpPlugin`](aws_smithy_http_server::plugin::HttpPlugin) and a 
+            //! [`ModelPlugin`](aws_smithy_http_server::plugin::HttpPlugin).
             //! Plugins allow you to build middleware which is aware of the operation it is being applied to.
             //!
             //! ```rust
@@ -114,13 +115,13 @@ open class ServerRootGenerator(
             //! ## use #{SmithyHttpServer}::plugin::IdentityPlugin as LoggingPlugin;
             //! ## use #{SmithyHttpServer}::plugin::IdentityPlugin as MetricsPlugin;
             //! ## use #{Hyper}::Body;
-            //! use #{SmithyHttpServer}::plugin::PluginPipeline;
+            //! use #{SmithyHttpServer}::plugin::HttpPlugins;
             //! use $crateName::{$serviceName, $builderName};
             //!
-            //! let plugins = PluginPipeline::new()
+            //! let http_plugins = HttpPlugins::new()
             //!         .push(LoggingPlugin)
             //!         .push(MetricsPlugin);
-            //! let builder: $builderName<Body, _, _> = $serviceName::builder_with_plugins(plugins, IdentityPlugin);
+            //! let builder: $builderName<Body, _, _> = $serviceName::builder_with_plugins(http_plugins, IdentityPlugin);
             //! ```
             //!
             //! Check out [`#{SmithyHttpServer}::plugin`] to learn more about plugins.

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRuntimeTypesReExportsGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRuntimeTypesReExportsGenerator.kt
@@ -9,14 +9,12 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCargoDependency
-import software.amazon.smithy.rust.codegen.server.smithy.ServerRuntimeType
 
 class ServerRuntimeTypesReExportsGenerator(
     codegenContext: CodegenContext,
 ) {
     private val runtimeConfig = codegenContext.runtimeConfig
     private val codegenScope = arrayOf(
-        "Router" to ServerRuntimeType.router(runtimeConfig),
         "SmithyHttpServer" to ServerCargoDependency.smithyHttpServer(runtimeConfig).toType(),
     )
 
@@ -30,8 +28,11 @@ class ServerRuntimeTypesReExportsGenerator(
                 pub use #{SmithyHttpServer}::operation::OperationShape;
             }
             pub mod plugin {
+                pub use #{SmithyHttpServer}::plugin::HttpPlugins;
+                pub use #{SmithyHttpServer}::plugin::ModelPlugins;
+                pub use #{SmithyHttpServer}::plugin::HttpPlugin;
+                pub use #{SmithyHttpServer}::plugin::ModelPlugin;
                 pub use #{SmithyHttpServer}::plugin::Plugin;
-                pub use #{SmithyHttpServer}::plugin::PluginPipeline;
                 pub use #{SmithyHttpServer}::plugin::PluginStack;
             }
             pub mod request {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRuntimeTypesReExportsGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRuntimeTypesReExportsGenerator.kt
@@ -31,7 +31,7 @@ class ServerRuntimeTypesReExportsGenerator(
                 pub use #{SmithyHttpServer}::plugin::HttpPlugins;
                 pub use #{SmithyHttpServer}::plugin::ModelPlugins;
                 pub use #{SmithyHttpServer}::plugin::HttpMarker;
-                pub use #{SmithyHttpServer}::plugin::ModelPlugin;
+                pub use #{SmithyHttpServer}::plugin::ModelMarker;
                 pub use #{SmithyHttpServer}::plugin::Plugin;
                 pub use #{SmithyHttpServer}::plugin::PluginStack;
             }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRuntimeTypesReExportsGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerRuntimeTypesReExportsGenerator.kt
@@ -30,7 +30,7 @@ class ServerRuntimeTypesReExportsGenerator(
             pub mod plugin {
                 pub use #{SmithyHttpServer}::plugin::HttpPlugins;
                 pub use #{SmithyHttpServer}::plugin::ModelPlugins;
-                pub use #{SmithyHttpServer}::plugin::HttpPlugin;
+                pub use #{SmithyHttpServer}::plugin::HttpMarker;
                 pub use #{SmithyHttpServer}::plugin::ModelPlugin;
                 pub use #{SmithyHttpServer}::plugin::Plugin;
                 pub use #{SmithyHttpServer}::plugin::PluginStack;

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -476,7 +476,7 @@ class ServerServiceGenerator(
                 /// Check out [`HttpPlugins`](#{SmithyHttpServer}::plugin::HttpPlugins) and
                 /// [`ModelPlugins`](#{SmithyHttpServer}::plugin::ModelPlugins) if you need to apply
                 /// multiple plugins.
-                pub fn builder_with_plugins<Body, HttpPl: #{SmithyHttpServer}::plugin::HttpMarker, ModelPl: #{SmithyHttpServer}::plugin::ModelPlugin>(http_plugin: HttpPl, model_plugin: ModelPl) -> $builderName<Body, HttpPl, ModelPl> {
+                pub fn builder_with_plugins<Body, HttpPl: #{SmithyHttpServer}::plugin::HttpMarker, ModelPl: #{SmithyHttpServer}::plugin::ModelMarker>(http_plugin: HttpPl, model_plugin: ModelPl) -> $builderName<Body, HttpPl, ModelPl> {
                     $builderName {
                         #{NotSetFields:W},
                         http_plugin,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -136,7 +136,7 @@ class ServerServiceGenerator(
                 where
                     HandlerType: #{SmithyHttpServer}::operation::Handler<crate::operation_shape::$structName, HandlerExtractors>,
 
-                    ModelPlugin: #{SmithyHttpServer}::plugin::Plugin<
+                    ModelPl: #{SmithyHttpServer}::plugin::Plugin<
                         $serviceName,
                         crate::operation_shape::$structName,
                         #{SmithyHttpServer}::operation::IntoService<crate::operation_shape::$structName, HandlerType>
@@ -144,9 +144,9 @@ class ServerServiceGenerator(
                     #{SmithyHttpServer}::operation::UpgradePlugin::<UpgradeExtractors>: #{SmithyHttpServer}::plugin::Plugin<
                         $serviceName,
                         crate::operation_shape::$structName,
-                        ModelPlugin::Output
+                        ModelPl::Output
                     >,
-                    HttpPlugin: #{SmithyHttpServer}::plugin::Plugin<
+                    HttpPl: #{SmithyHttpServer}::plugin::Plugin<
                         $serviceName,
                         crate::operation_shape::$structName,
                         <
@@ -154,13 +154,13 @@ class ServerServiceGenerator(
                             as #{SmithyHttpServer}::plugin::Plugin<
                                 $serviceName,
                                 crate::operation_shape::$structName,
-                                ModelPlugin::Output
+                                ModelPl::Output
                             >
                         >::Output
                     >,
 
-                    HttpPlugin::Output: #{Tower}::Service<#{Http}::Request<Body>, Response = #{Http}::Response<#{SmithyHttpServer}::body::BoxBody>, Error = ::std::convert::Infallible> + Clone + Send + 'static,
-                    <HttpPlugin::Output as #{Tower}::Service<#{Http}::Request<Body>>>::Future: Send + 'static,
+                    HttpPl::Output: #{Tower}::Service<#{Http}::Request<Body>, Response = #{Http}::Response<#{SmithyHttpServer}::body::BoxBody>, Error = ::std::convert::Infallible> + Clone + Send + 'static,
+                    <HttpPl::Output as #{Tower}::Service<#{Http}::Request<Body>>>::Future: Send + 'static,
 
                 {
                     use #{SmithyHttpServer}::operation::OperationShapeExt;
@@ -199,7 +199,7 @@ class ServerServiceGenerator(
                 where
                     S: #{SmithyHttpServer}::operation::OperationService<crate::operation_shape::$structName, ServiceExtractors>,
 
-                    ModelPlugin: #{SmithyHttpServer}::plugin::Plugin<
+                    ModelPl: #{SmithyHttpServer}::plugin::Plugin<
                         $serviceName,
                         crate::operation_shape::$structName,
                         #{SmithyHttpServer}::operation::Normalize<crate::operation_shape::$structName, S>
@@ -207,9 +207,9 @@ class ServerServiceGenerator(
                     #{SmithyHttpServer}::operation::UpgradePlugin::<UpgradeExtractors>: #{SmithyHttpServer}::plugin::Plugin<
                         $serviceName,
                         crate::operation_shape::$structName,
-                        ModelPlugin::Output
+                        ModelPl::Output
                     >,
-                    HttpPlugin: #{SmithyHttpServer}::plugin::Plugin<
+                    HttpPl: #{SmithyHttpServer}::plugin::Plugin<
                         $serviceName,
                         crate::operation_shape::$structName,
                         <
@@ -217,13 +217,13 @@ class ServerServiceGenerator(
                             as #{SmithyHttpServer}::plugin::Plugin<
                                 $serviceName,
                                 crate::operation_shape::$structName,
-                                ModelPlugin::Output
+                                ModelPl::Output
                             >
                         >::Output
                     >,
 
-                    HttpPlugin::Output: #{Tower}::Service<#{Http}::Request<Body>, Response = #{Http}::Response<#{SmithyHttpServer}::body::BoxBody>, Error = ::std::convert::Infallible> + Clone + Send + 'static,
-                    <HttpPlugin::Output as #{Tower}::Service<#{Http}::Request<Body>>>::Future: Send + 'static,
+                    HttpPl::Output: #{Tower}::Service<#{Http}::Request<Body>, Response = #{Http}::Response<#{SmithyHttpServer}::body::BoxBody>, Error = ::std::convert::Infallible> + Clone + Send + 'static,
+                    <HttpPl::Output as #{Tower}::Service<#{Http}::Request<Body>>>::Future: Send + 'static,
 
                 {
                     use #{SmithyHttpServer}::operation::OperationShapeExt;
@@ -394,7 +394,7 @@ class ServerServiceGenerator(
 
     /** Returns a `Writable` containing the builder struct definition and its implementations. */
     private fun builder(): Writable = writable {
-        val builderGenerics = listOf(builderBodyGenericTypeName, "HttpPlugin", "ModelPlugin").joinToString(", ")
+        val builderGenerics = listOf(builderBodyGenericTypeName, "HttpPl", "ModelPl").joinToString(", ")
         rustTemplate(
             """
             /// The service builder for [`$serviceName`].
@@ -402,8 +402,8 @@ class ServerServiceGenerator(
             /// Constructed via [`$serviceName::builder_with_plugins`] or [`$serviceName::builder_without_plugins`].
             pub struct $builderName<$builderGenerics> {
                 ${builderFields.joinToString(", ")},
-                http_plugin: HttpPlugin,
-                model_plugin: ModelPlugin
+                http_plugin: HttpPl,
+                model_plugin: ModelPl
             }
 
             impl<$builderGenerics> $builderName<$builderGenerics> {
@@ -473,9 +473,10 @@ class ServerServiceGenerator(
                 ///
                 /// Use [`$serviceName::builder_without_plugins`] if you don't need to apply plugins.
                 ///
-                /// Check out [`PluginPipeline`](#{SmithyHttpServer}::plugin::PluginPipeline) if you need to apply
+                /// Check out [`HttpPlugins`](#{SmithyHttpServer}::plugin::HttpPlugins) and
+                /// [`ModelPlugins`](#{SmithyHttpServer}::plugin::ModelPlugins) if you need to apply
                 /// multiple plugins.
-                pub fn builder_with_plugins<Body, HttpPlugin, ModelPlugin>(http_plugin: HttpPlugin, model_plugin: ModelPlugin) -> $builderName<Body, HttpPlugin, ModelPlugin> {
+                pub fn builder_with_plugins<Body, HttpPl: #{SmithyHttpServer}::plugin::HttpPlugin, ModelPl: #{SmithyHttpServer}::plugin::ModelPlugin>(http_plugin: HttpPl, model_plugin: ModelPl) -> $builderName<Body, HttpPl, ModelPl> {
                     $builderName {
                         #{NotSetFields:W},
                         http_plugin,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -476,7 +476,7 @@ class ServerServiceGenerator(
                 /// Check out [`HttpPlugins`](#{SmithyHttpServer}::plugin::HttpPlugins) and
                 /// [`ModelPlugins`](#{SmithyHttpServer}::plugin::ModelPlugins) if you need to apply
                 /// multiple plugins.
-                pub fn builder_with_plugins<Body, HttpPl: #{SmithyHttpServer}::plugin::HttpPlugin, ModelPl: #{SmithyHttpServer}::plugin::ModelPlugin>(http_plugin: HttpPl, model_plugin: ModelPl) -> $builderName<Body, HttpPl, ModelPl> {
+                pub fn builder_with_plugins<Body, HttpPl: #{SmithyHttpServer}::plugin::HttpMarker, ModelPl: #{SmithyHttpServer}::plugin::ModelPlugin>(http_plugin: HttpPl, model_plugin: ModelPl) -> $builderName<Body, HttpPl, ModelPl> {
                     $builderName {
                         #{NotSetFields:W},
                         http_plugin,

--- a/design/src/server/anatomy.md
+++ b/design/src/server/anatomy.md
@@ -466,40 +466,40 @@ stateDiagram-v2
 The service builder API requires plugins to be specified upfront - they must be passed as an argument to `builder_with_plugins` and cannot be modified afterwards.
 
 You might find yourself wanting to apply _multiple_ plugins to your service.
-This can be accommodated via [`PluginPipeline`].
+This can be accommodated via [`HttpPlugins`] and [`ModelPlugins`].
 
 ```rust
 # extern crate aws_smithy_http_server;
-use aws_smithy_http_server::plugin::PluginPipeline;
+use aws_smithy_http_server::plugin::HttpPlugins;
 # use aws_smithy_http_server::plugin::IdentityPlugin as LoggingPlugin;
 # use aws_smithy_http_server::plugin::IdentityPlugin as MetricsPlugin;
 
-let pipeline = PluginPipeline::new().push(LoggingPlugin).push(MetricsPlugin);
+let http_plugins = HttpPlugins::new().push(LoggingPlugin).push(MetricsPlugin);
 ```
 
 The plugins' runtime logic is executed in registration order.
 In the example above, `LoggingPlugin` would run first, while `MetricsPlugin` is executed last.
 
-If you are vending a plugin, you can leverage `PluginPipeline` as an extension point: you can add custom methods to it using an extension trait.
+If you are vending a plugin, you can leverage `HttpPlugins` or `ModelPlugins` as an extension point: you can add custom methods to it using an extension trait.
 For example:
 
 ```rust
 # extern crate aws_smithy_http_server;
-use aws_smithy_http_server::plugin::{PluginPipeline, PluginStack};
+use aws_smithy_http_server::plugin::{HttpPlugins, PluginStack};
 # use aws_smithy_http_server::plugin::IdentityPlugin as LoggingPlugin;
 # use aws_smithy_http_server::plugin::IdentityPlugin as AuthPlugin;
 
 pub trait AuthPluginExt<CurrentPlugins> {
-    fn with_auth(self) -> PluginPipeline<PluginStack<AuthPlugin, CurrentPlugins>>;
+    fn with_auth(self) -> HttpPlugins<PluginStack<AuthPlugin, CurrentPlugins>>;
 }
 
-impl<CurrentPlugins> AuthPluginExt<CurrentPlugins> for PluginPipeline<CurrentPlugins> {
-    fn with_auth(self) -> PluginPipeline<PluginStack<AuthPlugin, CurrentPlugins>> {
+impl<CurrentPlugins> AuthPluginExt<CurrentPlugins> for HttpPlugins<CurrentPlugins> {
+    fn with_auth(self) -> HttpPlugins<PluginStack<AuthPlugin, CurrentPlugins>> {
         self.push(AuthPlugin)
     }
 }
 
-let pipeline = PluginPipeline::new()
+let http_plugins = HttpPlugins::new()
     .push(LoggingPlugin)
     // Our custom method!
     .with_auth();

--- a/design/src/server/anatomy.md
+++ b/design/src/server/anatomy.md
@@ -518,15 +518,15 @@ You can create an instance of a service builder by calling either `builder_witho
 /// The service builder for [`PokemonService`].
 ///
 /// Constructed via [`PokemonService::builder`].
-pub struct PokemonServiceBuilder<Body, HttpPlugin, ModelPlugin> {
+pub struct PokemonServiceBuilder<Body, HttpPl, ModelPl> {
     capture_pokemon_operation: Option<Route<Body>>,
     empty_operation: Option<Route<Body>>,
     get_pokemon_species: Option<Route<Body>>,
     get_server_statistics: Option<Route<Body>>,
     get_storage: Option<Route<Body>>,
     health_check_operation: Option<Route<Body>>,
-    http_plugin: HttpPlugin,
-    model_plugin: ModelPlugin
+    http_plugin: HttpPl,
+    model_plugin: ModelPl,
 }
 ```
 
@@ -537,7 +537,7 @@ The builder has two setter methods for each [Smithy Operation](https://awslabs.g
     where
         HandlerType:Handler<GetPokemonSpecies, HandlerExtractors>,
 
-        ModelPlugin: Plugin<
+        ModelPl: Plugin<
             PokemonService,
             GetPokemonSpecies,
             IntoService<GetPokemonSpecies, HandlerType>
@@ -547,7 +547,7 @@ The builder has two setter methods for each [Smithy Operation](https://awslabs.g
             GetPokemonSpecies,
             ModelPlugin::Output
         >,
-        HttpPlugin: Plugin<
+        HttpPl: Plugin<
             PokemonService,
             GetPokemonSpecies,
             UpgradePlugin::<UpgradeExtractors>::Output
@@ -565,7 +565,7 @@ The builder has two setter methods for each [Smithy Operation](https://awslabs.g
     where
         S: OperationService<GetPokemonSpecies, ServiceExtractors>,
 
-        ModelPlugin: Plugin<
+        ModelPl: Plugin<
             PokemonService,
             GetPokemonSpecies,
             Normalize<GetPokemonSpecies, S>
@@ -575,7 +575,7 @@ The builder has two setter methods for each [Smithy Operation](https://awslabs.g
             GetPokemonSpecies,
             ModelPlugin::Output
         >,
-        HttpPlugin: Plugin<
+        HttpPl: Plugin<
             PokemonService,
             GetPokemonSpecies,
             UpgradePlugin::<UpgradeExtractors>::Output

--- a/design/src/server/instrumentation.md
+++ b/design/src/server/instrumentation.md
@@ -66,11 +66,11 @@ This is enabled via the `instrument` method provided by the `aws_smithy_http_ser
 # let handler = |req: GetPokemonSpeciesInput| async { Result::<GetPokemonSpeciesOutput, GetPokemonSpeciesError>::Ok(todo!()) };
 use aws_smithy_http_server::{
   instrumentation::InstrumentExt,
-  plugin::{IdentityPlugin, PluginPipeline}
+  plugin::{IdentityPlugin, HttpPlugins}
 };
 use pokemon_service_server_sdk::PokemonService;
 
-let http_plugins = PluginPipeline::new().instrument();
+let http_plugins = HttpPlugins::new().instrument();
 let app = PokemonService::builder_with_plugins(http_plugins, IdentityPlugin)
   .get_pokemon_species(handler)
   /* ... */

--- a/design/src/server/middleware.md
+++ b/design/src/server/middleware.md
@@ -352,7 +352,7 @@ You can provide a custom method to add your plugin to a collection of  `HttpPlug
 ```rust
 # extern crate aws_smithy_http_server;
 # pub struct PrintPlugin;
-# impl aws_smithy_http_server::plugin::HttpPlugin for PrintPlugin { }
+# impl aws_smithy_http_server::plugin::HttpMarker for PrintPlugin { }
 use aws_smithy_http_server::plugin::{HttpPlugins, PluginStack};
 
 /// This provides a [`print`](PrintExt::print) method on [`HttpPlugins`].
@@ -378,7 +378,7 @@ This allows for:
 # use aws_smithy_http_server::plugin::{PluginStack, Plugin};
 # struct PrintPlugin;
 # impl<Ser, Op, T> Plugin<Ser, Op, T> for PrintPlugin { type Output = T; fn apply(&self, svc: T) -> Self::Output { svc }}
-# impl aws_smithy_http_server::plugin::HttpPlugin for PrintPlugin { }
+# impl aws_smithy_http_server::plugin::HttpMarker for PrintPlugin { }
 # trait PrintExt<EP> { fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, EP>>; }
 # impl<EP> PrintExt<EP> for HttpPlugins<EP> { fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, EP>> { self.push(PrintPlugin) }}
 # use pokemon_service_server_sdk::{operation_shape::GetPokemonSpecies, input::*, output::*, error::*};

--- a/design/src/server/middleware.md
+++ b/design/src/server/middleware.md
@@ -352,6 +352,7 @@ You can provide a custom method to add your plugin to a collection of  `HttpPlug
 ```rust
 # extern crate aws_smithy_http_server;
 # pub struct PrintPlugin;
+# impl aws_smithy_http_server::plugin::HttpPlugin for PrintPlugin { }
 use aws_smithy_http_server::plugin::{HttpPlugins, PluginStack};
 
 /// This provides a [`print`](PrintExt::print) method on [`HttpPlugins`].
@@ -377,6 +378,7 @@ This allows for:
 # use aws_smithy_http_server::plugin::{PluginStack, Plugin};
 # struct PrintPlugin;
 # impl<Ser, Op, T> Plugin<Ser, Op, T> for PrintPlugin { type Output = T; fn apply(&self, svc: T) -> Self::Output { svc }}
+# impl aws_smithy_http_server::plugin::HttpPlugin for PrintPlugin { }
 # trait PrintExt<EP> { fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, EP>>; }
 # impl<EP> PrintExt<EP> for HttpPlugins<EP> { fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, EP>> { self.push(PrintPlugin) }}
 # use pokemon_service_server_sdk::{operation_shape::GetPokemonSpecies, input::*, output::*, error::*};

--- a/design/src/server/middleware.md
+++ b/design/src/server/middleware.md
@@ -226,7 +226,7 @@ scope! {
 // Construct `LoggingLayer`.
 let logging_plugin = LayerPlugin(LoggingLayer::new());
 let logging_plugin = Scoped::new::<LoggingScope>(logging_plugin);
-let http_plugins = PluginPipeline::new().push(logging_plugin);
+let http_plugins = HttpPlugins::new().push(logging_plugin);
 
 let app /* : PokemonService<Route<B>> */ = PokemonService::builder_with_plugins(http_plugins, IdentityPlugin)
     .get_pokemon_species(handler)
@@ -265,7 +265,7 @@ scope! {
 // Construct `BufferLayer`.
 let buffer_plugin = LayerPlugin(BufferLayer::new(3));
 let buffer_plugin = Scoped::new::<BufferScope>(buffer_plugin);
-let model_plugins = PluginPipeline::new().push(buffer_plugin);
+let model_plugins = ModelPlugins::new().push(buffer_plugin);
 
 let app /* : PokemonService<Route<B>> */ = PokemonService::builder_with_plugins(IdentityPlugin, model_plugins)
     .get_pokemon_species(handler)
@@ -347,23 +347,23 @@ where
 }
 ```
 
-You can provide a custom method to add your plugin to a `PluginPipeline` via an extension trait:
+You can provide a custom method to add your plugin to a collection of  `HttpPlugins` or `ModelPlugins` via an extension trait. For example, for `HttpPlugins`:
 
 ```rust
 # extern crate aws_smithy_http_server;
 # pub struct PrintPlugin;
-use aws_smithy_http_server::plugin::{PluginPipeline, PluginStack};
+use aws_smithy_http_server::plugin::{HttpPlugins, PluginStack};
 
-/// This provides a [`print`](PrintExt::print) method on [`PluginPipeline`].
+/// This provides a [`print`](PrintExt::print) method on [`HttpPlugins`].
 pub trait PrintExt<ExistingPlugins> {
     /// Causes all operations to print the operation name when called.
     ///
     /// This works by applying the [`PrintPlugin`].
-    fn print(self) -> PluginPipeline<PluginStack<PrintPlugin, ExistingPlugins>>;
+    fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, ExistingPlugins>>;
 }
 
-impl<ExistingPlugins> PrintExt<ExistingPlugins> for PluginPipeline<ExistingPlugins> {
-    fn print(self) -> PluginPipeline<PluginStack<PrintPlugin, ExistingPlugins>> {
+impl<ExistingPlugins> PrintExt<ExistingPlugins> for HttpPlugins<ExistingPlugins> {
+    fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, ExistingPlugins>> {
         self.push(PrintPlugin)
     }
 }
@@ -377,14 +377,14 @@ This allows for:
 # use aws_smithy_http_server::plugin::{PluginStack, Plugin};
 # struct PrintPlugin;
 # impl<Ser, Op, T> Plugin<Ser, Op, T> for PrintPlugin { type Output = T; fn apply(&self, svc: T) -> Self::Output { svc }}
-# trait PrintExt<EP> { fn print(self) -> PluginPipeline<PluginStack<PrintPlugin, EP>>; }
-# impl<EP> PrintExt<EP> for PluginPipeline<EP> { fn print(self) -> PluginPipeline<PluginStack<PrintPlugin, EP>> { self.push(PrintPlugin) }}
+# trait PrintExt<EP> { fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, EP>>; }
+# impl<EP> PrintExt<EP> for HttpPlugins<EP> { fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, EP>> { self.push(PrintPlugin) }}
 # use pokemon_service_server_sdk::{operation_shape::GetPokemonSpecies, input::*, output::*, error::*};
 # let handler = |req: GetPokemonSpeciesInput| async { Result::<GetPokemonSpeciesOutput, GetPokemonSpeciesError>::Ok(todo!()) };
-use aws_smithy_http_server::plugin::{IdentityPlugin, PluginPipeline};
+use aws_smithy_http_server::plugin::{IdentityPlugin, HttpPlugins};
 use pokemon_service_server_sdk::PokemonService;
 
-let http_plugins = PluginPipeline::new()
+let http_plugins = HttpPlugins::new()
     // [..other plugins..]
     // The custom method!
     .print();
@@ -397,4 +397,4 @@ let app /* : PokemonService<Route<B>> */ = PokemonService::builder_with_plugins(
 ```
 
 The custom `print` method hides the details of the `Plugin` trait from the average consumer.
-They interact with the utility methods on `PluginPipeline` and enjoy the self-contained documentation.
+They interact with the utility methods on `HttpPlugins` and enjoy the self-contained documentation.

--- a/examples/pokemon-service-common/tests/plugins_execution_order.rs
+++ b/examples/pokemon-service-common/tests/plugins_execution_order.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use aws_smithy_http::body::SdkBody;
-use aws_smithy_http_server::plugin::{IdentityPlugin, Plugin, PluginPipeline};
+use aws_smithy_http_server::plugin::{HttpPlugin, HttpPlugins, IdentityPlugin, Plugin};
 use tower::{Layer, Service};
 
 use pokemon_service_client::{operation::do_nothing::DoNothingInput, Config};
@@ -34,13 +34,15 @@ async fn plugin_layers_are_executed_in_registration_order() {
     // We can then check the vector content to verify the invocation order
     let output = Arc::new(Mutex::new(Vec::new()));
 
-    let pipeline = PluginPipeline::new()
+    let http_plugins = HttpPlugins::new()
         .push(SentinelPlugin::new("first", output.clone()))
         .push(SentinelPlugin::new("second", output.clone()));
-    let mut app =
-        pokemon_service_server_sdk::PokemonService::builder_with_plugins(pipeline, IdentityPlugin)
-            .do_nothing(do_nothing)
-            .build_unchecked();
+    let mut app = pokemon_service_server_sdk::PokemonService::builder_with_plugins(
+        http_plugins,
+        IdentityPlugin,
+    )
+    .do_nothing(do_nothing)
+    .build_unchecked();
     let request = DoNothingInput::builder()
         .build()
         .unwrap()
@@ -76,6 +78,8 @@ impl<Ser, Op, T> Plugin<Ser, Op, T> for SentinelPlugin {
         }
     }
 }
+
+impl HttpPlugin for SentinelPlugin {}
 
 /// A [`Service`] that adds a print log.
 #[derive(Clone, Debug)]

--- a/examples/pokemon-service-common/tests/plugins_execution_order.rs
+++ b/examples/pokemon-service-common/tests/plugins_execution_order.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use aws_smithy_http::body::SdkBody;
-use aws_smithy_http_server::plugin::{HttpPlugin, HttpPlugins, IdentityPlugin, Plugin};
+use aws_smithy_http_server::plugin::{HttpMarker, HttpPlugins, IdentityPlugin, Plugin};
 use tower::{Layer, Service};
 
 use pokemon_service_client::{operation::do_nothing::DoNothingInput, Config};
@@ -79,7 +79,7 @@ impl<Ser, Op, T> Plugin<Ser, Op, T> for SentinelPlugin {
     }
 }
 
-impl HttpPlugin for SentinelPlugin {}
+impl HttpMarker for SentinelPlugin {}
 
 /// A [`Service`] that adds a print log.
 #[derive(Clone, Debug)]

--- a/examples/pokemon-service/src/main.rs
+++ b/examples/pokemon-service/src/main.rs
@@ -10,7 +10,7 @@ use std::{net::SocketAddr, sync::Arc};
 use aws_smithy_http_server::{
     extension::OperationExtensionExt,
     instrumentation::InstrumentExt,
-    plugin::{alb_health_check::AlbHealthCheckLayer, IdentityPlugin, PluginPipeline, Scoped},
+    plugin::{alb_health_check::AlbHealthCheckLayer, HttpPlugins, IdentityPlugin, Scoped},
     request::request_id::ServerRequestIdProviderLayer,
     AddExtensionLayer,
 };
@@ -51,9 +51,9 @@ pub async fn main() {
         }
     }
     // Scope the `PrintPlugin`, defined in `plugin.rs`, to `PrintScope`
-    let print_plugin = Scoped::new::<PrintScope>(PluginPipeline::new().print());
+    let print_plugin = Scoped::new::<PrintScope>(HttpPlugins::new().print());
 
-    let plugins = PluginPipeline::new()
+    let plugins = HttpPlugins::new()
         // Apply the scoped `PrintPlugin`
         .push(print_plugin)
         // Apply the `OperationExtensionPlugin` defined in `aws_smithy_http_server::extension`. This allows other

--- a/examples/pokemon-service/src/plugin.rs
+++ b/examples/pokemon-service/src/plugin.rs
@@ -7,7 +7,7 @@
 
 use aws_smithy_http_server::{
     operation::OperationShape,
-    plugin::{HttpPlugin, HttpPlugins, Plugin, PluginStack},
+    plugin::{HttpMarker, HttpPlugins, Plugin, PluginStack},
     service::ServiceShape,
     shape_id::ShapeId,
 };
@@ -64,7 +64,7 @@ where
     }
 }
 
-impl HttpPlugin for PrintPlugin {}
+impl HttpMarker for PrintPlugin {}
 
 /// This provides a [`print`](PrintExt::print) method on [`HttpPlugins`].
 pub trait PrintExt<CurrentPlugin> {

--- a/examples/pokemon-service/src/plugin.rs
+++ b/examples/pokemon-service/src/plugin.rs
@@ -7,7 +7,7 @@
 
 use aws_smithy_http_server::{
     operation::OperationShape,
-    plugin::{Plugin, PluginPipeline, PluginStack},
+    plugin::{HttpPlugin, HttpPlugins, Plugin, PluginStack},
     service::ServiceShape,
     shape_id::ShapeId,
 };
@@ -63,16 +63,19 @@ where
         }
     }
 }
-/// This provides a [`print`](PrintExt::print) method on [`PluginPipeline`].
+
+impl HttpPlugin for PrintPlugin {}
+
+/// This provides a [`print`](PrintExt::print) method on [`HttpPlugins`].
 pub trait PrintExt<CurrentPlugin> {
     /// Causes all operations to print the operation name when called.
     ///
     /// This works by applying the [`PrintPlugin`].
-    fn print(self) -> PluginPipeline<PluginStack<PrintPlugin, CurrentPlugin>>;
+    fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, CurrentPlugin>>;
 }
 
-impl<CurrentPlugin> PrintExt<CurrentPlugin> for PluginPipeline<CurrentPlugin> {
-    fn print(self) -> PluginPipeline<PluginStack<PrintPlugin, CurrentPlugin>> {
+impl<CurrentPlugin> PrintExt<CurrentPlugin> for HttpPlugins<CurrentPlugin> {
+    fn print(self) -> HttpPlugins<PluginStack<PrintPlugin, CurrentPlugin>> {
         self.push(PrintPlugin)
     }
 }

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -28,7 +28,7 @@ use thiserror::Error;
 use tower::Service;
 
 use crate::operation::OperationShape;
-use crate::plugin::{Plugin, PluginPipeline, PluginStack};
+use crate::plugin::{HttpPlugin, HttpPlugins, Plugin, PluginStack};
 use crate::shape_id::ShapeId;
 
 pub use crate::request::extension::{Extension, MissingExtension};
@@ -128,16 +128,18 @@ where
     }
 }
 
-/// An extension trait on [`PluginPipeline`] allowing the application of [`OperationExtensionPlugin`].
+impl HttpPlugin for OperationExtensionPlugin {}
+
+/// An extension trait on [`HttpPlugins`] allowing the application of [`OperationExtensionPlugin`].
 ///
 /// See [`module`](crate::extension) documentation for more info.
 pub trait OperationExtensionExt<CurrentPlugin> {
     /// Apply the [`OperationExtensionPlugin`], which inserts the [`OperationExtension`] into every [`http::Response`].
-    fn insert_operation_extension(self) -> PluginPipeline<PluginStack<OperationExtensionPlugin, CurrentPlugin>>;
+    fn insert_operation_extension(self) -> HttpPlugins<PluginStack<OperationExtensionPlugin, CurrentPlugin>>;
 }
 
-impl<CurrentPlugin> OperationExtensionExt<CurrentPlugin> for PluginPipeline<CurrentPlugin> {
-    fn insert_operation_extension(self) -> PluginPipeline<PluginStack<OperationExtensionPlugin, CurrentPlugin>> {
+impl<CurrentPlugin> OperationExtensionExt<CurrentPlugin> for HttpPlugins<CurrentPlugin> {
+    fn insert_operation_extension(self) -> HttpPlugins<PluginStack<OperationExtensionPlugin, CurrentPlugin>> {
         self.push(OperationExtensionPlugin)
     }
 }
@@ -221,7 +223,7 @@ mod tests {
         }
 
         // Apply `Plugin`.
-        let plugins = PluginPipeline::new().insert_operation_extension();
+        let plugins = HttpPlugins::new().insert_operation_extension();
 
         // Apply `Plugin`s `Layer`.
         let layer = PluginLayer::new::<RestJson1, DummyOp>(plugins);

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -28,7 +28,7 @@ use thiserror::Error;
 use tower::Service;
 
 use crate::operation::OperationShape;
-use crate::plugin::{HttpPlugin, HttpPlugins, Plugin, PluginStack};
+use crate::plugin::{HttpMarker, HttpPlugins, Plugin, PluginStack};
 use crate::shape_id::ShapeId;
 
 pub use crate::request::extension::{Extension, MissingExtension};
@@ -128,7 +128,7 @@ where
     }
 }
 
-impl HttpPlugin for OperationExtensionPlugin {}
+impl HttpMarker for OperationExtensionPlugin {}
 
 /// An extension trait on [`HttpPlugins`] allowing the application of [`OperationExtensionPlugin`].
 ///

--- a/rust-runtime/aws-smithy-http-server/src/instrumentation/plugin.rs
+++ b/rust-runtime/aws-smithy-http-server/src/instrumentation/plugin.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::plugin::{PluginPipeline, PluginStack};
+use crate::plugin::{HttpPlugin, HttpPlugins, PluginStack};
 use crate::{operation::OperationShape, plugin::Plugin};
 
 use super::sensitivity::Sensitivity;
@@ -27,17 +27,19 @@ where
     }
 }
 
+impl HttpPlugin for InstrumentPlugin {}
+
 /// An extension trait for applying [`InstrumentPlugin`].
 pub trait InstrumentExt<CurrentPlugin> {
     /// Applies an [`InstrumentOperation`] to every operation, respecting the [@sensitive] trait given on the input and
     /// output models. See [`InstrumentOperation`](super::InstrumentOperation) for more information.
     ///
     /// [@sensitive]: https://awslabs.github.io/smithy/2.0/spec/documentation-traits.html#sensitive-trait
-    fn instrument(self) -> PluginPipeline<PluginStack<InstrumentPlugin, CurrentPlugin>>;
+    fn instrument(self) -> HttpPlugins<PluginStack<InstrumentPlugin, CurrentPlugin>>;
 }
 
-impl<CurrentPlugin> InstrumentExt<CurrentPlugin> for PluginPipeline<CurrentPlugin> {
-    fn instrument(self) -> PluginPipeline<PluginStack<InstrumentPlugin, CurrentPlugin>> {
+impl<CurrentPlugin> InstrumentExt<CurrentPlugin> for HttpPlugins<CurrentPlugin> {
+    fn instrument(self) -> HttpPlugins<PluginStack<InstrumentPlugin, CurrentPlugin>> {
         self.push(InstrumentPlugin)
     }
 }

--- a/rust-runtime/aws-smithy-http-server/src/instrumentation/plugin.rs
+++ b/rust-runtime/aws-smithy-http-server/src/instrumentation/plugin.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::plugin::{HttpPlugin, HttpPlugins, PluginStack};
+use crate::plugin::{HttpMarker, HttpPlugins, PluginStack};
 use crate::{operation::OperationShape, plugin::Plugin};
 
 use super::sensitivity::Sensitivity;
@@ -27,7 +27,7 @@ where
     }
 }
 
-impl HttpPlugin for InstrumentPlugin {}
+impl HttpMarker for InstrumentPlugin {}
 
 /// An extension trait for applying [`InstrumentPlugin`].
 pub trait InstrumentExt<CurrentPlugin> {

--- a/rust-runtime/aws-smithy-http-server/src/plugin/alb_health_check.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/alb_health_check.rs
@@ -9,9 +9,9 @@
 //! # Example
 //!
 //! ```no_run
-//! # use aws_smithy_http_server::{body, plugin::{PluginPipeline, alb_health_check::AlbHealthCheckLayer}};
+//! # use aws_smithy_http_server::{body, plugin::{HttpPlugins, alb_health_check::AlbHealthCheckLayer}};
 //! # use hyper::{Body, Response, StatusCode};
-//! let plugins = PluginPipeline::new()
+//! let plugins = HttpPlugins::new()
 //!     // Handle all `/ping` health check requests by returning a `200 OK`.
 //!     .layer(AlbHealthCheckLayer::from_handler("/ping", |_req| async {
 //!         StatusCode::OK

--- a/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
@@ -8,7 +8,7 @@ use super::{either::Either, IdentityPlugin, ModelPlugin};
 use crate::operation::OperationShape;
 use crate::service::ContainsOperation;
 
-use super::{HttpPlugin, Plugin};
+use super::{HttpMarker, Plugin};
 
 /// Filters the application of an inner [`Plugin`] using a predicate over the
 /// [`ServiceShape::Operations`](crate::service::ServiceShape::Operations).
@@ -41,7 +41,7 @@ where
     }
 }
 
-impl<Inner, F> HttpPlugin for FilterByOperation<Inner, F> where Inner: HttpPlugin {}
+impl<Inner, F> HttpMarker for FilterByOperation<Inner, F> where Inner: HttpMarker {}
 impl<Inner, F> ModelPlugin for FilterByOperation<Inner, F> where Inner: ModelPlugin {}
 
 /// Filters the application of an inner [`Plugin`] using a predicate over the

--- a/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::{either::Either, IdentityPlugin, ModelPlugin};
+use super::{either::Either, IdentityPlugin, ModelMarker};
 
 use crate::operation::OperationShape;
 use crate::service::ContainsOperation;
@@ -42,7 +42,7 @@ where
 }
 
 impl<Inner, F> HttpMarker for FilterByOperation<Inner, F> where Inner: HttpMarker {}
-impl<Inner, F> ModelPlugin for FilterByOperation<Inner, F> where Inner: ModelPlugin {}
+impl<Inner, F> ModelMarker for FilterByOperation<Inner, F> where Inner: ModelMarker {}
 
 /// Filters the application of an inner [`Plugin`] using a predicate over the
 /// [`ServiceShape::Operations`](crate::service::ServiceShape::Operations).

--- a/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::{either::Either, IdentityPlugin};
+use super::{either::Either, IdentityPlugin, ModelPlugin};
 
 use crate::operation::OperationShape;
 use crate::service::ContainsOperation;
 
-use super::Plugin;
+use super::{HttpPlugin, Plugin};
 
 /// Filters the application of an inner [`Plugin`] using a predicate over the
 /// [`ServiceShape::Operations`](crate::service::ServiceShape::Operations).
@@ -41,11 +41,14 @@ where
     }
 }
 
+impl<Inner, F> HttpPlugin for FilterByOperation<Inner, F> where Inner: HttpPlugin {}
+impl<Inner, F> ModelPlugin for FilterByOperation<Inner, F> where Inner: ModelPlugin {}
+
 /// Filters the application of an inner [`Plugin`] using a predicate over the
 /// [`ServiceShape::Operations`](crate::service::ServiceShape::Operations).
 ///
-/// Users should prefer [`Scoped`](crate::plugin::Scoped) and fallback to [`filter_by_operation`] in cases where
-/// [`Plugin`] application must be decided at runtime.
+/// Users should prefer [`Scoped`](crate::plugin::Scoped) and fallback to [`filter_by_operation`]
+/// in cases where [`Plugin`] application must be decided at runtime.
 ///
 /// # Example
 ///

--- a/rust-runtime/aws-smithy-http-server/src/plugin/http_plugins.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/http_plugins.rs
@@ -3,25 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// If you make any updates to this file (including Rust docs), make sure you make them to
+// `model_plugins.rs` too!
+
 use crate::plugin::{IdentityPlugin, Plugin, PluginStack};
 
-use super::LayerPlugin;
+use super::{HttpPlugin, LayerPlugin};
 
-/// A wrapper struct for composing [`Plugin`]s.
-/// It is used as input for the `builder_with_plugins` method on the generate service struct
+/// A wrapper struct for composing [`HttpPlugin`]s.
+/// It can be used as input for the `builder_with_plugins` method on the generated service struct
 /// (e.g. `PokemonService::builder_with_plugins`).
 ///
 /// ## Applying plugins in a sequence
 ///
-/// You can use the [`push`](PluginPipeline::push) method to apply a new plugin after the ones that
+/// You can use the [`push`](HttpPlugins::push) method to apply a new HTTP plugin after the ones that
 /// have already been registered.
 ///
 /// ```rust
-/// use aws_smithy_http_server::plugin::PluginPipeline;
+/// use aws_smithy_http_server::plugin::HttpPlugins;
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as LoggingPlugin;
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as MetricsPlugin;
 ///
-/// let pipeline = PluginPipeline::new().push(LoggingPlugin).push(MetricsPlugin);
+/// let http_plugins = HttpPlugins::new().push(LoggingPlugin).push(MetricsPlugin);
 /// ```
 ///
 /// The plugins' runtime logic is executed in registration order.
@@ -32,13 +35,14 @@ use super::LayerPlugin;
 /// From time to time, you might have a need to transform the entire pipeline that has been built
 /// so far - e.g. you only want to apply those plugins for a specific operation.
 ///
-/// `PluginPipeline` is itself a [`Plugin`]: you can apply any transformation that expects a
-/// [`Plugin`] to an entire pipeline. In this case, we want to use
-/// [`filter_by_operation`](crate::plugin::filter_by_operation) to limit the scope of
-/// the logging and metrics plugins to the `CheckHealth` operation:
+/// `HttpPlugins` is itself a [`Plugin`]: you can apply any transformation that expects a
+/// [`Plugin`] to an entire pipeline. In this case, we could use a [scoped
+/// plugin](crate::plugin::Scoped) to limit the scope of the logging and metrics plugins to the
+/// `CheckHealth` operation:
 ///
 /// ```rust
-/// use aws_smithy_http_server::plugin::{filter_by_operation, PluginPipeline};
+/// use aws_smithy_http_server::scope;
+/// use aws_smithy_http_server::plugin::{HttpPlugins, Scoped};
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as LoggingPlugin;
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as MetricsPlugin;
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as AuthPlugin;
@@ -49,91 +53,100 @@ use super::LayerPlugin;
 /// # impl CheckHealth { const ID: ShapeId = ShapeId::new("namespace#MyName", "namespace", "MyName"); }
 ///
 /// // The logging and metrics plugins will only be applied to the `CheckHealth` operation.
-///  let plugin = PluginPipeline::new()
-///         .push(LoggingPlugin)
-///         .push(MetricsPlugin);
-/// let filtered_plugin = filter_by_operation(plugin, |operation: Operation| operation == Operation::CheckHealth);
-/// let pipeline = PluginPipeline::new()
+/// let plugin = HttpPlugins::new()
+///     .push(LoggingPlugin)
+///     .push(MetricsPlugin);
+///
+/// scope! {
+///     struct OnlyCheckHealth {
+///         includes: [CheckHealth],
+///         excludes: [/* The rest of the operations go here */]
+///     }
+/// }
+///
+/// let filtered_plugin = Scoped::new::<OnlyCheckHealth>(&plugin);
+/// let http_plugins = HttpPlugins::new()
 ///     .push(filtered_plugin)
-///     // The auth plugin will be applied to all operations
+///     // The auth plugin will be applied to all operations.
 ///     .push(AuthPlugin);
 /// ```
 ///
-/// ## Concatenating two plugin pipelines
+/// ## Concatenating two collections of HTTP plugins
 ///
-/// `PluginPipeline` is a good way to bundle together multiple plugins, ensuring they are all
+/// `HttpPlugins` is a good way to bundle together multiple plugins, ensuring they are all
 /// registered in the correct order.
 ///
-/// Since `PluginPipeline` is itself a [`Plugin`], you can use the [`push`](PluginPipeline::push) to
-/// append, at once, all the plugins in another pipeline to the current pipeline:
+/// Since `HttpPlugins` is itself a [`HttpPlugin`], you can use the [`push`](HttpPlugins::push) to
+/// append, at once, all the HTTP plugins in another `HttpPlugins` to the current `HttpPlugins`:
 ///
 /// ```rust
-/// use aws_smithy_http_server::plugin::{IdentityPlugin, PluginPipeline, PluginStack};
+/// use aws_smithy_http_server::plugin::{IdentityPlugin, HttpPlugins, PluginStack};
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as LoggingPlugin;
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as MetricsPlugin;
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as AuthPlugin;
 ///
-/// pub fn get_bundled_pipeline() -> PluginPipeline<PluginStack<MetricsPlugin, PluginStack<LoggingPlugin, IdentityPlugin>>> {
-///     PluginPipeline::new().push(LoggingPlugin).push(MetricsPlugin)
+/// pub fn get_bundled_http_plugins() -> HttpPlugins<PluginStack<MetricsPlugin, PluginStack<LoggingPlugin, IdentityPlugin>>> {
+///     HttpPlugins::new().push(LoggingPlugin).push(MetricsPlugin)
 /// }
 ///
-/// let pipeline = PluginPipeline::new()
+/// let http_plugins = HttpPlugins::new()
 ///     .push(AuthPlugin)
-///     .push(get_bundled_pipeline());
+///     .push(get_bundled_http_plugins());
 /// ```
 ///
-/// ## Providing custom methods on `PluginPipeline`
+/// ## Providing custom methods on `HttpPlugins`
 ///
-/// You use an **extension trait** to add custom methods on `PluginPipeline`.
+/// You use an **extension trait** to add custom methods on `HttpPlugins`.
 ///
 /// This is a simple example using `AuthPlugin`:
 ///
 /// ```rust
-/// use aws_smithy_http_server::plugin::{PluginPipeline, PluginStack};
+/// use aws_smithy_http_server::plugin::{HttpPlugins, PluginStack};
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as LoggingPlugin;
 /// # use aws_smithy_http_server::plugin::IdentityPlugin as AuthPlugin;
 ///
 /// pub trait AuthPluginExt<CurrentPlugins> {
-///     fn with_auth(self) -> PluginPipeline<PluginStack<AuthPlugin, CurrentPlugins>>;
+///     fn with_auth(self) -> HttpPlugins<PluginStack<AuthPlugin, CurrentPlugins>>;
 /// }
 ///
-/// impl<CurrentPlugins> AuthPluginExt<CurrentPlugins> for PluginPipeline<CurrentPlugins> {
-///     fn with_auth(self) -> PluginPipeline<PluginStack<AuthPlugin, CurrentPlugins>> {
+/// impl<CurrentPlugins> AuthPluginExt<CurrentPlugins> for HttpPlugins<CurrentPlugins> {
+///     fn with_auth(self) -> HttpPlugins<PluginStack<AuthPlugin, CurrentPlugins>> {
 ///         self.push(AuthPlugin)
 ///     }
 /// }
 ///
-/// let pipeline = PluginPipeline::new()
+/// let http_plugins = HttpPlugins::new()
 ///     .push(LoggingPlugin)
 ///     // Our custom method!
 ///     .with_auth();
 /// ```
-pub struct PluginPipeline<P>(pub(crate) P);
+#[derive(Debug)]
+pub struct HttpPlugins<P>(pub(crate) P);
 
-impl Default for PluginPipeline<IdentityPlugin> {
+impl Default for HttpPlugins<IdentityPlugin> {
     fn default() -> Self {
         Self(IdentityPlugin)
     }
 }
 
-impl PluginPipeline<IdentityPlugin> {
-    /// Create an empty [`PluginPipeline`].
+impl HttpPlugins<IdentityPlugin> {
+    /// Create an empty [`HttpPlugins`].
     ///
-    /// You can use [`PluginPipeline::push`] to add plugins to it.
+    /// You can use [`HttpPlugins::push`] to add plugins to it.
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl<P> PluginPipeline<P> {
-    /// Apply a new plugin after the ones that have already been registered.
+impl<P> HttpPlugins<P> {
+    /// Apply a new HTTP plugin after the ones that have already been registered.
     ///
     /// ```rust
-    /// use aws_smithy_http_server::plugin::PluginPipeline;
+    /// use aws_smithy_http_server::plugin::HttpPlugins;
     /// # use aws_smithy_http_server::plugin::IdentityPlugin as LoggingPlugin;
     /// # use aws_smithy_http_server::plugin::IdentityPlugin as MetricsPlugin;
     ///
-    /// let pipeline = PluginPipeline::new().push(LoggingPlugin).push(MetricsPlugin);
+    /// let http_plugins = HttpPlugins::new().push(LoggingPlugin).push(MetricsPlugin);
     /// ```
     ///
     /// The plugins' runtime logic is executed in registration order.
@@ -163,18 +176,19 @@ impl<P> PluginPipeline<P> {
     ///     }
     /// }
     /// ```
-    ///
-    pub fn push<NewPlugin>(self, new_plugin: NewPlugin) -> PluginPipeline<PluginStack<NewPlugin, P>> {
-        PluginPipeline(PluginStack::new(new_plugin, self.0))
+    // We eagerly require `NewPlugin: HttpPlugin`, despite not really needing it, because compiler
+    // errors get _substantially_ better if the user makes a mistake.
+    pub fn push<NewPlugin: HttpPlugin>(self, new_plugin: NewPlugin) -> HttpPlugins<PluginStack<NewPlugin, P>> {
+        HttpPlugins(PluginStack::new(new_plugin, self.0))
     }
 
     /// Applies a single [`tower::Layer`] to all operations _before_ they are deserialized.
-    pub fn layer<L>(self, layer: L) -> PluginPipeline<PluginStack<LayerPlugin<L>, P>> {
-        PluginPipeline(PluginStack::new(LayerPlugin(layer), self.0))
+    pub fn layer<L>(self, layer: L) -> HttpPlugins<PluginStack<LayerPlugin<L>, P>> {
+        HttpPlugins(PluginStack::new(LayerPlugin(layer), self.0))
     }
 }
 
-impl<Ser, Op, T, InnerPlugin> Plugin<Ser, Op, T> for PluginPipeline<InnerPlugin>
+impl<Ser, Op, T, InnerPlugin> Plugin<Ser, Op, T> for HttpPlugins<InnerPlugin>
 where
     InnerPlugin: Plugin<Ser, Op, T>,
 {
@@ -184,3 +198,5 @@ where
         self.0.apply(input)
     }
 }
+
+impl<InnerPlugin> HttpPlugin for HttpPlugins<InnerPlugin> where InnerPlugin: HttpPlugin {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/http_plugins.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/http_plugins.rs
@@ -8,9 +8,9 @@
 
 use crate::plugin::{IdentityPlugin, Plugin, PluginStack};
 
-use super::{HttpPlugin, LayerPlugin};
+use super::{HttpMarker, LayerPlugin};
 
-/// A wrapper struct for composing [`HttpPlugin`]s.
+/// A wrapper struct for composing HTTP plugins.
 /// It can be used as input for the `builder_with_plugins` method on the generated service struct
 /// (e.g. `PokemonService::builder_with_plugins`).
 ///
@@ -76,8 +76,9 @@ use super::{HttpPlugin, LayerPlugin};
 /// `HttpPlugins` is a good way to bundle together multiple plugins, ensuring they are all
 /// registered in the correct order.
 ///
-/// Since `HttpPlugins` is itself a [`HttpPlugin`], you can use the [`push`](HttpPlugins::push) to
-/// append, at once, all the HTTP plugins in another `HttpPlugins` to the current `HttpPlugins`:
+/// Since `HttpPlugins` is itself a HTTP plugin (it implements the `HttpMarker` trait), you can use
+/// the [`push`](HttpPlugins::push) to append, at once, all the HTTP plugins in another
+/// `HttpPlugins` to the current `HttpPlugins`:
 ///
 /// ```rust
 /// use aws_smithy_http_server::plugin::{IdentityPlugin, HttpPlugins, PluginStack};
@@ -176,9 +177,9 @@ impl<P> HttpPlugins<P> {
     ///     }
     /// }
     /// ```
-    // We eagerly require `NewPlugin: HttpPlugin`, despite not really needing it, because compiler
+    // We eagerly require `NewPlugin: HttpMarker`, despite not really needing it, because compiler
     // errors get _substantially_ better if the user makes a mistake.
-    pub fn push<NewPlugin: HttpPlugin>(self, new_plugin: NewPlugin) -> HttpPlugins<PluginStack<NewPlugin, P>> {
+    pub fn push<NewPlugin: HttpMarker>(self, new_plugin: NewPlugin) -> HttpPlugins<PluginStack<NewPlugin, P>> {
         HttpPlugins(PluginStack::new(new_plugin, self.0))
     }
 
@@ -199,4 +200,4 @@ where
     }
 }
 
-impl<InnerPlugin> HttpPlugin for HttpPlugins<InnerPlugin> where InnerPlugin: HttpPlugin {}
+impl<InnerPlugin> HttpMarker for HttpPlugins<InnerPlugin> where InnerPlugin: HttpMarker {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::{HttpPlugin, ModelPlugin, Plugin};
+use super::{HttpMarker, ModelPlugin, Plugin};
 
 /// A [`Plugin`] that maps a service to itself.
 #[derive(Debug)]
@@ -18,4 +18,4 @@ impl<Ser, Op, S> Plugin<Ser, Op, S> for IdentityPlugin {
 }
 
 impl ModelPlugin for IdentityPlugin {}
-impl HttpPlugin for IdentityPlugin {}
+impl HttpMarker for IdentityPlugin {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::Plugin;
+use super::{HttpPlugin, ModelPlugin, Plugin};
 
 /// A [`Plugin`] that maps a service to itself.
+#[derive(Debug)]
 pub struct IdentityPlugin;
 
 impl<Ser, Op, S> Plugin<Ser, Op, S> for IdentityPlugin {
@@ -15,3 +16,6 @@ impl<Ser, Op, S> Plugin<Ser, Op, S> for IdentityPlugin {
         svc
     }
 }
+
+impl ModelPlugin for IdentityPlugin {}
+impl HttpPlugin for IdentityPlugin {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::{HttpMarker, ModelPlugin, Plugin};
+use super::{HttpMarker, ModelMarker, Plugin};
 
 /// A [`Plugin`] that maps a service to itself.
 #[derive(Debug)]
@@ -17,5 +17,5 @@ impl<Ser, Op, S> Plugin<Ser, Op, S> for IdentityPlugin {
     }
 }
 
-impl ModelPlugin for IdentityPlugin {}
+impl ModelMarker for IdentityPlugin {}
 impl HttpMarker for IdentityPlugin {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 
 use tower::Layer;
 
-use super::{HttpMarker, ModelPlugin, Plugin};
+use super::{HttpMarker, ModelMarker, Plugin};
 
 /// A [`Plugin`] which acts as a [`Layer`] `L`.
 pub struct LayerPlugin<L>(pub L);
@@ -27,7 +27,7 @@ where
 // to run this plugin as a HTTP plugin or a model plugin, so we implement both marker traits.
 
 impl<L> HttpMarker for LayerPlugin<L> {}
-impl<L> ModelPlugin for LayerPlugin<L> {}
+impl<L> ModelMarker for LayerPlugin<L> {}
 
 /// A [`Layer`] which acts as a [`Plugin`] `Pl` for specific protocol `P` and operation `Op`.
 pub struct PluginLayer<Ser, Op, Pl> {

--- a/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 
 use tower::Layer;
 
-use super::{HttpPlugin, ModelPlugin, Plugin};
+use super::{HttpMarker, ModelPlugin, Plugin};
 
 /// A [`Plugin`] which acts as a [`Layer`] `L`.
 pub struct LayerPlugin<L>(pub L);
@@ -24,9 +24,9 @@ where
 }
 
 // Without more information about what the layer `L` does, we can't know whether it's appropriate
-// to run this plugin as an `HttpPlugin` or a `ModelPlugin`, so we implement both.
+// to run this plugin as a HTTP plugin or a model plugin, so we implement both marker traits.
 
-impl<L> HttpPlugin for LayerPlugin<L> {}
+impl<L> HttpMarker for LayerPlugin<L> {}
 impl<L> ModelPlugin for LayerPlugin<L> {}
 
 /// A [`Layer`] which acts as a [`Plugin`] `Pl` for specific protocol `P` and operation `Op`.

--- a/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 
 use tower::Layer;
 
-use super::Plugin;
+use super::{HttpPlugin, ModelPlugin, Plugin};
 
 /// A [`Plugin`] which acts as a [`Layer`] `L`.
 pub struct LayerPlugin<L>(pub L);
@@ -22,6 +22,12 @@ where
         self.0.layer(svc)
     }
 }
+
+// Without more information about what the layer `L` does, we can't know whether it's appropriate
+// to run this plugin as an `HttpPlugin` or a `ModelPlugin`, so we implement both.
+
+impl<L> HttpPlugin for LayerPlugin<L> {}
+impl<L> ModelPlugin for LayerPlugin<L> {}
 
 /// A [`Layer`] which acts as a [`Plugin`] `Pl` for specific protocol `P` and operation `Op`.
 pub struct PluginLayer<Ser, Op, Pl> {

--- a/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
@@ -5,10 +5,10 @@
 
 //! The plugin system allows you to build middleware with an awareness of the operation it is applied to.
 //!
-//! The system centers around the [`Plugin`], [`HttpPlugin`], and [`ModelPlugin`] traits. In
+//! The system centers around the [`Plugin`], [`HttpMarker`], and [`ModelPlugin`] traits. In
 //! addition, this module provides helpers for composing and combining [`Plugin`]s.
 //!
-//! # [`HttpPlugin`] vs [`ModelPlugin`]
+//! # [`HttpMarker`] vs [`ModelPlugin`]
 //!
 //! Plugins come in two flavors: _HTTP_ plugins and _model_ plugins. The key difference between
 //! them is _when_ they run:
@@ -21,8 +21,8 @@
 //! See the relevant section in [the book], which contains an illustrative diagram.
 //!
 //! Both kinds of plugins implement the [`Plugin`] trait, but only HTTP plugins implement the
-//! [`HttpPlugin`] trait and only model plugins implement the [`ModelPlugin`]. There is no
-//! difference in how an HTTP plugin or a model plugin is applied, so both the [`HttpPlugin`] trait
+//! [`HttpMarker`] trait and only model plugins implement the [`ModelPlugin`]. There is no
+//! difference in how an HTTP plugin or a model plugin is applied, so both the [`HttpMarker`] trait
 //! and the [`ModelPlugin`] trait are _marker traits_, they carry no behavior. Their only purpose
 //! is to mark a plugin, at the type system leve, as allowed to run at a certain time. A plugin can be
 //! _both_ a HTTP plugin and a model plugin by implementing both traits; in this case, when the
@@ -110,9 +110,9 @@
 //! ```no_run
 //! # use aws_smithy_http_server::plugin::*;
 //! # struct Foo;
-//! # impl HttpPlugin for Foo { }
+//! # impl HttpMarker for Foo { }
 //! # let a = Foo; let b = Foo;
-//! // Combine `Plugin`s `a` and `b`. Both need to be `HttpPlugin`s.
+//! // Combine `Plugin`s `a` and `b`. Both need to implement `HttpMarker`.
 //! let plugin = HttpPlugins::new()
 //!     .push(a)
 //!     .push(b);
@@ -135,7 +135,7 @@
 //! use aws_smithy_http_server::{
 //!     operation::OperationShape,
 //!     service::ServiceShape,
-//!     plugin::{Plugin, HttpPlugin, HttpPlugins, ModelPlugin},
+//!     plugin::{Plugin, HttpMarker, HttpPlugins, ModelPlugin},
 //!     shape_id::ShapeId,
 //! };
 //! # use tower::{layer::util::Stack, Layer, Service};
@@ -190,7 +190,7 @@
 //! // This plugin could be registered as an HTTP plugin and a model plugin, so we implement both
 //! // marker traits.
 //!
-//! impl HttpPlugin for PrintPlugin { }
+//! impl HttpMarker for PrintPlugin { }
 //! impl ModelPlugin for PrintPlugin { }
 //! ```
 
@@ -252,8 +252,8 @@ where
 ///
 /// Compare with [`ModelPlugin`] in the [module](crate::plugin) documentation, which contains an
 /// example implementation too.
-pub trait HttpPlugin {}
-impl<'a, Pl> HttpPlugin for &'a Pl where Pl: HttpPlugin {}
+pub trait HttpMarker {}
+impl<'a, Pl> HttpMarker for &'a Pl where Pl: HttpMarker {}
 
 /// A model plugin is a plugin that acts on the modeled operation input after it is deserialized,
 /// and acts on the modeled operation output or the modeled operation error before it is
@@ -261,7 +261,7 @@ impl<'a, Pl> HttpPlugin for &'a Pl where Pl: HttpPlugin {}
 ///
 /// This trait is a _marker_ trait to indicate that a plugin can be registered as a model plugin.
 ///
-/// Compare with [`HttpPlugin`] in the [module](crate::plugin) documentation.
+/// Compare with [`HttpMarker`] in the [module](crate::plugin) documentation.
 ///
 /// # Example implementation of a [`ModelPlugin`]
 ///

--- a/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
@@ -5,13 +5,42 @@
 
 //! The plugin system allows you to build middleware with an awareness of the operation it is applied to.
 //!
-//! The system centers around the [`Plugin`] trait. In addition, this module provides helpers for composing and
-//! combining [`Plugin`]s.
+//! The system centers around the [`Plugin`], [`HttpPlugin`], and [`ModelPlugin`] traits. In
+//! addition, this module provides helpers for composing and combining [`Plugin`]s.
+//!
+//! # [`HttpPlugin`] vs [`ModelPlugin`]
+//!
+//! Plugins come in two flavors: _HTTP_ plugins and _model_ plugins. The key difference between
+//! them is _when_ they run:
+//!
+//! - A HTTP plugin acts on the HTTP request before it is deserialized, and acts on the HTTP response
+//!   after it is serialized.
+//! - A model plugin acts on the modeled operation input after it is deserialized, and acts on the
+//!   modeled operation output or the modeled operation error before it is serialized.
+//!
+//! See the relevant section in [the book], which contains an illustrative diagram.
+//!
+//! Both kinds of plugins implement the [`Plugin`] trait, but only HTTP plugins implement the
+//! [`HttpPlugin`] trait and only model plugins implement the [`ModelPlugin`]. There is no
+//! difference in how an HTTP plugin or a model plugin is applied, so both the [`HttpPlugin`] trait
+//! and the [`ModelPlugin`] trait are _marker traits_, they carry no behavior. Their only purpose
+//! is to mark a plugin, at the type system leve, as allowed to run at a certain time. A plugin can be
+//! _both_ a HTTP plugin and a model plugin by implementing both traits; in this case, when the
+//! plugin runs is decided by you when you register it in your application. [`IdentityPlugin`],
+//! [`Scoped`], and [`LayerPlugin`] are examples of plugins that implement both traits.
+//!
+//! In practice, most plugins are HTTP plugins. Since HTTP plugins run before a request has been
+//! correctly deserialized, HTTP plugins should be fast and lightweight. Only use model plugins if
+//! you absolutely require your middleware to run after deserialization, or to act on particular
+//! fields of your deserialized operation's input/output/errors.
+//!
+//! [the book]: https://awslabs.github.io/smithy-rs/design/server/anatomy.html
 //!
 //! # Filtered application of a HTTP [`Layer`](tower::Layer)
 //!
 //! ```
 //! # use aws_smithy_http_server::plugin::*;
+//! # use aws_smithy_http_server::scope;
 //! # use aws_smithy_http_server::shape_id::ShapeId;
 //! # let layer = ();
 //! # #[derive(PartialEq)]
@@ -21,8 +50,18 @@
 //! // Create a `Plugin` from a HTTP `Layer`
 //! let plugin = LayerPlugin(layer);
 //!
-//! // Only apply the layer to operations with name "GetPokemonSpecies"
-//! let plugin = filter_by_operation(plugin, |operation: Operation| operation == Operation::GetPokemonSpecies);
+//! scope! {
+//!     struct OnlyGetPokemonSpecies {
+//!         includes: [GetPokemonSpecies],
+//!         excludes: [/* The rest of the operations go here */]
+//!     }
+//! }
+//!
+//! // Only apply the layer to operations with name "GetPokemonSpecies".
+//! let filtered_plugin = Scoped::new::<OnlyGetPokemonSpecies>(&plugin);
+//!
+//! // The same effect can be achieved at runtime.
+//! let filtered_plugin = filter_by_operation(&plugin, |operation: Operation| operation == Operation::GetPokemonSpecies);
 //! ```
 //!
 //! # Construct a [`Plugin`] from a closure that takes as input the operation name
@@ -68,25 +107,35 @@
 //!
 //! # Combine [`Plugin`]s
 //!
-//! ```
+//! ```no_run
 //! # use aws_smithy_http_server::plugin::*;
-//! # let a = (); let b = ();
-//! // Combine `Plugin`s `a` and `b`
-//! let plugin = PluginPipeline::new()
+//! # struct Foo;
+//! # impl HttpPlugin for Foo { }
+//! # let a = Foo; let b = Foo;
+//! // Combine `Plugin`s `a` and `b`. Both need to be `HttpPlugin`s.
+//! let plugin = HttpPlugins::new()
 //!     .push(a)
 //!     .push(b);
 //! ```
 //!
-//! As noted in the [`PluginPipeline`] documentation, the plugins' runtime logic is executed in registration order,
+//! As noted in the [`HttpPlugins`] documentation, the plugins' runtime logic is executed in registration order,
 //! meaning that `a` is run _before_ `b` in the example above.
 //!
-//! # Example Implementation
+//! Similarly, you can use [`ModelPlugins`] to combine model plugins.
 //!
-//! ```rust
+//! # Example implementation of a [`Plugin`]
+//!
+//! The following is an example implementation of a [`Plugin`] that prints out the service's name
+//! and the name of the operation that was hit every time it runs. Since it doesn't act on the HTTP
+//! request nor the modeled operation input/output/errors, this plugin can be both an HTTP plugin
+//! and a model plugin. In practice, however, you'd only want to register it once, as either an
+//! HTTP plugin or a model plugin.
+//!
+//! ```no_run
 //! use aws_smithy_http_server::{
 //!     operation::OperationShape,
 //!     service::ServiceShape,
-//!     plugin::{Plugin, PluginPipeline, PluginStack},
+//!     plugin::{Plugin, HttpPlugin, HttpPlugins, ModelPlugin},
 //!     shape_id::ShapeId,
 //! };
 //! # use tower::{layer::util::Stack, Layer, Service};
@@ -137,16 +186,22 @@
 //!         }
 //!     }
 //! }
-//! ```
 //!
+//! // This plugin could be registered as an HTTP plugin and a model plugin, so we implement both
+//! // marker traits.
+//!
+//! impl HttpPlugin for PrintPlugin { }
+//! impl ModelPlugin for PrintPlugin { }
+//! ```
 
 pub mod alb_health_check;
 mod closure;
 mod either;
 mod filter;
+mod http_plugins;
 mod identity;
 mod layer;
-mod pipeline;
+mod model_plugins;
 #[doc(hidden)]
 pub mod scoped;
 mod stack;
@@ -154,9 +209,10 @@ mod stack;
 pub use closure::{plugin_from_operation_fn, OperationFn};
 pub use either::Either;
 pub use filter::{filter_by_operation, FilterByOperation};
+pub use http_plugins::HttpPlugins;
 pub use identity::IdentityPlugin;
 pub use layer::{LayerPlugin, PluginLayer};
-pub use pipeline::PluginPipeline;
+pub use model_plugins::ModelPlugins;
 pub use scoped::Scoped;
 pub use stack::PluginStack;
 
@@ -188,3 +244,222 @@ where
         <Pl as Plugin<Ser, Op, T>>::apply(self, inner)
     }
 }
+
+/// A HTTP plugin is a plugin that acts on the HTTP request before it is deserialized, and acts on
+/// the HTTP response after it is serialized.
+///
+/// This trait is a _marker_ trait to indicate that a plugin can be registered as an HTTP plugin.
+///
+/// Compare with [`ModelPlugin`] in the [module](crate::plugin) documentation, which contains an
+/// example implementation too.
+pub trait HttpPlugin {}
+impl<'a, Pl> HttpPlugin for &'a Pl where Pl: HttpPlugin {}
+
+/// A model plugin is a plugin that acts on the modeled operation input after it is deserialized,
+/// and acts on the modeled operation output or the modeled operation error before it is
+/// serialized.
+///
+/// This trait is a _marker_ trait to indicate that a plugin can be registered as a model plugin.
+///
+/// Compare with [`HttpPlugin`] in the [module](crate::plugin) documentation.
+///
+/// # Example implementation of a [`ModelPlugin`]
+///
+/// Model plugins are most useful when you really need to rely on the actual shape of your
+/// modeled operation input, operation output, and/or operation errors. For this reason, most
+/// model plugins' implementation are _operation-specific_: somewhere in the type signature
+/// of their definition, they'll rely on a operation shape's types. It is therefore important
+/// that you scope application of model plugins to the operations they are meant to work on, via
+/// [`Scoped`](crate::plugin::Scoped) or [`filter_by_operation`](crate::plugin::filter_by_operation).
+///
+/// Below is an example implementation of a model plugin that can only be applied to the
+/// `CheckHealth` operation: note how in the `Service` trait implementation, we require access to
+/// the operation's input, where we log the `health_info` field.
+///
+/// ```no_run
+/// use std::marker::PhantomData;
+///
+/// use aws_smithy_http_server::{operation::OperationShape, plugin::{ModelPlugin, Plugin}};
+/// use tower::Service;
+/// # pub struct SimpleService;
+/// # pub struct CheckHealth;
+/// # pub struct CheckHealthInput {
+/// #     health_info: (),
+/// # }
+/// # pub struct CheckHealthOutput;
+/// # impl aws_smithy_http_server::operation::OperationShape for CheckHealth {
+/// #     const ID: aws_smithy_http_server::shape_id::ShapeId = aws_smithy_http_server::shape_id::ShapeId::new(
+/// #         "com.amazonaws.simple#CheckHealth",
+/// #         "com.amazonaws.simple",
+/// #         "CheckHealth",
+/// #     );
+/// #     type Input = CheckHealthInput;
+/// #     type Output = CheckHealthOutput;
+/// #     type Error = std::convert::Infallible;
+/// # }
+///
+/// /// A model plugin that can only be applied to the `CheckHealth` operation.
+/// pub struct CheckHealthPlugin<Exts> {
+///     pub _exts: PhantomData<Exts>,
+/// }
+///
+/// impl<Exts> CheckHealthPlugin<Exts> {
+///     pub fn new() -> Self {
+///         Self { _exts: PhantomData }
+///     }
+/// }
+///
+/// impl<T, Exts> Plugin<SimpleService, CheckHealth, T> for CheckHealthPlugin<Exts> {
+///     type Output = CheckHealthService<T, Exts>;
+///
+///     fn apply(&self, input: T) -> Self::Output {
+///         CheckHealthService {
+///             inner: input,
+///             _exts: PhantomData,
+///         }
+///     }
+/// }
+///
+/// impl<Exts> ModelPlugin for CheckHealthPlugin<Exts> { }
+///
+/// #[derive(Clone)]
+/// pub struct CheckHealthService<S, Exts> {
+///     inner: S,
+///     _exts: PhantomData<Exts>,
+/// }
+///
+/// impl<S, Exts> Service<(<CheckHealth as OperationShape>::Input, Exts)> for CheckHealthService<S, Exts>
+/// where
+///     S: Service<(<CheckHealth as OperationShape>::Input, Exts)>,
+/// {
+///     type Response = S::Response;
+///     type Error = S::Error;
+///     type Future = S::Future;
+///
+///     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+///         self.inner.poll_ready(cx)
+///     }
+///
+///     fn call(&mut self, req: (<CheckHealth as OperationShape>::Input, Exts)) -> Self::Future {
+///         let (input, _exts) = &req;
+///
+///         // We have access to `CheckHealth`'s modeled operation input!
+///         dbg!(&input.health_info);
+///
+///         self.inner.call(req)
+///     }
+/// }
+///
+/// // In `main.rs` or wherever we register plugins, we have to make sure we only apply this plugin
+/// // to the the only operation it can be applied to, the `CheckHealth` operation. If we apply the
+/// // plugin to other operations, we will get a compilation error.
+///
+/// use aws_smithy_http_server::plugin::Scoped;
+/// use aws_smithy_http_server::scope;
+///
+/// pub fn main() {
+///     scope! {
+///         struct OnlyCheckHealth {
+///             includes: [CheckHealth],
+///             excludes: [/* The rest of the operations go here */]
+///         }
+///     }
+///
+///     let model_plugin = CheckHealthPlugin::new();
+///     # _foo(&model_plugin);
+///
+///     // Scope the plugin to the `CheckHealth` operation.
+///     let scoped_plugin = Scoped::new::<OnlyCheckHealth>(model_plugin);
+///     # fn _foo(model_plugin: &CheckHealthPlugin<()>) {}
+/// }
+/// ```
+///
+/// If you are a service owner and don't care about giving a name to the model plugin, you can
+/// simplify this down to:
+///
+/// ```no_run
+/// use std::marker::PhantomData;
+///
+/// use aws_smithy_http_server::operation::OperationShape;
+/// use tower::Service;
+/// # pub struct SimpleService;
+/// # pub struct CheckHealth;
+/// # pub struct CheckHealthInput {
+/// #     health_info: (),
+/// # }
+/// # pub struct CheckHealthOutput;
+/// # impl aws_smithy_http_server::operation::OperationShape for CheckHealth {
+/// #     const ID: aws_smithy_http_server::shape_id::ShapeId = aws_smithy_http_server::shape_id::ShapeId::new(
+/// #         "com.amazonaws.simple#CheckHealth",
+/// #         "com.amazonaws.simple",
+/// #         "CheckHealth",
+/// #     );
+/// #     type Input = CheckHealthInput;
+/// #     type Output = CheckHealthOutput;
+/// #     type Error = std::convert::Infallible;
+/// # }
+///
+/// #[derive(Clone)]
+/// pub struct CheckHealthService<S, Exts> {
+///     inner: S,
+///     _exts: PhantomData<Exts>,
+/// }
+///
+/// impl<S, Exts> Service<(<CheckHealth as OperationShape>::Input, Exts)> for CheckHealthService<S, Exts>
+/// where
+///     S: Service<(<CheckHealth as OperationShape>::Input, Exts)>,
+/// {
+///     type Response = S::Response;
+///     type Error = S::Error;
+///     type Future = S::Future;
+///
+///     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+///         self.inner.poll_ready(cx)
+///     }
+///
+///     fn call(&mut self, req: (<CheckHealth as OperationShape>::Input, Exts)) -> Self::Future {
+///         let (input, _exts) = &req;
+///
+///         // We have access to `CheckHealth`'s modeled operation input!
+///         dbg!(&input.health_info);
+///
+///         self.inner.call(req)
+///     }
+/// }
+///
+/// // In `main.rs`:
+///
+/// use aws_smithy_http_server::plugin::LayerPlugin;
+/// use aws_smithy_http_server::plugin::Scoped;
+/// use aws_smithy_http_server::scope;
+///
+/// fn new_check_health_service<S, Ext>(inner: S) -> CheckHealthService<S, Ext> {
+///     CheckHealthService {
+///         inner,
+///         _exts: PhantomData,
+///     }
+/// }
+///
+/// pub fn main() {
+///     scope! {
+///         struct OnlyCheckHealth {
+///             includes: [CheckHealth],
+///             excludes: [/* The rest of the operations go here */]
+///         }
+///     }
+///
+///     # fn new_check_health_service(inner: ()) -> CheckHealthService<(), ()> {
+///     #     CheckHealthService {
+///     #         inner,
+///     #         _exts: PhantomData,
+///     #     }
+///     # }
+///     let layer = tower::layer::layer_fn(new_check_health_service);
+///     let model_plugin = LayerPlugin(layer);
+///
+///     // Scope the plugin to the `CheckHealth` operation.
+///     let scoped_plugin = Scoped::new::<OnlyCheckHealth>(model_plugin);
+/// }
+/// ```
+pub trait ModelPlugin {}
+impl<'a, Pl> ModelPlugin for &'a Pl where Pl: ModelPlugin {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
@@ -5,10 +5,10 @@
 
 //! The plugin system allows you to build middleware with an awareness of the operation it is applied to.
 //!
-//! The system centers around the [`Plugin`], [`HttpMarker`], and [`ModelPlugin`] traits. In
+//! The system centers around the [`Plugin`], [`HttpMarker`], and [`ModelMarker`] traits. In
 //! addition, this module provides helpers for composing and combining [`Plugin`]s.
 //!
-//! # [`HttpMarker`] vs [`ModelPlugin`]
+//! # HTTP plugins vs model plugins
 //!
 //! Plugins come in two flavors: _HTTP_ plugins and _model_ plugins. The key difference between
 //! them is _when_ they run:
@@ -21,9 +21,9 @@
 //! See the relevant section in [the book], which contains an illustrative diagram.
 //!
 //! Both kinds of plugins implement the [`Plugin`] trait, but only HTTP plugins implement the
-//! [`HttpMarker`] trait and only model plugins implement the [`ModelPlugin`]. There is no
+//! [`HttpMarker`] trait and only model plugins implement the [`ModelMarker`] trait. There is no
 //! difference in how an HTTP plugin or a model plugin is applied, so both the [`HttpMarker`] trait
-//! and the [`ModelPlugin`] trait are _marker traits_, they carry no behavior. Their only purpose
+//! and the [`ModelMarker`] trait are _marker traits_, they carry no behavior. Their only purpose
 //! is to mark a plugin, at the type system leve, as allowed to run at a certain time. A plugin can be
 //! _both_ a HTTP plugin and a model plugin by implementing both traits; in this case, when the
 //! plugin runs is decided by you when you register it in your application. [`IdentityPlugin`],
@@ -135,7 +135,7 @@
 //! use aws_smithy_http_server::{
 //!     operation::OperationShape,
 //!     service::ServiceShape,
-//!     plugin::{Plugin, HttpMarker, HttpPlugins, ModelPlugin},
+//!     plugin::{Plugin, HttpMarker, HttpPlugins, ModelMarker},
 //!     shape_id::ShapeId,
 //! };
 //! # use tower::{layer::util::Stack, Layer, Service};
@@ -191,7 +191,7 @@
 //! // marker traits.
 //!
 //! impl HttpMarker for PrintPlugin { }
-//! impl ModelPlugin for PrintPlugin { }
+//! impl ModelMarker for PrintPlugin { }
 //! ```
 
 pub mod alb_health_check;
@@ -250,7 +250,7 @@ where
 ///
 /// This trait is a _marker_ trait to indicate that a plugin can be registered as an HTTP plugin.
 ///
-/// Compare with [`ModelPlugin`] in the [module](crate::plugin) documentation, which contains an
+/// Compare with [`ModelMarker`] in the [module](crate::plugin) documentation, which contains an
 /// example implementation too.
 pub trait HttpMarker {}
 impl<'a, Pl> HttpMarker for &'a Pl where Pl: HttpMarker {}
@@ -263,7 +263,7 @@ impl<'a, Pl> HttpMarker for &'a Pl where Pl: HttpMarker {}
 ///
 /// Compare with [`HttpMarker`] in the [module](crate::plugin) documentation.
 ///
-/// # Example implementation of a [`ModelPlugin`]
+/// # Example implementation of a model plugin
 ///
 /// Model plugins are most useful when you really need to rely on the actual shape of your
 /// modeled operation input, operation output, and/or operation errors. For this reason, most
@@ -279,7 +279,7 @@ impl<'a, Pl> HttpMarker for &'a Pl where Pl: HttpMarker {}
 /// ```no_run
 /// use std::marker::PhantomData;
 ///
-/// use aws_smithy_http_server::{operation::OperationShape, plugin::{ModelPlugin, Plugin}};
+/// use aws_smithy_http_server::{operation::OperationShape, plugin::{ModelMarker, Plugin}};
 /// use tower::Service;
 /// # pub struct SimpleService;
 /// # pub struct CheckHealth;
@@ -320,7 +320,7 @@ impl<'a, Pl> HttpMarker for &'a Pl where Pl: HttpMarker {}
 ///     }
 /// }
 ///
-/// impl<Exts> ModelPlugin for CheckHealthPlugin<Exts> { }
+/// impl<Exts> ModelMarker for CheckHealthPlugin<Exts> { }
 ///
 /// #[derive(Clone)]
 /// pub struct CheckHealthService<S, Exts> {
@@ -461,5 +461,5 @@ impl<'a, Pl> HttpMarker for &'a Pl where Pl: HttpMarker {}
 ///     let scoped_plugin = Scoped::new::<OnlyCheckHealth>(model_plugin);
 /// }
 /// ```
-pub trait ModelPlugin {}
-impl<'a, Pl> ModelPlugin for &'a Pl where Pl: ModelPlugin {}
+pub trait ModelMarker {}
+impl<'a, Pl> ModelMarker for &'a Pl where Pl: ModelMarker {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/model_plugins.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/model_plugins.rs
@@ -8,9 +8,9 @@
 
 use crate::plugin::{IdentityPlugin, Plugin, PluginStack};
 
-use super::{LayerPlugin, ModelPlugin};
+use super::{LayerPlugin, ModelMarker};
 
-/// A wrapper struct for composing [`ModelPlugin`]s.
+/// A wrapper struct for composing model plugins.
 /// It operates identically to [`HttpPlugins`](crate::plugin::HttpPlugins); see its documentation.
 #[derive(Debug)]
 pub struct ModelPlugins<P>(pub(crate) P);
@@ -68,9 +68,9 @@ impl<P> ModelPlugins<P> {
     ///     }
     /// }
     /// ```
-    // We eagerly require `NewPlugin: ModelPlugin`, despite not really needing it, because compiler
+    // We eagerly require `NewPlugin: ModelMarker`, despite not really needing it, because compiler
     // errors get _substantially_ better if the user makes a mistake.
-    pub fn push<NewPlugin: ModelPlugin>(self, new_plugin: NewPlugin) -> ModelPlugins<PluginStack<NewPlugin, P>> {
+    pub fn push<NewPlugin: ModelMarker>(self, new_plugin: NewPlugin) -> ModelPlugins<PluginStack<NewPlugin, P>> {
         ModelPlugins(PluginStack::new(new_plugin, self.0))
     }
 
@@ -91,4 +91,4 @@ where
     }
 }
 
-impl<InnerPlugin> ModelPlugin for ModelPlugins<InnerPlugin> where InnerPlugin: ModelPlugin {}
+impl<InnerPlugin> ModelMarker for ModelPlugins<InnerPlugin> where InnerPlugin: ModelMarker {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/model_plugins.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/model_plugins.rs
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// If you make any updates to this file (including Rust docs), make sure you make them to
+// `http_plugins.rs` too!
+
+use crate::plugin::{IdentityPlugin, Plugin, PluginStack};
+
+use super::{LayerPlugin, ModelPlugin};
+
+/// A wrapper struct for composing [`ModelPlugin`]s.
+/// It operates identically to [`HttpPlugins`]; see its documentation.
+#[derive(Debug)]
+pub struct ModelPlugins<P>(pub(crate) P);
+
+impl Default for ModelPlugins<IdentityPlugin> {
+    fn default() -> Self {
+        Self(IdentityPlugin)
+    }
+}
+
+impl ModelPlugins<IdentityPlugin> {
+    /// Create an empty [`ModelPlugins`].
+    ///
+    /// You can use [`ModelPlugins::push`] to add plugins to it.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<P> ModelPlugins<P> {
+    /// Apply a new model plugin after the ones that have already been registered.
+    ///
+    /// ```rust
+    /// use aws_smithy_http_server::plugin::ModelPlugins;
+    /// # use aws_smithy_http_server::plugin::IdentityPlugin as LoggingPlugin;
+    /// # use aws_smithy_http_server::plugin::IdentityPlugin as MetricsPlugin;
+    ///
+    /// let model_plugins = ModelPlugins::new().push(LoggingPlugin).push(MetricsPlugin);
+    /// ```
+    ///
+    /// The plugins' runtime logic is executed in registration order.
+    /// In our example above, `LoggingPlugin` would run first, while `MetricsPlugin` is executed last.
+    ///
+    /// ## Implementation notes
+    ///
+    /// Plugins are applied to the underlying [`Service`](tower::Service) in opposite order compared
+    /// to their registration order.
+    ///
+    /// As an example:
+    ///
+    /// ```rust,compile_fail
+    /// #[derive(Debug)]
+    /// pub struct PrintPlugin;
+    ///
+    /// impl<Ser, Op, S> Plugin<Ser, Op, T> for PrintPlugin
+    /// // [...]
+    /// {
+    ///     // [...]
+    ///     fn apply(&self, inner: T) -> Self::Service {
+    ///         PrintService {
+    ///             inner,
+    ///             service_id: Ser::ID,
+    ///             operation_id: Op::ID
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    // We eagerly require `NewPlugin: ModelPlugin`, despite not really needing it, because compiler
+    // errors get _substantially_ better if the user makes a mistake.
+    pub fn push<NewPlugin: ModelPlugin>(self, new_plugin: NewPlugin) -> ModelPlugins<PluginStack<NewPlugin, P>> {
+        ModelPlugins(PluginStack::new(new_plugin, self.0))
+    }
+
+    /// Applies a single [`tower::Layer`] to all operations _before_ they are deserialized.
+    pub fn layer<L>(self, layer: L) -> ModelPlugins<PluginStack<LayerPlugin<L>, P>> {
+        ModelPlugins(PluginStack::new(LayerPlugin(layer), self.0))
+    }
+}
+
+impl<Ser, Op, T, InnerPlugin> Plugin<Ser, Op, T> for ModelPlugins<InnerPlugin>
+where
+    InnerPlugin: Plugin<Ser, Op, T>,
+{
+    type Output = InnerPlugin::Output;
+
+    fn apply(&self, input: T) -> Self::Output {
+        self.0.apply(input)
+    }
+}
+
+impl<InnerPlugin> ModelPlugin for ModelPlugins<InnerPlugin> where InnerPlugin: ModelPlugin {}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/model_plugins.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/model_plugins.rs
@@ -11,7 +11,7 @@ use crate::plugin::{IdentityPlugin, Plugin, PluginStack};
 use super::{LayerPlugin, ModelPlugin};
 
 /// A wrapper struct for composing [`ModelPlugin`]s.
-/// It operates identically to [`HttpPlugins`]; see its documentation.
+/// It operates identically to [`HttpPlugins`](crate::plugin::HttpPlugins); see its documentation.
 #[derive(Debug)]
 pub struct ModelPlugins<P>(pub(crate) P);
 

--- a/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
@@ -5,7 +5,7 @@
 
 use std::marker::PhantomData;
 
-use super::{HttpMarker, ModelPlugin, Plugin};
+use super::{HttpMarker, ModelMarker, Plugin};
 
 /// Marker struct for `true`.
 ///
@@ -103,7 +103,7 @@ where
 }
 
 impl<Scope, Pl> HttpMarker for Scoped<Scope, Pl> where Pl: HttpMarker {}
-impl<Scope, Pl> ModelPlugin for Scoped<Scope, Pl> where Pl: ModelPlugin {}
+impl<Scope, Pl> ModelMarker for Scoped<Scope, Pl> where Pl: ModelMarker {}
 
 /// A macro to help with scoping [plugins](crate::plugin) to a subset of all operations.
 ///

--- a/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
@@ -5,7 +5,7 @@
 
 use std::marker::PhantomData;
 
-use super::Plugin;
+use super::{HttpPlugin, ModelPlugin, Plugin};
 
 /// Marker struct for `true`.
 ///
@@ -102,12 +102,15 @@ where
     }
 }
 
+impl<Scope, Pl> HttpPlugin for Scoped<Scope, Pl> where Pl: HttpPlugin {}
+impl<Scope, Pl> ModelPlugin for Scoped<Scope, Pl> where Pl: ModelPlugin {}
+
 /// A macro to help with scoping [plugins](crate::plugin) to a subset of all operations.
 ///
 /// The scope must partition _all_ operations, that is, each and every operation must be included or excluded, but not
 /// both.
 ///
-/// The generated server SDK exports a similar `scope` macro which is aware of a services operations and can complete
+/// The generated server SDK exports a similar `scope` macro which is aware of a service's operations and can complete
 /// underspecified scopes automatically.
 ///
 /// # Example

--- a/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
@@ -5,7 +5,7 @@
 
 use std::marker::PhantomData;
 
-use super::{HttpPlugin, ModelPlugin, Plugin};
+use super::{HttpMarker, ModelPlugin, Plugin};
 
 /// Marker struct for `true`.
 ///
@@ -102,7 +102,7 @@ where
     }
 }
 
-impl<Scope, Pl> HttpPlugin for Scoped<Scope, Pl> where Pl: HttpPlugin {}
+impl<Scope, Pl> HttpMarker for Scoped<Scope, Pl> where Pl: HttpMarker {}
 impl<Scope, Pl> ModelPlugin for Scoped<Scope, Pl> where Pl: ModelPlugin {}
 
 /// A macro to help with scoping [plugins](crate::plugin) to a subset of all operations.

--- a/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
@@ -3,13 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::Plugin;
+use super::{HttpPlugin, ModelPlugin, Plugin};
 
 /// A wrapper struct which composes an `Inner` and an `Outer` [`Plugin`].
 ///
 /// The `Inner::map` is run _then_ the `Outer::map`.
 ///
-/// Note that the primary tool for composing plugins is [`PluginPipeline`](crate::plugin::PluginPipeline).
+/// Note that the primary tool for composing HTTP plugins is
+/// [`HttpPlugins`](crate::plugin::HttpPlugins), and the primary tool for composing HTTP plugins is
+/// [`ModelPlugins`](crate::plugin::ModelPlugins); if you are an application writer, you should
+/// prefer composing plugins using these.
 pub struct PluginStack<Inner, Outer> {
     inner: Inner,
     outer: Outer,
@@ -33,4 +36,18 @@ where
         let svc = self.inner.apply(input);
         self.outer.apply(svc)
     }
+}
+
+impl<Inner, Outer> HttpPlugin for PluginStack<Inner, Outer>
+where
+    Inner: HttpPlugin,
+    Outer: HttpPlugin,
+{
+}
+
+impl<Inner, Outer> ModelPlugin for PluginStack<Inner, Outer>
+where
+    Inner: ModelPlugin,
+    Outer: ModelPlugin,
+{
 }

--- a/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::{HttpMarker, ModelPlugin, Plugin};
+use super::{HttpMarker, ModelMarker, Plugin};
 
 /// A wrapper struct which composes an `Inner` and an `Outer` [`Plugin`].
 ///
@@ -45,9 +45,9 @@ where
 {
 }
 
-impl<Inner, Outer> ModelPlugin for PluginStack<Inner, Outer>
+impl<Inner, Outer> ModelMarker for PluginStack<Inner, Outer>
 where
-    Inner: ModelPlugin,
-    Outer: ModelPlugin,
+    Inner: ModelMarker,
+    Outer: ModelMarker,
 {
 }

--- a/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::{HttpPlugin, ModelPlugin, Plugin};
+use super::{HttpMarker, ModelPlugin, Plugin};
 
 /// A wrapper struct which composes an `Inner` and an `Outer` [`Plugin`].
 ///
@@ -38,10 +38,10 @@ where
     }
 }
 
-impl<Inner, Outer> HttpPlugin for PluginStack<Inner, Outer>
+impl<Inner, Outer> HttpMarker for PluginStack<Inner, Outer>
 where
-    Inner: HttpPlugin,
-    Outer: HttpPlugin,
+    Inner: HttpMarker,
+    Outer: HttpMarker,
 {
 }
 


### PR DESCRIPTION
So far, servers have tacitly worked with the notion that plugins come in
two flavors: "HTTP plugins" and "model plugins":

- A HTTP plugin acts on the HTTP request before it is deserialized, and
  acts on the HTTP response after it is serialized.
- A model plugin acts on the modeled operation input after it is
  deserialized, and acts on the modeled operation output or the modeled
  operation error before it is serialized.

However, this notion was never reified in the type system. Thus, users
who pass in a model plugin where a HTTP plugin is expected or
viceversa in several APIs:

```rust
let pipeline = PluginPipeline::new().push(http_plugin).push(model_plugin);

let app = SimpleService::builder_with_plugins(http_plugins, IdentityPlugin)
    .post_operation(handler)
    /* ... */
    .build()
    .unwrap();
```

would get the typical Tower service compilation errors, which can get
very confusing:

```
error[E0631]: type mismatch in function arguments
  --> simple/rust-server-codegen/src/main.rs:47:6
   |
15 | fn new_svc<S, Ext>(inner: S) -> model_plugin::PostOperationService<S, Ext> {
   | -------------------------------------------------------------------------- found signature defined here
...
47 |     .post_operation(post_operation)
   |      ^^^^^^^^^^^^^^ expected due to this
   |
   = note: expected function signature `fn(Upgrade<RestJson1, (PostOperationInput, _), PostOperationService<aws_smithy_http_server::operation::IntoService<simple::operation_shape::PostOperation, _>, _>>) -> _`
              found function signature `fn(aws_smithy_http_server::operation::IntoService<simple::operation_shape::PostOperation, _>) -> _`
   = note: required for `LayerFn<fn(aws_smithy_http_server::operation::IntoService<..., ...>) -> ... {new_svc::<..., ...>}>` to implement `Layer<Upgrade<RestJson1, (PostOperationInput, _), PostOperationService<aws_smithy_http_server::operation::IntoService<simple::operation_shape::PostOperation, _>, _>>>`
   = note: the full type name has been written to '/local/home/davidpz/workplace/smithy-ws/src/SmithyRsSource/target/debug/deps/simple-6577f9f79749ceb9.long-type-4938700695428041031.txt'
```

This commit introduces the `HttpPlugin` and `ModelPlugin` marker traits,
allowing plugins to be marked as an HTTP plugin, a model plugin, or
both. It also removes the primary way of concatenating plugins,
`PluginPipeline`, in favor of `HttpPlugins` and `ModelPlugins`, which
eagerly check that whenever a plugin is `push`ed, it is of the expected
type. The generated service type in the server SDKs'
`builder_with_plugins` constructor now takes an `HttpPlugin` as its
first parameter, and a `ModelPlugin` as its second parameter.

I think this change perhaps goes counter to the generally accepted
wisdom that trait bounds in Rust should be enforced "at the latest
possible moment", that is, only when the behavior encoded in the trait
implementation is relied upon in the code (citation needed).
However, the result is that exposing the concepts of HTTP plugin and
model plugin in the type system makes for code that is easier to reason
about, and produces more helpful compiler error messages.

Documentation about the plugin system has been expanded, particularly on
how to implement model plugins.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
