### PR TITLE
Improve local dev experience with `aws:sdk:assemble` build target

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -453,7 +453,12 @@ tasks["test"].dependsOn("assemble")
 tasks["test"].finalizedBy(Cargo.CLIPPY.toString, Cargo.TEST.toString, Cargo.DOCS.toString)
 
 tasks.register<Delete>("deleteSdk") {
-    delete = setOf(outputDir)
+    delete(
+        fileTree(outputDir) {
+            // Delete files but keep directories so that terminals don't get messed up in local development
+            include("**/*.*")
+        },
+    )
 }
 tasks["clean"].dependsOn("deleteSdk")
 tasks["clean"].doFirst {


### PR DESCRIPTION
In local dev, if you have a terminal/shell open to `aws/sdk/build/aws-sdk/...` and run the `aws:sdk:assemble` target, that shell's current working directory will break and you'll have to change directory to somewhere safe and change back in order to do anything again (at least on MacOS).

This PR makes the `deleteSdk` target that `aws:sdk:assemble` depends on only delete files instead of directories so that the current working directory doesn't get invalidated.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
