### PR TITLE
Improve docs on config bag and type erasure

### DIFF
--- a/rust-runtime/aws-smithy-types/src/config_bag/storable.rs
+++ b/rust-runtime/aws-smithy-types/src/config_bag/storable.rs
@@ -22,6 +22,8 @@ pub trait Store: Sized + Send + Sync + 'static {
 }
 
 /// Store an item in the config bag by replacing the existing value
+///
+/// See the [module docs](crate::config_bag) for more documentation.
 #[non_exhaustive]
 pub struct StoreReplace<U>(PhantomData<U>);
 
@@ -32,6 +34,8 @@ impl<U> Debug for StoreReplace<U> {
 }
 
 /// Store an item in the config bag by effectively appending it to a list
+///
+/// See the [module docs](crate::config_bag) for more documentation.
 #[non_exhaustive]
 pub struct StoreAppend<U>(PhantomData<U>);
 
@@ -42,6 +46,8 @@ impl<U> Debug for StoreAppend<U> {
 }
 
 /// Trait that marks the implementing types as able to be stored in the config bag
+///
+/// See the [module docs](crate::config_bag) for more documentation.
 pub trait Storable: Send + Sync + Debug + 'static {
     /// Specify how an item is stored in the config bag, e.g. [`StoreReplace`] and [`StoreAppend`]
     type Storer: Store;

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -14,8 +14,6 @@
     unreachable_pub
 )]
 pub mod base64;
-//TODO(enableNewSmithyRuntimeLaunch): Unhide this module when switching to the orchestrator
-#[doc(hidden)]
 /// A typemap for storing configuration.
 pub mod config_bag;
 pub mod date_time;
@@ -25,8 +23,6 @@ pub mod primitive;
 pub mod retry;
 pub mod timeout;
 
-//TODO(enableNewSmithyRuntimeLaunch): Unhide this module when switching to the orchestrator
-#[doc(hidden)]
 /// Utilities for type erasure.
 pub mod type_erasure;
 


### PR DESCRIPTION
This PR improves the docs on the aws-smithy-types `config_bag` and `type_erasure` modules.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
