### PR TITLE
Fix panic from repeat clones of `TypeErasedBox`

### DIFF
--- a/rust-runtime/aws-smithy-types/src/config_bag.rs
+++ b/rust-runtime/aws-smithy-types/src/config_bag.rs
@@ -855,6 +855,13 @@ mod test {
         layer_1.unset::<TestStr>();
         assert!(layer_1.try_clone().unwrap().load::<TestStr>().is_none());
 
+        // It is cloneable multiple times in succession
+        let _ = layer_1
+            .try_clone()
+            .expect("clone 1")
+            .try_clone()
+            .expect("clone 2");
+
         #[derive(Clone, Debug)]
         struct Rope(String);
         impl Storable for Rope {


### PR DESCRIPTION
This PR fixes a panic that would result from cloning a cloneable `TypeErasedBox` twice.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
