### PR TITLE
Increase max line length for generated client code

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
@@ -170,7 +170,8 @@ class ClientCodegenVisitor(
             ),
         )
         try {
-            "cargo fmt".runCommand(fileManifest.baseDir, timeout = settings.codegenConfig.formatTimeoutSeconds.toLong())
+            // use an increased max_width to make rustfmt fail less frequently
+            "cargo fmt -- --config max_width=150".runCommand(fileManifest.baseDir, timeout = settings.codegenConfig.formatTimeoutSeconds.toLong())
         } catch (err: CommandFailed) {
             logger.warning("Failed to run cargo fmt: [${service.id}]\n${err.output}")
         }


### PR DESCRIPTION
This PR increases the max line length on generated client code to reduce the likelihood of rustfmt failing to format files.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
