### PR TITLE
Update the S3 benchmark for correctness and performance

### DIFF
--- a/aws/sdk/s3-benchmark/benchmark/Cargo.lock
+++ b/aws/sdk/s3-benchmark/benchmark/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
+name = "async-trait"
+version = "0.1.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fa67157abdfd688a259b6648808757db9347af834624f27ec646da976aee5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,11 +415,15 @@ dependencies = [
 name = "benchmark"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "aws-smithy-client",
  "aws-smithy-http",
  "clap",
+ "hyper",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -735,9 +750,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1005,18 +1020,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1264,9 +1279,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/aws/sdk/s3-benchmark/benchmark/Cargo.toml
+++ b/aws/sdk/s3-benchmark/benchmark/Cargo.toml
@@ -12,6 +12,10 @@ publish = false
 aws-config = "0.55.3"
 aws-sdk-s3 = "0.28.0"
 aws-smithy-http = "0.55.3"
+aws-smithy-client= { version = "0.55.3", features = ["client-hyper"] }
 clap = { version = "4.3.2", default-features = false, features = ["derive", "std", "help"] }
 tokio = { version = "1.28.2", features = ["full"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing = "0.1"
+async-trait = "0.1.68"
+hyper = { version = "0.14.27", features = ["client"] }

--- a/aws/sdk/s3-benchmark/benchmark/src/get_test.rs
+++ b/aws/sdk/s3-benchmark/benchmark/src/get_test.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::{verify, Args, BoxError};
+use async_trait::async_trait;
+use aws_config::SdkConfig;
+use aws_sdk_s3::Client;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct GetTestResult {
+    pub(crate) expected: PathBuf,
+    pub(crate) actual: PathBuf,
+}
+
+#[async_trait]
+pub(crate) trait GetBenchmark {
+    type Setup: Send;
+    async fn prepare(&self, conf: &SdkConfig) -> Self::Setup;
+    async fn do_get(
+        &self,
+        state: Self::Setup,
+        target_path: &Path,
+        args: &Args,
+    ) -> Result<PathBuf, BoxError>;
+    async fn do_bench(
+        &self,
+        state: Self::Setup,
+        args: &Args,
+        expected_path: &Path,
+    ) -> Result<GetTestResult, BoxError> {
+        let target_path = expected_path.with_extension("downloaded");
+        let downloaded_path = self.do_get(state, &target_path, args).await?;
+        Ok(GetTestResult {
+            expected: expected_path.to_path_buf(),
+            actual: downloaded_path,
+        })
+    }
+
+    async fn verify(
+        &self,
+        _client: &Client,
+        _args: &Args,
+        result: GetTestResult,
+    ) -> Result<(), BoxError> {
+        verify::diff(&result.actual, &result.expected).await
+    }
+}

--- a/aws/sdk/s3-benchmark/benchmark/src/latencies.rs
+++ b/aws/sdk/s3-benchmark/benchmark/src/latencies.rs
@@ -6,7 +6,7 @@
 use std::fmt;
 use std::time;
 
-const ONE_GIGABYTE: u64 = 1024 * 1024 * 1024;
+const ONE_GIGABYTE: u64 = 1000 * 1000 * 1000;
 
 #[derive(Debug)]
 pub struct Latencies {

--- a/aws/sdk/s3-benchmark/benchmark/src/multipart_get.rs
+++ b/aws/sdk/s3-benchmark/benchmark/src/multipart_get.rs
@@ -4,80 +4,174 @@
  */
 
 use crate::{Args, BoxError, BENCH_KEY};
+use async_trait::async_trait;
+use aws_config::SdkConfig;
 use aws_sdk_s3 as s3;
+use aws_sdk_s3::Client;
+use aws_smithy_http::byte_stream::AggregatedBytes;
 use std::fmt;
-use std::path::Path;
+use std::fs::File;
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::watch::channel;
+use std::time::{Duration, SystemTime};
+
+use crate::get_test::GetBenchmark;
 use tokio::sync::Semaphore;
+use tokio::task::spawn_blocking;
+use tokio::time::timeout;
+use tracing::{info_span, Instrument};
+
+pub(crate) struct GetObjectMultipart {}
+impl GetObjectMultipart {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl GetBenchmark for GetObjectMultipart {
+    type Setup = Vec<Client>;
+
+    async fn prepare(&self, conf: &SdkConfig) -> Self::Setup {
+        let clients = (0..32).map(|_| Client::new(&conf)).collect::<Vec<_>>();
+        for client in &clients {
+            let _ = client.list_buckets().send().await;
+        }
+        clients
+    }
+
+    async fn do_get(
+        &self,
+        state: Self::Setup,
+        target_path: &Path,
+        args: &Args,
+    ) -> Result<PathBuf, BoxError> {
+        get_object_multipart(&state, args, target_path, &args.bucket, BENCH_KEY).await?;
+        Ok(target_path.to_path_buf())
+    }
+}
 
 pub async fn get_object_multipart(
-    client: &s3::Client,
+    clients: &[s3::Client],
     args: &Args,
-    path: &Path,
+    target_path: &Path,
+    bucket: &str,
+    key: &str,
 ) -> Result<(), BoxError> {
-    let mut part_count = (args.size_bytes / args.part_size_bytes + 1) as i64;
-    let mut size_of_last_part = (args.size_bytes % args.part_size_bytes) as i64;
+    let mut part_count = (args.size_bytes / args.part_size_bytes + 1) as u64;
+    let mut size_of_last_part = (args.size_bytes % args.part_size_bytes) as u64;
     if size_of_last_part == 0 {
-        size_of_last_part = args.part_size_bytes as i64;
+        size_of_last_part = args.part_size_bytes as u64;
         part_count -= 1;
     }
 
-    let mut ranges = (0..part_count).map(|i| {
+    let ranges = (0..part_count).map(|i| {
         if i == part_count - 1 {
-            let start = i * args.part_size_bytes as i64;
+            let start = i * args.part_size_bytes as u64;
             ContentRange::new(start, start + size_of_last_part - 1)
         } else {
             ContentRange::new(
-                i * args.part_size_bytes as i64,
-                (i + 1) * args.part_size_bytes as i64 - 1,
+                i * args.part_size_bytes as u64,
+                (i + 1) * args.part_size_bytes as u64 - 1,
             )
         }
     });
-    let (tx, rx) = channel(ranges.next().unwrap());
-    for range in ranges {
-        tx.send(range)?;
-    }
 
     let semaphore = Arc::new(Semaphore::new(args.concurrency));
     let mut tasks = Vec::new();
-    for _ in 0..part_count {
+    let file = Arc::new(File::create(target_path)?);
+    for (id, range) in ranges.enumerate() {
         let semaphore = semaphore.clone();
-        let client = client.clone();
-        let bucket = args.bucket.clone();
-        let mut rx = rx.clone();
-        tasks.push(tokio::spawn(async move {
-            let _permit = semaphore.acquire().await?;
-            let range = rx.borrow_and_update().to_string();
+        let client = clients[id % clients.len()].clone();
+        let file = file.clone();
+        let bucket = bucket.to_string();
+        let key = key.to_string();
+        tasks.push(tokio::spawn(
+            async move {
+                let _permit = semaphore.acquire_owned().await?;
 
-            let part = client
-                .get_object()
-                .bucket(bucket)
-                .key(BENCH_KEY)
-                .range(range)
-                .send()
-                .await?;
+                let start = SystemTime::now();
+                tracing::debug!(range = ?range);
 
-            Result::<_, BoxError>::Ok(part.body)
-        }));
+                let body =
+                    download_part_retry_on_timeout(id, &range, &client, &bucket, &key).await?;
+                tracing::debug!(id =? id, load_duration = ?start.elapsed().unwrap());
+                let mut offset = range.start;
+                let write_duration = SystemTime::now();
+                spawn_blocking(move || {
+                    for part in body.into_segments() {
+                        file.write_all_at(&part, offset)?;
+                        offset += part.len() as u64;
+                    }
+                    Ok::<_, BoxError>(())
+                })
+                .await??;
+                tracing::debug!(id =? id, write_duration = ?write_duration.elapsed().unwrap());
+                Result::<_, BoxError>::Ok(())
+            }
+            .instrument(info_span!("run-collect-part", id = id)),
+        ));
     }
     for task in tasks {
-        let mut body = task.await??.into_async_read();
-        let mut file = tokio::fs::File::create(path).await?;
-        tokio::io::copy(&mut body, &mut file).await?;
+        task.await??;
     }
 
     Ok(())
 }
 
+async fn download_part_retry_on_timeout(
+    id: usize,
+    range: &ContentRange,
+    client: &Client,
+    bucket: &str,
+    key: &str,
+) -> Result<AggregatedBytes, BoxError> {
+    loop {
+        match timeout(
+            Duration::from_millis(1000),
+            download_part(id, range, client, bucket, key),
+        )
+        .await
+        {
+            Ok(result) => return result,
+            Err(_) => tracing::warn!("get part timeout"),
+        }
+    }
+}
+
+async fn download_part(
+    id: usize,
+    range: &ContentRange,
+    client: &Client,
+    bucket: &str,
+    key: &str,
+) -> Result<AggregatedBytes, BoxError> {
+    let part = client
+        .get_object()
+        .bucket(bucket)
+        .key(key)
+        .range(range.to_string())
+        .send()
+        .instrument(info_span!("get_object", id = id))
+        .await?;
+
+    let body = part
+        .body
+        .collect()
+        .instrument(info_span!("collect-body", id = id))
+        .await?;
+    Ok(body)
+}
+
 #[derive(Debug)]
 struct ContentRange {
-    start: i64,
-    end: i64,
+    start: u64,
+    end: u64,
 }
 
 impl ContentRange {
-    fn new(start: i64, end: i64) -> Self {
+    fn new(start: u64, end: u64) -> Self {
         Self { start, end }
     }
 }

--- a/aws/sdk/s3-benchmark/benchmark/src/multipart_put.rs
+++ b/aws/sdk/s3-benchmark/benchmark/src/multipart_put.rs
@@ -3,26 +3,60 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::put_test::PutBenchmark;
 use crate::{Args, BoxError, BENCH_KEY};
+use async_trait::async_trait;
+use aws_config::SdkConfig;
 use aws_sdk_s3 as s3;
+use aws_sdk_s3::Client;
 use aws_smithy_http::byte_stream::ByteStream;
-use aws_smithy_http::byte_stream::Length;
 use s3::types::CompletedMultipartUpload;
 use s3::types::CompletedPart;
+use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::Semaphore;
+use std::time::{Duration, SystemTime};
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::time::timeout;
+
+pub(crate) struct PutObjectMultipart;
+
+#[async_trait]
+impl PutBenchmark for PutObjectMultipart {
+    type Setup = Vec<Client>;
+
+    async fn prepare(&self, conf: &SdkConfig) -> Self::Setup {
+        let clients = (0..32).map(|_| Client::new(&conf)).collect::<Vec<_>>();
+        for client in &clients {
+            let _ = client.list_buckets().send().await;
+        }
+        clients
+    }
+
+    async fn do_put(
+        &self,
+        state: Self::Setup,
+        target_key: &str,
+        local_file: &Path,
+        args: &Args,
+    ) -> Result<(), BoxError> {
+        put_object_multipart(&state, args, target_key, local_file).await
+    }
+}
 
 pub async fn put_object_multipart(
-    client: &s3::Client,
+    client: &[s3::Client],
     args: &Args,
+    target_key: &str,
     path: &Path,
 ) -> Result<(), BoxError> {
-    let upload_id = client
+    let upload_id = client[0]
         .create_multipart_upload()
         .bucket(&args.bucket)
-        .key(BENCH_KEY)
+        .key(target_key)
         .send()
         .await?
         .upload_id
@@ -44,15 +78,17 @@ pub async fn put_object_multipart(
         } else {
             args.part_size_bytes
         };
-        tasks.push(tokio::spawn(upload_part(
-            semaphore.clone(),
-            client.clone(),
+        let permit = semaphore.clone().acquire_owned().await?;
+        tasks.push(tokio::spawn(upload_part_retry_on_timeout(
+            permit,
+            client[part as usize % client.len()].clone(),
             args.bucket.clone(),
             upload_id.clone(),
             path.to_path_buf(),
             offset,
             length,
             part,
+            Duration::from_millis(args.part_upload_timeout_millis),
         )));
     }
     let mut parts = Vec::new();
@@ -60,7 +96,7 @@ pub async fn put_object_multipart(
         parts.push(task.await??);
     }
 
-    client
+    client[0]
         .complete_multipart_upload()
         .bucket(&args.bucket)
         .key(BENCH_KEY)
@@ -76,9 +112,8 @@ pub async fn put_object_multipart(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn upload_part(
-    semaphore: Arc<Semaphore>,
+async fn upload_part_retry_on_timeout(
+    permit: OwnedSemaphorePermit,
     client: s3::Client,
     bucket: String,
     upload_id: String,
@@ -86,15 +121,40 @@ async fn upload_part(
     offset: u64,
     length: u64,
     part: u64,
+    timeout_dur: Duration,
 ) -> Result<CompletedPart, BoxError> {
-    let _permit = semaphore.acquire().await?;
+    loop {
+        match timeout(
+            timeout_dur,
+            upload_part(&client, &bucket, &upload_id, &path, offset, length, part),
+        )
+        .await
+        {
+            Ok(res) => {
+                drop(permit);
+                return res;
+            }
+            Err(_) => tracing::warn!(id = ?part, "timeout!"),
+        }
+    }
+}
 
-    let stream = ByteStream::read_from()
-        .path(path)
-        .offset(offset)
-        .length(Length::Exact(length))
-        .build()
-        .await?;
+#[allow(clippy::too_many_arguments)]
+async fn upload_part(
+    client: &s3::Client,
+    bucket: &str,
+    upload_id: &str,
+    path: &Path,
+    offset: u64,
+    length: u64,
+    part: u64,
+) -> Result<CompletedPart, BoxError> {
+    let start = SystemTime::now();
+    let mut file = File::open(path).await?;
+    file.seek(SeekFrom::Start(offset)).await?;
+    let mut buf = vec![0; length as usize];
+    file.read_exact(&mut buf).await?;
+    let stream = ByteStream::from(buf);
     let part_output = client
         .upload_part()
         .key(BENCH_KEY)
@@ -104,6 +164,7 @@ async fn upload_part(
         .part_number(part as i32 + 1) // S3 takes a 1-based index
         .send()
         .await?;
+    tracing::debug!(part = ?part, upload_duration = ?start.elapsed().unwrap(), "upload-part");
     Ok(CompletedPart::builder()
         .part_number(part as i32 + 1)
         .e_tag(part_output.e_tag.expect("must have an e-tag"))

--- a/aws/sdk/s3-benchmark/benchmark/src/put_test.rs
+++ b/aws/sdk/s3-benchmark/benchmark/src/put_test.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::multipart_get::get_object_multipart;
+use crate::{verify, Args, BoxError, BENCH_KEY};
+use async_trait::async_trait;
+use aws_config::SdkConfig;
+use aws_sdk_s3::Client;
+use std::env::temp_dir;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct PutTestResult {
+    local_file: PathBuf,
+    bucket: String,
+    key: String,
+}
+
+#[async_trait]
+pub(crate) trait PutBenchmark {
+    type Setup: Send;
+    async fn prepare(&self, conf: &SdkConfig) -> Self::Setup;
+    async fn do_put(
+        &self,
+        state: Self::Setup,
+        target_key: &str,
+        local_file: &Path,
+        args: &Args,
+    ) -> Result<(), BoxError>;
+    async fn do_bench(
+        &self,
+        state: Self::Setup,
+        args: &Args,
+        file: &Path,
+    ) -> Result<PutTestResult, BoxError> {
+        self.do_put(state, BENCH_KEY, file, args).await?;
+        Ok(PutTestResult {
+            local_file: file.to_path_buf(),
+            bucket: args.bucket.clone(),
+            key: BENCH_KEY.to_string(),
+        })
+    }
+
+    async fn verify(
+        &self,
+        client: &Client,
+        args: &Args,
+        result: PutTestResult,
+    ) -> Result<(), BoxError> {
+        let dir = temp_dir();
+        let downloaded_path = dir.join("downloaded_file");
+        get_object_multipart(
+            &[client.clone()][..],
+            args,
+            &downloaded_path,
+            &result.bucket,
+            &result.key,
+        )
+        .await?;
+        verify::diff(&result.local_file, &downloaded_path).await
+    }
+}

--- a/aws/sdk/s3-benchmark/benchmark/src/verify.rs
+++ b/aws/sdk/s3-benchmark/benchmark/src/verify.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::BoxError;
+use std::path::Path;
+use std::time::SystemTime;
+use tokio::process::Command;
+
+pub(crate) async fn diff(a: &Path, b: &Path) -> Result<(), BoxError> {
+    let start_diff = SystemTime::now();
+    let diff_ok = Command::new("diff")
+        .arg(a)
+        .arg(b)
+        .arg("-q")
+        .spawn()
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+    tracing::info!(diff_duration = ?start_diff.elapsed().unwrap());
+    if !diff_ok.success() {
+        Err("files differ")?
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION


## Motivation and Context
Gain a better understanding of S3 performance with the Rust SDK

## Description
Updates the S3 benchmark to:
1. Add verify step (untimed)
2. Improve performance by reading and writing from the disk concurrently
3. Add support for using multiple clients simultaeneously
4. Fix correctness issues & simplify
5. Add timeouts on the parts

## Testing
Ran the benchmark locally and on a c5n.18xlarge


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
