### PR TITLE
add reëxport for SharedInterceptor to SDK config modules

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGenerator.kt
@@ -28,9 +28,11 @@ class ClientRuntimeTypesReExportGenerator(
                 """
                 pub use #{ConfigBag};
                 pub use #{Interceptor};
+                pub use #{SharedInterceptor};
                 """,
                 "ConfigBag" to RuntimeType.configBag(rc),
                 "Interceptor" to RuntimeType.interceptor(rc),
+                "SharedInterceptor" to RuntimeType.sharedInterceptor(rc),
             )
         }
         rustCrate.withModule(ClientRustModule.endpoint(codegenContext)) {


### PR DESCRIPTION
We weren't already doing this but we should b/c it's needed to use the `add_interceptor` and `set_interceptors` config methods

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
