### PR TITLE
Remove third party types from public APIs Part 2

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -640,3 +640,9 @@ message = "The implementation `From<http::header::value::InvalidHeaderValue>` fo
 references = ["smithy-rs#2845"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "ysaito1001"
+
+[[smithy-rs]]
+message = "The implementation `From<bytes_utils::segmented::SegmentedBuf>` for `aws_smithy_http::event_stream::RawMessage` has been removed."
+references = ["smithy-rs#2848"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "ysaito1001"

--- a/rust-runtime/aws-smithy-http/external-types.toml
+++ b/rust-runtime/aws-smithy-http/external-types.toml
@@ -31,7 +31,4 @@ allowed_external_types = [
 
     # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Once tooling permits it, only allow the following types in the `event-stream` feature
     "aws_smithy_eventstream::*",
-
-    # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Decide whether to expose this type or not
-    "bytes_utils::segmented::SegmentedBuf",
 ]

--- a/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
@@ -97,8 +97,8 @@ pub enum RawMessage {
     Invalid(Option<Bytes>),
 }
 
-impl From<&mut SegmentedBuf<Bytes>> for RawMessage {
-    fn from(buf: &mut SegmentedBuf<Bytes>) -> Self {
+impl RawMessage {
+    pub(crate) fn invalid(buf: &mut SegmentedBuf<Bytes>) -> Self {
         Self::Invalid(Some(buf.copy_to_bytes(buf.remaining())))
     }
 }
@@ -213,7 +213,7 @@ impl<T, E> Receiver<T, E> {
                 ReceiverError {
                     kind: ReceiverErrorKind::UnexpectedEndOfStream,
                 },
-                self.buffer.buffered().into(),
+                RawMessage::invalid(self.buffer.buffered()),
             ));
         }
         Ok(None)


### PR DESCRIPTION
## Motivation and Context
Addresses item 8 in #2413 

## Description
This PR removes the third party types as follows:
- removes `SegmentedBuf` from public API in `aws-smithy-http` (used when the feature `event-stream` was enabled)

## Testing
- [x] Passed tests in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
