### PR TITLE
Stop rebuilding `sdk-lints` all the time

### DIFF
--- a/buildSrc/src/main/kotlin/RustBuildTool.kt
+++ b/buildSrc/src/main/kotlin/RustBuildTool.kt
@@ -28,7 +28,6 @@ private fun runCli(
                 }
             }
             .copyTo(action)
-        action.environment("RUSTFLAGS", "--cfg aws_sdk_unstable")
         action.execute()
     }
 }


### PR DESCRIPTION
I noticed `sdk-lints` was getting recompiled just about every time I ran `git commit` as part of the pre-commit hooks. It looks like a compiler flag was added to the `ExecRustBuildTool` task type that isn't actually used by any tools. Removing it should eliminate compiler flag conflicts between the gradle targets and pre-commit. 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
