### PR TITLE
Make the SDK invocation ID generator configurable

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecorator.kt
@@ -9,20 +9,33 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginSection
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.util.letIf
 
 class InvocationIdDecorator : ClientCodegenDecorator {
     override val name: String get() = "InvocationIdDecorator"
     override val order: Byte get() = 0
+
     override fun serviceRuntimePluginCustomizations(
         codegenContext: ClientCodegenContext,
         baseCustomizations: List<ServiceRuntimePluginCustomization>,
     ): List<ServiceRuntimePluginCustomization> =
         baseCustomizations.letIf(codegenContext.smithyRuntimeMode.generateOrchestrator) {
             it + listOf(InvocationIdRuntimePluginCustomization(codegenContext))
+        }
+
+    override fun configCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<ConfigCustomization>,
+    ): List<ConfigCustomization> =
+        baseCustomizations.letIf(codegenContext.smithyRuntimeMode.generateOrchestrator) {
+            it + listOf(InvocationIdConfigCustomization(codegenContext))
         }
 }
 
@@ -40,6 +53,64 @@ private class InvocationIdRuntimePluginCustomization(
             section.registerInterceptor(codegenContext.runtimeConfig, this) {
                 rustTemplate("#{InvocationIdInterceptor}::new()", *codegenScope)
             }
+        }
+    }
+}
+
+const val GENERATOR_DOCS: String =
+    "The invocation ID generator generates ID values for the `amz-sdk-invocation-id` header. " +
+        "By default, this will be a random UUID. Overriding it may be useful in tests that " +
+        "examine the HTTP request and need to be deterministic."
+
+private class InvocationIdConfigCustomization(
+    codegenContext: ClientCodegenContext,
+) : ConfigCustomization() {
+    private val awsRuntime = AwsRuntimeType.awsRuntime(codegenContext.runtimeConfig)
+    private val codegenScope = arrayOf(
+        *preludeScope,
+        "InvocationIdGenerator" to awsRuntime.resolve("invocation_id::InvocationIdGenerator"),
+        "SharedInvocationIdGenerator" to awsRuntime.resolve("invocation_id::SharedInvocationIdGenerator"),
+    )
+
+    override fun section(section: ServiceConfig): Writable = writable {
+        when (section) {
+            is ServiceConfig.BuilderImpl -> {
+                docs("Overrides the default invocation ID generator.\n\n$GENERATOR_DOCS")
+                rustTemplate(
+                    """
+                    pub fn invocation_id_generator(mut self, gen: impl #{InvocationIdGenerator} + 'static) -> Self {
+                        self.set_invocation_id_generator(#{Some}(#{SharedInvocationIdGenerator}::new(gen)));
+                        self
+                    }
+                    """,
+                    *codegenScope,
+                )
+
+                docs("Overrides the default invocation ID generator.\n\n$GENERATOR_DOCS")
+                rustTemplate(
+                    """
+                    pub fn set_invocation_id_generator(&mut self, gen: #{Option}<#{SharedInvocationIdGenerator}>) -> &mut Self {
+                        self.config.store_or_unset(gen);
+                        self
+                    }
+                    """,
+                    *codegenScope,
+                )
+            }
+
+            is ServiceConfig.ConfigImpl -> {
+                docs("Returns the invocation ID generator if one was given in config.\n\n$GENERATOR_DOCS")
+                rustTemplate(
+                    """
+                    pub fn invocation_id_generator(&self) -> #{Option}<#{SharedInvocationIdGenerator}> {
+                        self.config.load::<#{SharedInvocationIdGenerator}>().cloned()
+                    }
+                    """,
+                    *codegenScope,
+                )
+            }
+
+            else -> {}
         }
     }
 }

--- a/aws/sdk-codegen/src/test/kotlin/SdkCodegenIntegrationTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/SdkCodegenIntegrationTest.kt
@@ -8,41 +8,43 @@ import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rustsdk.awsSdkIntegrationTest
 
 class SdkCodegenIntegrationTest {
-    val model = """
-        namespace test
+    companion object {
+        val model = """
+            namespace test
 
-        use aws.api#service
-        use aws.auth#sigv4
-        use aws.protocols#restJson1
-        use smithy.rules#endpointRuleSet
+            use aws.api#service
+            use aws.auth#sigv4
+            use aws.protocols#restJson1
+            use smithy.rules#endpointRuleSet
 
-        @service(sdkId: "dontcare")
-        @restJson1
-        @sigv4(name: "dontcare")
-        @auth([sigv4])
-        @endpointRuleSet({
-            "version": "1.0",
-            "rules": [{ "type": "endpoint", "conditions": [], "endpoint": { "url": "https://example.com" } }],
-            "parameters": {
-                "Region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
+            @service(sdkId: "dontcare")
+            @restJson1
+            @sigv4(name: "dontcare")
+            @auth([sigv4])
+            @endpointRuleSet({
+                "version": "1.0",
+                "rules": [{ "type": "endpoint", "conditions": [], "endpoint": { "url": "https://example.com" } }],
+                "parameters": {
+                    "Region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
+                }
+            })
+            service TestService {
+                version: "2023-01-01",
+                operations: [SomeOperation]
             }
-        })
-        service TestService {
-            version: "2023-01-01",
-            operations: [SomeOperation]
-        }
 
-        structure SomeOutput {
-            someAttribute: Long,
-            someVal: String
-        }
+            structure SomeOutput {
+                someAttribute: Long,
+                someVal: String
+            }
 
-        @http(uri: "/SomeOperation", method: "GET")
-        @optionalAuth
-        operation SomeOperation {
-            output: SomeOutput
-        }
-    """.asSmithyModel()
+            @http(uri: "/SomeOperation", method: "GET")
+            @optionalAuth
+            operation SomeOperation {
+                output: SomeOutput
+            }
+        """.asSmithyModel()
+    }
 
     @Test
     fun smokeTestSdkCodegen() {

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/InvocationIdDecoratorTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk
+
+import SdkCodegenIntegrationTest
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
+import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+
+class InvocationIdDecoratorTest {
+    @Test
+    fun customInvocationIdGenerator() {
+        awsSdkIntegrationTest(SdkCodegenIntegrationTest.model) { context, rustCrate ->
+            val rc = context.runtimeConfig
+            val moduleName = context.moduleUseName()
+            rustCrate.integrationTest("custom_invocation_id") {
+                rustTemplate(
+                    """
+                    ##[#{tokio}::test]
+                    async fn custom_invocation_id() {
+                        ##[derive(::std::fmt::Debug)]
+                        struct TestIdGen;
+                        impl #{InvocationIdGenerator} for TestIdGen {
+                            fn generate(&self) -> #{Result}<#{Option}<#{InvocationId}>, #{BoxError}> {
+                                #{Ok}(#{Some}(#{InvocationId}::new("custom".into())))
+                            }
+                        }
+
+                        let (conn, rx) = #{capture_request}(None);
+                        let config = $moduleName::Config::builder()
+                            .http_connector(conn)
+                            .invocation_id_generator(TestIdGen)
+                            .build();
+                        assert!(config.invocation_id_generator().is_some());
+
+                        let client = $moduleName::Client::from_conf(config);
+
+                        let _ = client.some_operation().send().await;
+                        let request = rx.expect_request();
+                        assert_eq!("custom", request.headers().get("amz-sdk-invocation-id").unwrap());
+                    }
+                    """,
+                    *preludeScope,
+                    "tokio" to CargoDependency.Tokio.toType(),
+                    "InvocationIdGenerator" to AwsRuntimeType.awsRuntime(rc)
+                        .resolve("invocation_id::InvocationIdGenerator"),
+                    "InvocationId" to AwsRuntimeType.awsRuntime(rc)
+                        .resolve("invocation_id::InvocationId"),
+                    "BoxError" to RuntimeType.boxError(rc),
+                    "capture_request" to RuntimeType.captureRequest(rc),
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR makes it possible to configure the invocation ID generator in config.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
