### PR TITLE
Set RUSTUP_TOOLCHAIN in Dockerfile

### DIFF
--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -207,4 +207,7 @@ ENV SMITHY_RS_DOCKER_BUILD_IMAGE=1
 RUN pip3 install --no-cache-dir mypy==0.991
 WORKDIR /home/build
 COPY sanity-test /home/build/sanity-test
+# RUSTUP_TOOLCHAIN takes precedence over everything except `+<toolchain>` args. This will allow us to ignore the toolchain
+# file during CI, avoiding issues during Rust version upgrades.
+ENV RUSTUP_TOOLCHAIN=${rust_stable_version}
 RUN /home/build/sanity-test


### PR DESCRIPTION
## Motivation and Context
During releases, if the toolchain version has changed, we'll try to invoke a Rust version that doesn't exist. This pins it to the stable version.

## Description
Set the `RUSTUP_TOOLCHAIN` environment variable in the release/CI dockerfile

## Testing
- ran a release with this image


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
