### PR TITLE
Move `alb_health_check` module out of the `plugin` module

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -658,3 +658,9 @@ message = "The AppName property can now be set with `sdk_ua_app_id` in profile f
 references = ["smithy-rs#2724"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "rcoh"
+
+[[smithy-rs]]
+message = "The `alb_health_check` module has been moved out of the `plugin` module into a new `layer` module. ALB health checks should be enacted before routing, and plugins run after routing, so the module location was misleading. Examples have been corrected to reflect the intended application of the layer."
+references = ["smithy-rs#2865"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
+author = "david-perez"

--- a/examples/pokemon-service/tests/simple.rs
+++ b/examples/pokemon-service/tests/simple.rs
@@ -89,3 +89,31 @@ async fn simple_integration_test() {
 
     assert_eq!(result.status(), 200);
 }
+
+#[tokio::test]
+#[serial]
+async fn health_check() {
+    let _child = common::run_server().await;
+
+    use pokemon_service::{DEFAULT_ADDRESS, DEFAULT_PORT};
+    let url = format!("http://{DEFAULT_ADDRESS}:{DEFAULT_PORT}/ping");
+    let uri = url.parse::<hyper::Uri>().expect("invalid URL");
+
+    // Since the `/ping` route is not modeled in Smithy, we use a regular
+    // Hyper HTTP client to make a request to it.
+    let request = hyper::Request::builder()
+        .uri(uri)
+        .body(hyper::Body::empty())
+        .expect("failed to build request");
+
+    let response = hyper::Client::new()
+        .request(request)
+        .await
+        .expect("failed to get response");
+
+    assert_eq!(response.status(), hyper::StatusCode::OK);
+    let body = hyper::body::to_bytes(response.into_body())
+        .await
+        .expect("failed to read response body");
+    assert!(body.is_empty());
+}

--- a/rust-runtime/aws-smithy-http-server/src/layer/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/layer/mod.rs
@@ -1,0 +1,9 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! This module hosts [`Layer`](tower::Layer)s that are generally meant to be applied _around_ the
+//! [`Router`](crate::routing::Router), so they are enacted before a request is routed.
+
+pub mod alb_health_check;

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod body;
 pub(crate) mod error;
 pub mod extension;
 pub mod instrumentation;
+pub mod layer;
 pub mod operation;
 pub mod plugin;
 #[doc(hidden)]

--- a/rust-runtime/aws-smithy-http-server/src/plugin/either.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/either.rs
@@ -15,6 +15,8 @@ use tower::{Layer, Service};
 
 use super::Plugin;
 
+// TODO(https://github.com/awslabs/smithy-rs/pull/2441#pullrequestreview-1331345692): Seems like
+// this type should land in `tower-0.5`.
 pin_project! {
     /// Combine two different [`Futures`](std::future::Future)/[`Services`](tower::Service)/
     /// [`Layers`](tower::Layer)/[`Plugins`](super::Plugin) into a single type.

--- a/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
@@ -194,9 +194,8 @@
 //! impl ModelMarker for PrintPlugin { }
 //! ```
 
-pub mod alb_health_check;
 mod closure;
-mod either;
+pub(crate) mod either;
 mod filter;
 mod http_plugins;
 mod identity;


### PR DESCRIPTION
The current module location is misleading, since you never want to run
the layer as a plugin: plugins always run after routing, and the health
check should be enacted before routing. Examples have been corrected,
and a test has been added.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
