### PR TITLE
Fix the middleware benchmark and rerun

### DIFF
--- a/aws/sra-test/integration-tests/aws-sdk-s3/benches/README.md
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/benches/README.md
@@ -1,0 +1,6 @@
+### Middleware vs. Orchestrator Benchmark
+
+To run the benchmark:
+```bash
+./gradlew :aws:sra-test:assemble && (cd aws/sra-test/integration-tests/aws-sdk-s3 && cargo bench)
+```

--- a/aws/sra-test/integration-tests/aws-sdk-s3/benches/middleware_vs_orchestrator.rs
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/benches/middleware_vs_orchestrator.rs
@@ -88,35 +88,11 @@ macro_rules! middleware_bench_fn {
 }
 
 async fn orchestrator(client: &s3::Client) {
-    #[derive(Debug)]
-    struct FixupPlugin {
-        region: String,
-    }
-    impl RuntimePlugin for FixupPlugin {
-        fn configure(
-            &self,
-            cfg: &mut ConfigBag,
-            _interceptors: &mut InterceptorRegistrar,
-        ) -> Result<(), aws_smithy_runtime_api::client::runtime_plugin::BoxError> {
-            let params_builder = s3::endpoint::Params::builder()
-                .set_region(Some(self.region.clone()))
-                .bucket("test-bucket");
-
-            cfg.put(params_builder);
-            Ok(())
-        }
-    }
     let _output = client
         .list_objects_v2()
         .bucket("test-bucket")
         .prefix("prefix~")
-        .send_orchestrator_with_plugin(Some(FixupPlugin {
-            region: client
-                .conf()
-                .region()
-                .map(|c| c.as_ref().to_string())
-                .unwrap(),
-        }))
+        .send_orchestrator()
         .await
         .expect("successful execution");
 }


### PR DESCRIPTION
## Motivation and Context
Rerun the middleware benchmark.

Results:
```
    Finished bench [optimized + debuginfo] target(s) in 3.77s
     Running benches/middleware_vs_orchestrator.rs (/Users/rcoh/code/smithy-rs/target/release/deps/middleware_vs_orchestrator-eec2a5ed375836b0)
compare/middleware (HEAD)/S3 ListObjectsV2
                        time:   [27.887 µs 27.956 µs 28.030 µs]
                        change: [+22.004% +22.457% +22.923%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
compare/middleware (last_release)/S3 ListObjectsV2
                        time:   [22.076 µs 22.122 µs 22.176 µs]
                        change: [-3.1947% -2.7875% -2.4454%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
compare/orchestrator/S3 ListObjectsV2
                        time:   [27.711 µs 27.764 µs 27.821 µs]
                        change: [-11.548% -11.313% -11.097%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
```

## Description
- The fixup plugin is not required anymore.
- Added a readme with instructions
## Testing
- ran the benchmark


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
