### PR TITLE
Add RUSTFLAG="--cfg aws_sdk_unstable" to ci-scripts

### DIFF
--- a/tools/ci-scripts/check-aws-sdk-adhoc-tests
+++ b/tools/ci-scripts/check-aws-sdk-adhoc-tests
@@ -7,6 +7,8 @@
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
+export RUSTFLAG="--cfg aws_sdk_unstable"
+
 set -eu
 cd smithy-rs
 

--- a/tools/ci-scripts/check-aws-sdk-orchestrator-impl
+++ b/tools/ci-scripts/check-aws-sdk-orchestrator-impl
@@ -9,6 +9,8 @@
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
 
+export RUSTFLAG="--cfg aws_sdk_unstable"
+
 set -eu
 cd smithy-rs
 

--- a/tools/ci-scripts/check-aws-sdk-smoketest-docs-clippy-udeps
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-docs-clippy-udeps
@@ -6,6 +6,8 @@
 
 set -eux
 
+export RUSTFLAG="--cfg aws_sdk_unstable"
+
 # Docs, clippy, etc on the smoketest itself
 pushd aws-sdk-smoketest &>/dev/null
 

--- a/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
@@ -5,5 +5,8 @@
 #
 
 set -eux
+
+export RUSTFLAG="--cfg aws_sdk_unstable"
+
 cd aws-sdk-smoketest
 cargo test --all-features

--- a/tools/ci-scripts/check-client-codegen-integration-tests
+++ b/tools/ci-scripts/check-client-codegen-integration-tests
@@ -5,6 +5,9 @@
 #
 
 set -eux
+
+export RUSTFLAG="--cfg aws_sdk_unstable"
+
 cd smithy-rs
 
 # TODO(enableNewSmithyRuntimeCleanup): Only run the orchestrator version of this

--- a/tools/ci-scripts/check-only-aws-sdk-services
+++ b/tools/ci-scripts/check-only-aws-sdk-services
@@ -7,6 +7,9 @@
 # this job runs `cargo check` only instead of `cargo test --all-features`
 
 set -eux
+
+export RUSTFLAG="--cfg aws_sdk_unstable"
+
 cd aws-sdk
 
 # Remove examples from workspace


### PR DESCRIPTION
## Motivation and Context
This is a sub-PR of https://github.com/awslabs/smithy-rs/pull/2615.
It adds RUSTFLAG="--cfg aws_sdk_unstable" to some ci-scripts to so that it tests with unstable features.
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
