### PR TITLE
More tidying up of `aws-smithy-runtime-api`

### DIFF
--- a/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
@@ -77,7 +77,7 @@ impl<AP> RequestChecksumInterceptor<AP> {
 
 impl<AP> Interceptor for RequestChecksumInterceptor<AP>
 where
-    AP: Fn(&Input) -> Result<Option<ChecksumAlgorithm>, BoxError>,
+    AP: Fn(&Input) -> Result<Option<ChecksumAlgorithm>, BoxError> + Send + Sync,
 {
     fn read_before_serialization(
         &self,

--- a/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
@@ -54,7 +54,7 @@ impl<VE> ResponseChecksumInterceptor<VE> {
 
 impl<VE> Interceptor for ResponseChecksumInterceptor<VE>
 where
-    VE: Fn(&Input) -> bool,
+    VE: Fn(&Input) -> bool + Send + Sync,
 {
     fn read_before_serialization(
         &self,

--- a/aws/rust-runtime/aws-inlineable/src/route53_resource_id_preprocessor.rs
+++ b/aws/rust-runtime/aws-inlineable/src/route53_resource_id_preprocessor.rs
@@ -69,7 +69,7 @@ where
 
 impl<G, T> Interceptor for Route53ResourceIdInterceptor<G, T>
 where
-    G: for<'a> Fn(&'a mut T) -> &'a mut Option<String>,
+    G: for<'a> Fn(&'a mut T) -> &'a mut Option<String> + Send + Sync,
     T: fmt::Debug + Send + Sync + 'static,
 {
     fn modify_before_serialization(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
@@ -91,7 +91,7 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                         /// ## }
                         /// ## }
                         /// ```
-                        pub fn interceptor(mut self, interceptor: impl #{Interceptor} + Send + Sync + 'static) -> Self {
+                        pub fn interceptor(mut self, interceptor: impl #{Interceptor} + 'static) -> Self {
                             self.push_interceptor(#{SharedInterceptor}::new(interceptor));
                             self
                         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -199,7 +199,7 @@ class CustomizableOperationGenerator(
                         /// `map_request`, and `mutate_request` (the last two are implemented via interceptors under the hood).
                         /// The order in which those user-specified operation interceptors are invoked should not be relied upon
                         /// as it is an implementation detail.
-                        pub fn interceptor(mut self, interceptor: impl #{Interceptor} + #{Send} + #{Sync} + 'static) -> Self {
+                        pub fn interceptor(mut self, interceptor: impl #{Interceptor} + 'static) -> Self {
                             self.interceptors.push(#{SharedInterceptor}::new(interceptor));
                             self
                         }

--- a/rust-runtime/aws-smithy-http/src/result.rs
+++ b/rust-runtime/aws-smithy-http/src/result.rs
@@ -232,9 +232,14 @@ impl DispatchFailure {
         self.source.is_user()
     }
 
-    /// Returns the optional error kind associated with an unclassified error
-    pub fn is_other(&self) -> Option<ErrorKind> {
+    /// Returns true if the error is an unclassified error.
+    pub fn is_other(&self) -> bool {
         self.source.is_other()
+    }
+
+    /// Returns the optional error kind associated with an unclassified error
+    pub fn as_other(&self) -> Option<ErrorKind> {
+        self.source.as_other()
     }
 
     /// Returns the inner error if it is a connector error
@@ -633,8 +638,13 @@ impl ConnectorError {
         matches!(self.kind, ConnectorErrorKind::User)
     }
 
+    /// Returns true if the error is an unclassified error.
+    pub fn is_other(&self) -> bool {
+        matches!(self.kind, ConnectorErrorKind::Other(..))
+    }
+
     /// Returns the optional error kind associated with an unclassified error
-    pub fn is_other(&self) -> Option<ErrorKind> {
+    pub fn as_other(&self) -> Option<ErrorKind> {
         match &self.kind {
             ConnectorErrorKind::Other(ek) => *ek,
             _ => None,

--- a/rust-runtime/aws-smithy-http/src/retry.rs
+++ b/rust-runtime/aws-smithy-http/src/retry.rs
@@ -45,7 +45,7 @@ impl DefaultResponseRetryClassifier {
             Err(SdkError::DispatchFailure(err)) => {
                 if err.is_timeout() || err.is_io() {
                     Err(RetryKind::Error(ErrorKind::TransientError))
-                } else if let Some(ek) = err.is_other() {
+                } else if let Some(ek) = err.as_other() {
                     Err(RetryKind::Error(ek))
                 } else {
                     Err(RetryKind::UnretryableFailure)

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
@@ -72,14 +72,14 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
     /// between invocation of this hook and `after_execution` is very close
     /// to full duration of the execution.
     ///
-    /// **Available Information:** The [InterceptorContext::input()] is
-    /// **ALWAYS** available. Other information **WILL NOT** be available.
+    /// **Available Information:** The [`InterceptorContext::input`](context::InterceptorContext::input)
+    /// is **ALWAYS** available. Other information **WILL NOT** be available.
     ///
     /// **Error Behavior:** Errors raised by this hook will be stored
     /// until all interceptors have had their `before_execution` invoked.
     /// Other hooks will then be skipped and execution will jump to
     /// `modify_before_completion` with the raised error as the
-    /// [InterceptorContext::output_or_error()]. If multiple
+    /// [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error). If multiple
     /// `before_execution` methods raise errors, the latest
     /// will be used and earlier ones will be logged and dropped.
     fn read_before_execution(
@@ -103,14 +103,14 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         **When:** This will **ALWAYS** be called once per execution, except when a
         failure occurs earlier in the request pipeline.
 
-        **Available Information:** The [InterceptorContext::input()] is
+        **Available Information:** The [`InterceptorContext::input`](context::InterceptorContext::input) is
         **ALWAYS** available. This request may have been modified by earlier
         `modify_before_serialization` hooks, and may be modified further by
         later hooks. Other information **WILL NOT** be available.
 
         **Error Behavior:** If errors are raised by this hook,
         execution will jump to `modify_before_completion` with the raised
-        error as the [InterceptorContext::output_or_error()].
+        error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
 
         **Return Constraints:** The input message returned by this hook
         MUST be the same type of input message passed into this hook.
@@ -131,12 +131,12 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         duration between invocation of this hook and `after_serialization` is
         very close to the amount of time spent marshalling the request.
 
-        **Available Information:** The [InterceptorContext::input()] is
+        **Available Information:** The [`InterceptorContext::input`](context::InterceptorContext::input) is
         **ALWAYS** available. Other information **WILL NOT** be available.
 
         **Error Behavior:** If errors are raised by this hook,
         execution will jump to `modify_before_completion` with the raised
-        error as the [InterceptorContext::output_or_error()].
+        error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
         "
     );
 
@@ -144,21 +144,20 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         read_after_serialization,
         BeforeTransmitInterceptorContextRef,
         "
-        /// A hook called after the input message is marshalled into
-        /// a transport message.
-        ///
-        /// **When:** This will **ALWAYS** be called once per execution, except when a
-        /// failure occurs earlier in the request pipeline. The duration
-        /// between invocation of this hook and `before_serialization` is very
-        /// close to the amount of time spent marshalling the request.
-        ///
-        /// **Available Information:** The [InterceptorContext::input()]
-        /// and [InterceptorContext::request()] are **ALWAYS** available.
-        /// Other information **WILL NOT** be available.
-        ///
-        /// **Error Behavior:** If errors are raised by this hook,
-        /// execution will jump to `modify_before_completion` with the raised
-        /// error as the [InterceptorContext::output_or_error()].
+        A hook called after the input message is marshalled into
+        a transport message.
+
+        **When:** This will **ALWAYS** be called once per execution, except when a
+        failure occurs earlier in the request pipeline. The duration
+        between invocation of this hook and `before_serialization` is very
+        close to the amount of time spent marshalling the request.
+
+        **Available Information:** The [`InterceptorContext::request`](context::InterceptorContext::request)
+        is **ALWAYS** available. Other information **WILL NOT** be available.
+
+        **Error Behavior:** If errors are raised by this hook,
+        execution will jump to `modify_before_completion` with the raised
+        error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
         "
     );
 
@@ -170,13 +169,12 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         has the ability to modify and return a new transport request
         message of the same type, except when a failure occurs earlier in the request pipeline.
 
-        **Available Information:** The [InterceptorContext::input()]
-        and [InterceptorContext::request()] are **ALWAYS** available.
-        Other information **WILL NOT** be available.
+        **Available Information:** The [`InterceptorContext::request`](context::InterceptorContext::request)
+        is **ALWAYS** available. Other information **WILL NOT** be available.
 
         **Error Behavior:** If errors are raised by this hook,
         execution will jump to `modify_before_completion` with the raised
-        error as the [InterceptorContext::output_or_error()].
+        error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
 
         **Return Constraints:** The transport request message returned by this
         hook MUST be the same type of request message passed into this hook
@@ -195,9 +193,8 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         failure occurs earlier in the request pipeline. This method will be
         called multiple times in the event of retries.
 
-        **Available Information:** The [InterceptorContext::input()]
-        and [InterceptorContext::request()] are **ALWAYS** available.
-        Other information **WILL NOT** be available. In the event of retries,
+        **Available Information:** The [`InterceptorContext::request`](context::InterceptorContext::request)
+        is **ALWAYS** available. Other information **WILL NOT** be available. In the event of retries,
         the `InterceptorContext` will not include changes made in previous
         attempts (e.g. by request signers or other interceptors).
 
@@ -205,7 +202,7 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         until all interceptors have had their `before_attempt` invoked.
         Other hooks will then be skipped and execution will jump to
         `modify_before_attempt_completion` with the raised error as the
-        [InterceptorContext::output_or_error()]. If multiple
+        [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error). If multiple
         `before_attempt` methods raise errors, the latest will be used
         and earlier ones will be logged and dropped.
         "
@@ -223,18 +220,16 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         failure occurs earlier in the request pipeline. This method may be
         called multiple times in the event of retries.
 
-        **Available Information:** The [InterceptorContext::input()]
-        and [InterceptorContext::request()] are **ALWAYS** available.
-        The `http::Request` may have been modified by earlier
+        **Available Information:** The [`InterceptorContext::request`](context::InterceptorContext::request)
+        is **ALWAYS** available. The `http::Request` may have been modified by earlier
         `modify_before_signing` hooks, and may be modified further by later
         hooks. Other information **WILL NOT** be available. In the event of
         retries, the `InterceptorContext` will not include changes made
-        in previous attempts
-        (e.g. by request signers or other interceptors).
+        in previous attempts (e.g. by request signers or other interceptors).
 
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion` with
-        the raised error as the [InterceptorContext::output_or_error()].
+        the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
 
         **Return Constraints:** The transport request message returned by this
         hook MUST be the same type of request message passed into this hook
@@ -255,15 +250,14 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         invocation of this hook and `after_signing` is very close to
         the amount of time spent signing the request.
 
-        **Available Information:** The [InterceptorContext::input()]
-        and [InterceptorContext::request()] are **ALWAYS** available.
+        **Available Information:** The [`InterceptorContext::request`](context::InterceptorContext::request) is **ALWAYS** available.
         Other information **WILL NOT** be available. In the event of retries,
         the `InterceptorContext` will not include changes made in previous
         attempts (e.g. by request signers or other interceptors).
 
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion` with
-        the raised error as the [InterceptorContext::output_or_error()].
+        the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
         "
     );
 
@@ -279,15 +273,14 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         invocation of this hook and `before_signing` is very close to
         the amount of time spent signing the request.
 
-        **Available Information:** The [InterceptorContext::input()]
-        and [InterceptorContext::request()] are **ALWAYS** available.
+        **Available Information:** The [`InterceptorContext::request`](context::InterceptorContext::request) is **ALWAYS** available.
         Other information **WILL NOT** be available. In the event of retries,
         the `InterceptorContext` will not include changes made in previous
         attempts (e.g. by request signers or other interceptors).
 
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion` with
-        the raised error as the [InterceptorContext::output_or_error()].
+        the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
         "
     );
 
@@ -295,26 +288,25 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         mut modify_before_transmit,
         BeforeTransmitInterceptorContextMut,
         "
-        /// A hook called before the transport request message is sent to the
-        /// service. This method has the ability to modify and return
-        /// a new transport request message of the same type.
-        ///
-        /// **When:** This will **ALWAYS** be called once per attempt, except when a
-        /// failure occurs earlier in the request pipeline. This method may be
-        /// called multiple times in the event of retries.
-        ///
-        /// **Available Information:** The [InterceptorContext::input()]
-        /// and [InterceptorContext::request()] are **ALWAYS** available.
-        /// The `http::Request` may have been modified by earlier
-        /// `modify_before_transmit` hooks, and may be modified further by later
-        /// hooks. Other information **WILL NOT** be available.
-        /// In the event of retries, the `InterceptorContext` will not include
-        /// changes made in previous attempts (e.g. by request signers or
+        A hook called before the transport request message is sent to the
+        service. This method has the ability to modify and return
+        a new transport request message of the same type.
+
+        **When:** This will **ALWAYS** be called once per attempt, except when a
+        failure occurs earlier in the request pipeline. This method may be
+        called multiple times in the event of retries.
+
+        **Available Information:** The [`InterceptorContext::request`](context::InterceptorContext::request)
+        is **ALWAYS** available. The `http::Request` may have been modified by earlier
+        `modify_before_transmit` hooks, and may be modified further by later
+        hooks. Other information **WILL NOT** be available.
+        In the event of retries, the `InterceptorContext` will not include
+        changes made in previous attempts (e.g. by request signers or
         other interceptors).
 
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion` with
-        the raised error as the [InterceptorContext::output_or_error()].
+        the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
 
         **Return Constraints:** The transport request message returned by this
         hook MUST be the same type of request message passed into this hook
@@ -338,16 +330,15 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         Depending on the protocol, the duration may not include the
         time spent reading the response data.
 
-        **Available Information:** The [InterceptorContext::input()]
-        and [InterceptorContext::request()] are **ALWAYS** available.
-        Other information **WILL NOT** be available. In the event of retries,
+        **Available Information:** The [`InterceptorContext::request`](context::InterceptorContext::request)
+        is **ALWAYS** available. Other information **WILL NOT** be available. In the event of retries,
         the `InterceptorContext` will not include changes made in previous
         attempts (e.g. by request signers or other interceptors).
 
 
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion` with
-        the raised error as the [InterceptorContext::output_or_error()].
+        the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
         "
     );
 
@@ -366,16 +357,14 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         Depending on the protocol, the duration may not include the time
         spent reading the response data.
 
-        **Available Information:** The [InterceptorContext::input()],
-        [InterceptorContext::request()] and
-        [InterceptorContext::response()] are **ALWAYS** available.
-        Other information **WILL NOT** be available. In the event of retries,
+        **Available Information:** The [`InterceptorContext::response`](context::InterceptorContext::response)
+        is **ALWAYS** available. Other information **WILL NOT** be available. In the event of retries,
         the `InterceptorContext` will not include changes made in previous
         attempts (e.g. by request signers or other interceptors).
 
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion` with
-        the raised error as the [InterceptorContext::output_or_error()].
+        the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
         "
     );
 
@@ -391,10 +380,8 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         failure occurs earlier in the request pipeline. This method may be
         called multiple times in the event of retries.
 
-        **Available Information:** The [InterceptorContext::input()],
-        [InterceptorContext::request()] and
-        [InterceptorContext::response()] are **ALWAYS** available.
-        The transmit_response may have been modified by earlier
+        **Available Information:** The [`InterceptorContext::response`](context::InterceptorContext::response)
+        is **ALWAYS** available. The transmit_response may have been modified by earlier
         `modify_before_deserialization` hooks, and may be modified further by
         later hooks. Other information **WILL NOT** be available. In the event of
         retries, the `InterceptorContext` will not include changes made in
@@ -403,7 +390,7 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion` with
         the raised error as the
-        [InterceptorContext::output_or_error()].
+        [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
 
         **Return Constraints:** The transport response message returned by this
         hook MUST be the same type of response message passed into
@@ -425,16 +412,14 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         Depending on the protocol and operation, the duration may include
         the time spent downloading the response data.
 
-        **Available Information:** The [InterceptorContext::input()],
-        [InterceptorContext::request()] and
-        [InterceptorContext::response()] are **ALWAYS** available.
-        Other information **WILL NOT** be available. In the event of retries,
+        **Available Information:** The [`InterceptorContext::response`](context::InterceptorContext::response)
+        is **ALWAYS** available. Other information **WILL NOT** be available. In the event of retries,
         the `InterceptorContext` will not include changes made in previous
         attempts (e.g. by request signers or other interceptors).
 
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion`
-        with the raised error as the [InterceptorContext::output_or_error()].
+        with the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
         "
     );
 
@@ -452,16 +437,14 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
         the duration may include the time spent downloading
         the response data.
 
-        **Available Information:** The [InterceptorContext::input()],
-        [InterceptorContext::request()],
-        [InterceptorContext::response()] and
-        [InterceptorContext::output_or_error()] are **ALWAYS** available. In the event
-        of retries, the `InterceptorContext` will not include changes made
+        **Available Information:** The [`InterceptorContext::response`](context::InterceptorContext::response)
+        and [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error)
+        are **ALWAYS** available. In the event of retries, the `InterceptorContext` will not include changes made
         in previous attempts (e.g. by request signers or other interceptors).
 
         **Error Behavior:** If errors are raised by this
         hook, execution will jump to `modify_before_attempt_completion` with
-        the raised error as the [InterceptorContext::output_or_error()].
+        the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
         "
     );
 
@@ -473,16 +456,19 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
     /// failure occurs before `before_attempt`. This method may
     /// be called multiple times in the event of retries.
     ///
-    /// **Available Information:** The [InterceptorContext::input()],
-    /// [InterceptorContext::request()],
-    /// [InterceptorContext::response()] and
-    /// [InterceptorContext::output_or_error()] are **ALWAYS** available. In the event
-    /// of retries, the `InterceptorContext` will not include changes made
+    /// **Available Information:**
+    /// The [`InterceptorContext::input`](context::InterceptorContext::input),
+    /// [`InterceptorContext::request`](context::InterceptorContext::request),
+    /// [`InterceptorContext::response`](context::InterceptorContext::response), or
+    /// [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error) **MAY** be available.
+    /// If the operation succeeded, the `output` will be available. Otherwise, any of the other
+    /// pieces of information may be available depending on where in the operation lifecycle it failed.
+    /// In the event of retries, the `InterceptorContext` will not include changes made
     /// in previous attempts (e.g. by request signers or other interceptors).
     ///
     /// **Error Behavior:** If errors are raised by this
     /// hook, execution will jump to `after_attempt` with
-    /// the raised error as the [InterceptorContext::output_or_error()].
+    /// the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
     ///
     /// **Return Constraints:** Any output message returned by this
     /// hook MUST match the operation being invoked. Any error type can be
@@ -502,14 +488,15 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
     /// **When:** This will **ALWAYS** be called once per attempt, as long as
     /// `before_attempt` has been executed.
     ///
-    /// **Available Information:** The [InterceptorContext::input()],
-    /// [InterceptorContext::request()] and
-    /// [InterceptorContext::output_or_error()] are **ALWAYS** available.
-    /// The [InterceptorContext::response()] is available if a
-    /// response was received by the service for this attempt.
-    /// In the event of retries, the `InterceptorContext` will not include
-    /// changes made in previous attempts (e.g. by request signers or other
-    /// interceptors).
+    /// **Available Information:**
+    /// The [`InterceptorContext::input`](context::InterceptorContext::input),
+    /// [`InterceptorContext::request`](context::InterceptorContext::request),
+    /// [`InterceptorContext::response`](context::InterceptorContext::response), or
+    /// [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error) **MAY** be available.
+    /// If the operation succeeded, the `output` will be available. Otherwise, any of the other
+    /// pieces of information may be available depending on where in the operation lifecycle it failed.
+    /// In the event of retries, the `InterceptorContext` will not include changes made
+    /// in previous attempts (e.g. by request signers or other interceptors).
     ///
     /// **Error Behavior:** Errors raised by this hook will be stored
     /// until all interceptors have had their `after_attempt` invoked.
@@ -518,7 +505,7 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
     /// retry strategy determines that the execution is retryable,
     /// execution will then jump to `before_attempt`. Otherwise,
     /// execution will jump to `modify_before_attempt_completion` with the
-    /// raised error as the [InterceptorContext::output_or_error()].
+    /// raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
     fn read_after_attempt(
         &self,
         context: &FinalizerInterceptorContextRef<'_>,
@@ -536,15 +523,19 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
     ///
     /// **When:** This will **ALWAYS** be called once per execution.
     ///
-    /// **Available Information:** The [InterceptorContext::input()]
-    /// and [InterceptorContext::output_or_error()] are **ALWAYS** available. The
-    /// [InterceptorContext::request()]
-    /// and [InterceptorContext::response()] are available if the
-    /// execution proceeded far enough for them to be generated.
+    /// **Available Information:**
+    /// The [`InterceptorContext::input`](context::InterceptorContext::input),
+    /// [`InterceptorContext::request`](context::InterceptorContext::request),
+    /// [`InterceptorContext::response`](context::InterceptorContext::response), or
+    /// [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error) **MAY** be available.
+    /// If the operation succeeded, the `output` will be available. Otherwise, any of the other
+    /// pieces of information may be available depending on where in the operation lifecycle it failed.
+    /// In the event of retries, the `InterceptorContext` will not include changes made
+    /// in previous attempts (e.g. by request signers or other interceptors).
     ///
     /// **Error Behavior:** If errors are raised by this
     /// hook , execution will jump to `after_attempt` with
-    /// the raised error as the [InterceptorContext::output_or_error()].
+    /// the raised error as the [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error).
     ///
     /// **Return Constraints:** Any output message returned by this
     /// hook MUST match the operation being invoked. Any error type can be
@@ -565,17 +556,21 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
     /// between invocation of this hook and `before_execution` is very
     /// close to the full duration of the execution.
     ///
-    /// **Available Information:** The [InterceptorContext::input()]
-    /// and [InterceptorContext::output_or_error()] are **ALWAYS** available. The
-    /// [InterceptorContext::request()] and
-    /// [InterceptorContext::response()] are available if the
-    /// execution proceeded far enough for them to be generated.
+    /// **Available Information:**
+    /// The [`InterceptorContext::input`](context::InterceptorContext::input),
+    /// [`InterceptorContext::request`](context::InterceptorContext::request),
+    /// [`InterceptorContext::response`](context::InterceptorContext::response), or
+    /// [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error) **MAY** be available.
+    /// If the operation succeeded, the `output` will be available. Otherwise, any of the other
+    /// pieces of information may be available depending on where in the operation lifecycle it failed.
+    /// In the event of retries, the `InterceptorContext` will not include changes made
+    /// in previous attempts (e.g. by request signers or other interceptors).
     ///
     /// **Error Behavior:** Errors raised by this hook will be stored
     /// until all interceptors have had their `after_execution` invoked.
     /// The error will then be treated as the
-    /// [InterceptorContext::output_or_error()] to the customer. If multiple
-    /// `after_execution` methods raise errors , the latest will be
+    /// [`InterceptorContext::output_or_error`](context::InterceptorContext::output_or_error)
+    /// to the customer. If multiple `after_execution` methods raise errors , the latest will be
     /// used and earlier ones will be logged and dropped.
     fn read_after_execution(
         &self,

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
@@ -37,9 +37,13 @@ use std::{fmt, mem};
 use tracing::{debug, error, trace};
 
 // TODO(enableNewSmithyRuntimeLaunch): New-type `Input`/`Output`/`Error`
+/// Type-erased operation input.
 pub type Input = TypeErasedBox;
+/// Type-erased operation output.
 pub type Output = TypeErasedBox;
+/// Type-erased operation error.
 pub type Error = TypeErasedError;
+/// Type-erased result for an operation.
 pub type OutputOrError = Result<Output, OrchestratorError<Error>>;
 
 type Request = HttpRequest;
@@ -316,6 +320,8 @@ where
         )
     }
 
+    /// Convert this context into the final operation result that is returned in client's the public API.
+    #[doc(hidden)]
     pub fn finalize(self) -> Result<O, SdkError<E, HttpResponse>> {
         let Self {
             output_or_error,

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context/wrappers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context/wrappers.rs
@@ -8,191 +8,237 @@ use crate::client::interceptors::context::{Request, Response};
 use crate::client::orchestrator::OrchestratorError;
 use std::fmt::Debug;
 
-macro_rules! output {
-    (&Option<Result<$o_ty:ty, $e_ty:ty>>) => {
-        Option<Result<&$o_ty, &$e_ty>>
-    };
-    (&Option<$ty:ty>) => {
-        Option<&$ty>
-    };
-    (&mut Option<$ty:ty>) => {
-        Option<&mut $ty>
-    };
-    (&Result<$o_ty:ty, $e_ty:ty>) => {
-        Result<&$o_ty, &$e_ty>
-    };
-    (&$($tt:tt)+) => {
-        &$($tt)+
-    };
-    (&mut $($tt:tt)+) => {
-        &mut $($tt)+
-    };
-}
-
-macro_rules! declare_method {
-    (&mut $name:ident, $inner_name:ident, $doc:literal, Option<$ty:ty>) => {
-        #[doc=$doc]
-        pub fn $name(&mut self) -> Option<&mut $ty> {
-            self.inner.$inner_name.as_ref()
-        }
-    };
-    (&$name:ident, $inner_name:ident, $doc:literal, Option<$ty:ty>) => {
-        #[doc=$doc]
-        pub fn $name(&self) -> Option<$ty> {
-            self.inner.$inner_name.as_mut()
-        }
-    };
-    (&mut $name:ident, $doc:literal, $($tt:tt)+) => {
-        #[doc=$doc]
-        pub fn $name(&mut self) -> output!(&mut $($tt)+) {
-            self.inner.$name().expect(concat!("`", stringify!($name), "` wasn't set in the underlying interceptor context. This is a bug."))
-        }
-    };
-    (&$name:ident, $doc:literal, $($tt:tt)+) => {
-        #[doc=$doc]
-        pub fn $name(&self) -> output!(&$($tt)+) {
-            self.inner.$name().expect(concat!("`", stringify!($name), "` wasn't set in the underlying interceptor context. This is a bug."))
-        }
-    };
-}
-
-macro_rules! declare_known_method {
-    (output_or_error: &mut $($tt:tt)+) => {
-        declare_method!(&mut output_or_error_mut, "Returns a mutable reference to the deserialized output or error.", $($tt)+);
-    };
-    (output_or_error: &$($tt:tt)+) => {
-        declare_method!(&output_or_error, "Returns a reference to the deserialized output or error.", $($tt)+);
-    };
-    (input: &mut $($tt:tt)+) => {
-        declare_method!(&mut input_mut, "Returns a mutable reference to the input.", $($tt)+);
-    };
-    (input: &$($tt:tt)+) => {
-        declare_method!(&input, "Returns a reference to the input.", $($tt)+);
-    };
-    (request: &mut $($tt:tt)+) => {
-        declare_method!(&mut request_mut, "Returns a mutable reference to the transmittable request for the operation being invoked.", $($tt)+);
-    };
-    (request: &$($tt:tt)+) => {
-        declare_method!(&request, "Returns a reference to the transmittable request for the operation being invoked.", $($tt)+);
-    };
-    (response: &mut $($tt:tt)+) => {
-        declare_method!(&mut response_mut, "Returns a mutable reference to the response.", $($tt)+);
-    };
-    (response: &$($tt:tt)+) => {
-        declare_method!(&response, "Returns a reference to the response.", $($tt)+);
-    };
-}
-
-macro_rules! declare_wrapper {
-    (($ref_struct_name:ident readonly)$($tt:tt)+) => {
-        pub struct $ref_struct_name<'a, I = Input, O = Output, E = Error> {
-            inner: &'a InterceptorContext<I, O, E>,
-        }
-
-        impl<'a, I, O, E: Debug> From<&'a InterceptorContext<I, O, E>> for $ref_struct_name<'a, I, O, E>
-        {
+macro_rules! impl_from_interceptor_context {
+    (ref $wrapper:ident) => {
+        impl<'a, I, O, E> From<&'a InterceptorContext<I, O, E>> for $wrapper<'a, I, O, E> {
             fn from(inner: &'a InterceptorContext<I, O, E>) -> Self {
                 Self { inner }
             }
         }
-
-        impl<'a, I, O, E: Debug> $ref_struct_name<'a, I, O, E> {
-            declare_ref_wrapper_methods!($($tt)+);
-        }
     };
-    (($ref_struct_name:ident $mut_struct_name:ident)$($tt:tt)+) => {
-        declare_wrapper!(($ref_struct_name readonly) $($tt)+);
-
-        pub struct $mut_struct_name<'a, I = Input, O = Output, E = Error> {
-            inner: &'a mut InterceptorContext<I, O, E>,
-        }
-
-        impl<'a, I, O, E: Debug> From<&'a mut InterceptorContext<I, O, E>> for $mut_struct_name<'a, I, O, E>
-        {
+    (mut $wrapper:ident) => {
+        impl<'a, I, O, E> From<&'a mut InterceptorContext<I, O, E>> for $wrapper<'a, I, O, E> {
             fn from(inner: &'a mut InterceptorContext<I, O, E>) -> Self {
                 Self { inner }
             }
         }
-
-        impl<'a, I, O, E: Debug> $mut_struct_name<'a, I, O, E> {
-            declare_ref_wrapper_methods!($($tt)+);
-            declare_mut_wrapper_methods!($($tt)+);
-        }
     };
 }
 
-macro_rules! declare_ref_wrapper_methods {
-    (($field:ident: $($head:tt)+)$($tail:tt)+) => {
-        declare_known_method!($field: &$($head)+);
-        declare_ref_wrapper_methods!($($tail)+);
-    };
-    (($field:ident: $($tt:tt)+)) => {
-        declare_known_method!($field: &$($tt)+);
-    };
-}
-
-macro_rules! declare_mut_wrapper_methods {
-    (($field:ident: $($head:tt)+)$($tail:tt)+) => {
-        declare_known_method!($field: &mut $($head)+);
-        declare_mut_wrapper_methods!($($tail)+);
-    };
-    (($field:ident: $($tt:tt)+)) => {
-        declare_known_method!($field: &mut $($tt)+);
+macro_rules! expect {
+    ($self:ident, $what:ident) => {
+        $self.inner.$what().expect(concat!(
+            "`",
+            stringify!($what),
+            "` wasn't set in the underlying interceptor context. This is a bug."
+        ))
     };
 }
 
-declare_wrapper!(
-    (BeforeSerializationInterceptorContextRef BeforeSerializationInterceptorContextMut)
-    (input: I)
-);
+//
+// BeforeSerializationInterceptorContextRef
+//
 
-declare_wrapper!(
-    (BeforeTransmitInterceptorContextRef BeforeTransmitInterceptorContextMut)
-    (request: Request)
-);
+#[derive(Debug)]
+pub struct BeforeSerializationInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
+    inner: &'a InterceptorContext<I, O, E>,
+}
 
-declare_wrapper!(
-    (BeforeDeserializationInterceptorContextRef BeforeDeserializationInterceptorContextMut)
-    (input: I)
-    (request: Request)
-    (response: Response)
-);
+impl_from_interceptor_context!(ref BeforeSerializationInterceptorContextRef);
 
-impl<'a, I, O, E: Debug> BeforeDeserializationInterceptorContextMut<'a, I, O, E> {
+impl<'a, I, O, E> BeforeSerializationInterceptorContextRef<'a, I, O, E> {
+    /// Returns a reference to the input.
+    pub fn input(&self) -> &I {
+        expect!(self, input)
+    }
+}
+
+//
+// BeforeSerializationInterceptorContextMut
+//
+
+#[derive(Debug)]
+pub struct BeforeSerializationInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
+    inner: &'a mut InterceptorContext<I, O, E>,
+}
+
+impl_from_interceptor_context!(mut BeforeSerializationInterceptorContextMut);
+
+impl<'a, I, O, E> BeforeSerializationInterceptorContextMut<'a, I, O, E> {
+    /// Returns a reference to the input.
+    pub fn input(&self) -> &I {
+        expect!(self, input)
+    }
+
+    /// Returns a mutable reference to the input.
+    pub fn input_mut(&mut self) -> &mut I {
+        expect!(self, input_mut)
+    }
+}
+
+//
+// BeforeSerializationInterceptorContextRef
+//
+
+#[derive(Debug)]
+pub struct BeforeTransmitInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
+    inner: &'a InterceptorContext<I, O, E>,
+}
+
+impl_from_interceptor_context!(ref BeforeTransmitInterceptorContextRef);
+
+impl<'a, I, O, E> BeforeTransmitInterceptorContextRef<'a, I, O, E> {
+    /// Returns a reference to the transmittable request for the operation being invoked.
+    pub fn request(&self) -> &Request {
+        expect!(self, request)
+    }
+}
+
+//
+// BeforeSerializationInterceptorContextMut
+//
+
+#[derive(Debug)]
+pub struct BeforeTransmitInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
+    inner: &'a mut InterceptorContext<I, O, E>,
+}
+
+impl_from_interceptor_context!(mut BeforeTransmitInterceptorContextMut);
+
+impl<'a, I, O, E> BeforeTransmitInterceptorContextMut<'a, I, O, E> {
+    /// Returns a reference to the transmittable request for the operation being invoked.
+    pub fn request(&self) -> &Request {
+        expect!(self, request)
+    }
+
+    /// Returns a mutable reference to the transmittable request for the operation being invoked.
+    pub fn request_mut(&mut self) -> &mut Request {
+        expect!(self, request_mut)
+    }
+}
+
+//
+// BeforeDeserializationInterceptorContextRef
+//
+
+#[derive(Debug)]
+pub struct BeforeDeserializationInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
+    inner: &'a InterceptorContext<I, O, E>,
+}
+
+impl_from_interceptor_context!(ref BeforeDeserializationInterceptorContextRef);
+
+impl<'a, I, O, E> BeforeDeserializationInterceptorContextRef<'a, I, O, E> {
+    /// Returns a reference to the input.
+    pub fn input(&self) -> &I {
+        expect!(self, input)
+    }
+
+    /// Returns a reference to the transmittable request for the operation being invoked.
+    pub fn request(&self) -> &Request {
+        expect!(self, request)
+    }
+
+    /// Returns a reference to the response.
+    pub fn response(&self) -> &Response {
+        expect!(self, response)
+    }
+}
+
+//
+// BeforeDeserializationInterceptorContextMut
+//
+
+pub struct BeforeDeserializationInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
+    inner: &'a mut InterceptorContext<I, O, E>,
+}
+
+impl_from_interceptor_context!(mut BeforeDeserializationInterceptorContextMut);
+
+impl<'a, I, O, E> BeforeDeserializationInterceptorContextMut<'a, I, O, E> {
+    /// Returns a reference to the input.
+    pub fn input(&self) -> &I {
+        expect!(self, input)
+    }
+
+    /// Returns a reference to the transmittable request for the operation being invoked.
+    pub fn request(&self) -> &Request {
+        expect!(self, request)
+    }
+
+    /// Returns a reference to the response.
+    pub fn response(&self) -> &Response {
+        expect!(self, response)
+    }
+
+    /// Returns a mutable reference to the input.
+    pub fn input_mut(&mut self) -> &mut I {
+        expect!(self, input_mut)
+    }
+
+    /// Returns a mutable reference to the transmittable request for the operation being invoked.
+    pub fn request_mut(&mut self) -> &mut Request {
+        expect!(self, request_mut)
+    }
+
+    /// Returns a mutable reference to the response.
+    pub fn response_mut(&mut self) -> &mut Response {
+        expect!(self, response_mut)
+    }
+
     #[doc(hidden)]
+    #[cfg(feature = "test-util")]
     /// Downgrade this helper struct, returning the underlying InterceptorContext. There's no good
     /// reason to use this unless you're writing tests or you have to interact with an API that
     /// doesn't support the helper structs.
-    pub fn into_inner(&mut self) -> &'_ mut InterceptorContext<I, O, E> {
+    pub fn inner_mut(&mut self) -> &'_ mut InterceptorContext<I, O, E> {
         self.inner
     }
 }
 
-declare_wrapper!(
-    (AfterDeserializationInterceptorContextRef readonly)
-    (input: I)
-    (request: Request)
-    (response: Response)
-    (output_or_error: Result<O, OrchestratorError<E>>
-));
+//
+// AfterDeserializationInterceptorContextRef
+//
 
-// Why are all the rest of these defined with a macro but these last two aren't? I simply ran out of
-// time. Consider updating the macros to support these last two if you're looking for a challenge.
-// - Zelda
+pub struct AfterDeserializationInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
+    inner: &'a InterceptorContext<I, O, E>,
+}
+
+impl_from_interceptor_context!(ref AfterDeserializationInterceptorContextRef);
+
+impl<'a, I, O, E> AfterDeserializationInterceptorContextRef<'a, I, O, E> {
+    /// Returns a reference to the input.
+    pub fn input(&self) -> &I {
+        expect!(self, input)
+    }
+
+    /// Returns a reference to the transmittable request for the operation being invoked.
+    pub fn request(&self) -> &Request {
+        expect!(self, request)
+    }
+
+    /// Returns a reference to the response.
+    pub fn response(&self) -> &Response {
+        expect!(self, response)
+    }
+
+    /// Returns a reference to the deserialized output or error.
+    pub fn output_or_error(&self) -> Result<&O, &OrchestratorError<E>> {
+        expect!(self, output_or_error)
+    }
+}
+
+//
+// FinalizerInterceptorContextRef
+//
 
 pub struct FinalizerInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
     inner: &'a InterceptorContext<I, O, E>,
 }
 
-impl<'a, I, O, E: Debug> From<&'a InterceptorContext<I, O, E>>
-    for FinalizerInterceptorContextRef<'a, I, O, E>
-{
-    fn from(inner: &'a InterceptorContext<I, O, E>) -> Self {
-        Self { inner }
-    }
-}
+impl_from_interceptor_context!(ref FinalizerInterceptorContextRef);
 
-impl<'a, I, O, E: Debug> FinalizerInterceptorContextRef<'a, I, O, E> {
+impl<'a, I, O, E> FinalizerInterceptorContextRef<'a, I, O, E> {
     /// Returns the operation input.
     pub fn input(&self) -> Option<&I> {
         self.inner.input.as_ref()
@@ -214,19 +260,17 @@ impl<'a, I, O, E: Debug> FinalizerInterceptorContextRef<'a, I, O, E> {
     }
 }
 
+//
+// FinalizerInterceptorContextMut
+//
+
 pub struct FinalizerInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
     inner: &'a mut InterceptorContext<I, O, E>,
 }
 
-impl<'a, I, O, E: Debug> From<&'a mut InterceptorContext<I, O, E>>
-    for FinalizerInterceptorContextMut<'a, I, O, E>
-{
-    fn from(inner: &'a mut InterceptorContext<I, O, E>) -> Self {
-        Self { inner }
-    }
-}
+impl_from_interceptor_context!(mut FinalizerInterceptorContextMut);
 
-impl<'a, I, O, E: Debug> FinalizerInterceptorContextMut<'a, I, O, E> {
+impl<'a, I, O, E> FinalizerInterceptorContextMut<'a, I, O, E> {
     /// Returns the operation input.
     pub fn input(&self) -> Option<&I> {
         self.inner.input.as_ref()

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context/wrappers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context/wrappers.rs
@@ -187,7 +187,6 @@ impl<'a, I, O, E> BeforeDeserializationInterceptorContextMut<'a, I, O, E> {
     }
 
     #[doc(hidden)]
-    #[cfg(feature = "test-util")]
     /// Downgrade this helper struct, returning the underlying InterceptorContext. There's no good
     /// reason to use this unless you're writing tests or you have to interact with an API that
     /// doesn't support the helper structs.

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context/wrappers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context/wrappers.rs
@@ -39,6 +39,9 @@ macro_rules! expect {
 // BeforeSerializationInterceptorContextRef
 //
 
+/// Interceptor context for the `read_before_execution` and `read_before_serialization` hooks.
+///
+/// Only the input is available at this point in the operation.
 #[derive(Debug)]
 pub struct BeforeSerializationInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
     inner: &'a InterceptorContext<I, O, E>,
@@ -57,6 +60,9 @@ impl<'a, I, O, E> BeforeSerializationInterceptorContextRef<'a, I, O, E> {
 // BeforeSerializationInterceptorContextMut
 //
 
+/// Interceptor context for the `modify_before_serialization` hook.
+///
+/// Only the input is available at this point in the operation.
 #[derive(Debug)]
 pub struct BeforeSerializationInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
     inner: &'a mut InterceptorContext<I, O, E>,
@@ -80,6 +86,9 @@ impl<'a, I, O, E> BeforeSerializationInterceptorContextMut<'a, I, O, E> {
 // BeforeSerializationInterceptorContextRef
 //
 
+/// Interceptor context for several hooks in between serialization and transmission.
+///
+/// Only the request is available at this point in the operation.
 #[derive(Debug)]
 pub struct BeforeTransmitInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
     inner: &'a InterceptorContext<I, O, E>,
@@ -98,6 +107,9 @@ impl<'a, I, O, E> BeforeTransmitInterceptorContextRef<'a, I, O, E> {
 // BeforeSerializationInterceptorContextMut
 //
 
+/// Interceptor context for several hooks in between serialization and transmission.
+///
+/// Only the request is available at this point in the operation.
 #[derive(Debug)]
 pub struct BeforeTransmitInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
     inner: &'a mut InterceptorContext<I, O, E>,
@@ -121,6 +133,9 @@ impl<'a, I, O, E> BeforeTransmitInterceptorContextMut<'a, I, O, E> {
 // BeforeDeserializationInterceptorContextRef
 //
 
+/// Interceptor context for hooks before deserializing the response.
+///
+/// Only the response is available at this point in the operation.
 #[derive(Debug)]
 pub struct BeforeDeserializationInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
     inner: &'a InterceptorContext<I, O, E>,
@@ -129,16 +144,6 @@ pub struct BeforeDeserializationInterceptorContextRef<'a, I = Input, O = Output,
 impl_from_interceptor_context!(ref BeforeDeserializationInterceptorContextRef);
 
 impl<'a, I, O, E> BeforeDeserializationInterceptorContextRef<'a, I, O, E> {
-    /// Returns a reference to the input.
-    pub fn input(&self) -> &I {
-        expect!(self, input)
-    }
-
-    /// Returns a reference to the transmittable request for the operation being invoked.
-    pub fn request(&self) -> &Request {
-        expect!(self, request)
-    }
-
     /// Returns a reference to the response.
     pub fn response(&self) -> &Response {
         expect!(self, response)
@@ -149,6 +154,9 @@ impl<'a, I, O, E> BeforeDeserializationInterceptorContextRef<'a, I, O, E> {
 // BeforeDeserializationInterceptorContextMut
 //
 
+/// Interceptor context for hooks before deserializing the response.
+///
+/// Only the response is available at this point in the operation.
 pub struct BeforeDeserializationInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
     inner: &'a mut InterceptorContext<I, O, E>,
 }
@@ -156,29 +164,9 @@ pub struct BeforeDeserializationInterceptorContextMut<'a, I = Input, O = Output,
 impl_from_interceptor_context!(mut BeforeDeserializationInterceptorContextMut);
 
 impl<'a, I, O, E> BeforeDeserializationInterceptorContextMut<'a, I, O, E> {
-    /// Returns a reference to the input.
-    pub fn input(&self) -> &I {
-        expect!(self, input)
-    }
-
-    /// Returns a reference to the transmittable request for the operation being invoked.
-    pub fn request(&self) -> &Request {
-        expect!(self, request)
-    }
-
     /// Returns a reference to the response.
     pub fn response(&self) -> &Response {
         expect!(self, response)
-    }
-
-    /// Returns a mutable reference to the input.
-    pub fn input_mut(&mut self) -> &mut I {
-        expect!(self, input_mut)
-    }
-
-    /// Returns a mutable reference to the transmittable request for the operation being invoked.
-    pub fn request_mut(&mut self) -> &mut Request {
-        expect!(self, request_mut)
     }
 
     /// Returns a mutable reference to the response.
@@ -199,6 +187,9 @@ impl<'a, I, O, E> BeforeDeserializationInterceptorContextMut<'a, I, O, E> {
 // AfterDeserializationInterceptorContextRef
 //
 
+/// Interceptor context for hooks after deserializing the response.
+///
+/// The response and the deserialized output or error are available at this point in the operation.
 pub struct AfterDeserializationInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
     inner: &'a InterceptorContext<I, O, E>,
 }
@@ -206,16 +197,6 @@ pub struct AfterDeserializationInterceptorContextRef<'a, I = Input, O = Output, 
 impl_from_interceptor_context!(ref AfterDeserializationInterceptorContextRef);
 
 impl<'a, I, O, E> AfterDeserializationInterceptorContextRef<'a, I, O, E> {
-    /// Returns a reference to the input.
-    pub fn input(&self) -> &I {
-        expect!(self, input)
-    }
-
-    /// Returns a reference to the transmittable request for the operation being invoked.
-    pub fn request(&self) -> &Request {
-        expect!(self, request)
-    }
-
     /// Returns a reference to the response.
     pub fn response(&self) -> &Response {
         expect!(self, response)
@@ -231,6 +212,11 @@ impl<'a, I, O, E> AfterDeserializationInterceptorContextRef<'a, I, O, E> {
 // FinalizerInterceptorContextRef
 //
 
+/// Interceptor context for finalization hooks.
+///
+/// This context is used by the `read_after_attempt` and `read_after_execution` hooks
+/// that are all called upon both success and failure, and may have varying levels
+/// of context available depending on where a failure occurred if the operation failed.
 pub struct FinalizerInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
     inner: &'a InterceptorContext<I, O, E>,
 }
@@ -263,6 +249,11 @@ impl<'a, I, O, E> FinalizerInterceptorContextRef<'a, I, O, E> {
 // FinalizerInterceptorContextMut
 //
 
+/// Interceptor context for finalization hooks.
+///
+/// This context is used by the `modify_before_attempt_completion` and `modify_before_completion` hooks
+/// that are all called upon both success and failure, and may have varying levels
+/// of context available depending on where a failure occurred if the operation failed.
 pub struct FinalizerInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
     inner: &'a mut InterceptorContext<I, O, E>,
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/lib.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/lib.rs
@@ -4,8 +4,7 @@
  */
 
 #![warn(
-    // TODO(enableNewSmithyRuntimeLaunch): Add in remaining missing docs
-    // missing_docs,
+    missing_docs,
     rustdoc::missing_crate_level_docs,
     unreachable_pub,
     rust_2018_idioms

--- a/rust-runtime/aws-smithy-runtime/src/client/connectors/connection_poisoning.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/connectors/connection_poisoning.rs
@@ -72,7 +72,7 @@ impl Interceptor for ConnectionPoisoningInterceptor {
             .ok_or("retry classifiers are required for connection poisoning to work")?;
 
         let error_is_transient = retry_classifiers
-            .classify_retry(context.into_inner())
+            .classify_retry(context.inner_mut())
             .map(|reason| reason == RetryReason::Error(ErrorKind::TransientError))
             .unwrap_or_default();
         let connection_poisoning_is_enabled =

--- a/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
@@ -5,14 +5,244 @@
 
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_runtime_api::box_error::BoxError;
-use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::context::{
+    BeforeSerializationInterceptorContextRef, BeforeTransmitInterceptorContextMut,
+    FinalizerInterceptorContextMut, FinalizerInterceptorContextRef,
+};
+use aws_smithy_runtime_api::client::interceptors::context::{
+    Error, Input, InterceptorContext, Output,
+};
+use aws_smithy_runtime_api::client::interceptors::{
+    Interceptor, InterceptorError, SharedInterceptor,
+};
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use std::error::Error as StdError;
 use std::fmt;
 use std::marker::PhantomData;
+
+macro_rules! interceptor_impl_fn {
+    (mut $interceptor:ident) => {
+        pub(crate) fn $interceptor(
+            self,
+            ctx: &mut InterceptorContext,
+            runtime_components: &RuntimeComponents,
+            cfg: &mut ConfigBag,
+        ) -> Result<(), InterceptorError> {
+            tracing::trace!(concat!(
+                "running `",
+                stringify!($interceptor),
+                "` interceptors"
+            ));
+            let mut result: Result<(), BoxError> = Ok(());
+            let mut ctx = ctx.into();
+            for interceptor in self.into_iter() {
+                if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                    if let Err(new_error) =
+                        interceptor.$interceptor(&mut ctx, runtime_components, cfg)
+                    {
+                        if let Err(last_error) = result {
+                            tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                        }
+                        result = Err(new_error);
+                    }
+                }
+            }
+            result.map_err(InterceptorError::$interceptor)
+        }
+    };
+    (ref $interceptor:ident) => {
+        pub(crate) fn $interceptor(
+            self,
+            ctx: &InterceptorContext,
+            runtime_components: &RuntimeComponents,
+            cfg: &mut ConfigBag,
+        ) -> Result<(), InterceptorError> {
+            let mut result: Result<(), BoxError> = Ok(());
+            let ctx = ctx.into();
+            for interceptor in self.into_iter() {
+                if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                    if let Err(new_error) = interceptor.$interceptor(&ctx, runtime_components, cfg)
+                    {
+                        if let Err(last_error) = result {
+                            tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                        }
+                        result = Err(new_error);
+                    }
+                }
+            }
+            result.map_err(InterceptorError::$interceptor)
+        }
+    };
+}
+
+#[derive(Debug)]
+pub(crate) struct Interceptors<I> {
+    interceptors: I,
+}
+
+impl<I> Interceptors<I>
+where
+    I: Iterator<Item = SharedInterceptor>,
+{
+    pub(crate) fn new(interceptors: I) -> Self {
+        Self { interceptors }
+    }
+
+    fn into_iter(self) -> impl Iterator<Item = ConditionallyEnabledInterceptor> {
+        self.interceptors.map(ConditionallyEnabledInterceptor)
+    }
+
+    pub(crate) fn read_before_execution(
+        self,
+        operation: bool,
+        ctx: &InterceptorContext<Input, Output, Error>,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), InterceptorError> {
+        tracing::trace!(
+            "running {} `read_before_execution` interceptors",
+            if operation { "operation" } else { "client" }
+        );
+        let mut result: Result<(), BoxError> = Ok(());
+        let ctx: BeforeSerializationInterceptorContextRef<'_> = ctx.into();
+        for interceptor in self.into_iter() {
+            if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                if let Err(new_error) = interceptor.read_before_execution(&ctx, cfg) {
+                    if let Err(last_error) = result {
+                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                    }
+                    result = Err(new_error);
+                }
+            }
+        }
+        result.map_err(InterceptorError::read_before_execution)
+    }
+
+    interceptor_impl_fn!(mut modify_before_serialization);
+    interceptor_impl_fn!(ref read_before_serialization);
+    interceptor_impl_fn!(ref read_after_serialization);
+    interceptor_impl_fn!(mut modify_before_retry_loop);
+    interceptor_impl_fn!(ref read_before_attempt);
+    interceptor_impl_fn!(mut modify_before_signing);
+    interceptor_impl_fn!(ref read_before_signing);
+    interceptor_impl_fn!(ref read_after_signing);
+    interceptor_impl_fn!(mut modify_before_transmit);
+    interceptor_impl_fn!(ref read_before_transmit);
+    interceptor_impl_fn!(ref read_after_transmit);
+    interceptor_impl_fn!(mut modify_before_deserialization);
+    interceptor_impl_fn!(ref read_before_deserialization);
+    interceptor_impl_fn!(ref read_after_deserialization);
+
+    pub(crate) fn modify_before_attempt_completion(
+        self,
+        ctx: &mut InterceptorContext<Input, Output, Error>,
+        runtime_components: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), InterceptorError> {
+        tracing::trace!("running `modify_before_attempt_completion` interceptors");
+        let mut result: Result<(), BoxError> = Ok(());
+        let mut ctx: FinalizerInterceptorContextMut<'_> = ctx.into();
+        for interceptor in self.into_iter() {
+            if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                if let Err(new_error) =
+                    interceptor.modify_before_attempt_completion(&mut ctx, runtime_components, cfg)
+                {
+                    if let Err(last_error) = result {
+                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                    }
+                    result = Err(new_error);
+                }
+            }
+        }
+        result.map_err(InterceptorError::modify_before_attempt_completion)
+    }
+
+    pub(crate) fn read_after_attempt(
+        self,
+        ctx: &InterceptorContext<Input, Output, Error>,
+        runtime_components: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), InterceptorError> {
+        tracing::trace!("running `read_after_attempt` interceptors");
+        let mut result: Result<(), BoxError> = Ok(());
+        let ctx: FinalizerInterceptorContextRef<'_> = ctx.into();
+        for interceptor in self.into_iter() {
+            if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                if let Err(new_error) =
+                    interceptor.read_after_attempt(&ctx, runtime_components, cfg)
+                {
+                    if let Err(last_error) = result {
+                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                    }
+                    result = Err(new_error);
+                }
+            }
+        }
+        result.map_err(InterceptorError::read_after_attempt)
+    }
+
+    pub(crate) fn modify_before_completion(
+        self,
+        ctx: &mut InterceptorContext<Input, Output, Error>,
+        runtime_components: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), InterceptorError> {
+        tracing::trace!("running `modify_before_completion` interceptors");
+        let mut result: Result<(), BoxError> = Ok(());
+        let mut ctx: FinalizerInterceptorContextMut<'_> = ctx.into();
+        for interceptor in self.into_iter() {
+            if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                if let Err(new_error) =
+                    interceptor.modify_before_completion(&mut ctx, runtime_components, cfg)
+                {
+                    if let Err(last_error) = result {
+                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                    }
+                    result = Err(new_error);
+                }
+            }
+        }
+        result.map_err(InterceptorError::modify_before_completion)
+    }
+
+    pub(crate) fn read_after_execution(
+        self,
+        ctx: &InterceptorContext<Input, Output, Error>,
+        runtime_components: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), InterceptorError> {
+        tracing::trace!("running `read_after_execution` interceptors");
+        let mut result: Result<(), BoxError> = Ok(());
+        let ctx: FinalizerInterceptorContextRef<'_> = ctx.into();
+        for interceptor in self.into_iter() {
+            if let Some(interceptor) = interceptor.if_enabled(cfg) {
+                if let Err(new_error) =
+                    interceptor.read_after_execution(&ctx, runtime_components, cfg)
+                {
+                    if let Err(last_error) = result {
+                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                    }
+                    result = Err(new_error);
+                }
+            }
+        }
+        result.map_err(InterceptorError::read_after_execution)
+    }
+}
+
+/// A interceptor wrapper to conditionally enable the interceptor based on [`DisableInterceptor`]
+struct ConditionallyEnabledInterceptor(SharedInterceptor);
+impl ConditionallyEnabledInterceptor {
+    fn if_enabled(&self, cfg: &ConfigBag) -> Option<&dyn Interceptor> {
+        if self.0.enabled(cfg) {
+            Some(self.0.as_ref())
+        } else {
+            None
+        }
+    }
+}
 
 pub struct MapRequestInterceptor<F, E> {
     f: F,
@@ -84,5 +314,73 @@ where
         (self.f)(request);
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "test-util"))]
+mod tests {
+    use super::*;
+    use aws_smithy_runtime_api::box_error::BoxError;
+    use aws_smithy_runtime_api::client::interceptors::context::{
+        BeforeTransmitInterceptorContextRef, Input, InterceptorContext,
+    };
+    use aws_smithy_runtime_api::client::interceptors::{
+        disable_interceptor, Interceptor, SharedInterceptor,
+    };
+    use aws_smithy_runtime_api::client::runtime_components::{
+        RuntimeComponents, RuntimeComponentsBuilder,
+    };
+    use aws_smithy_types::config_bag::ConfigBag;
+
+    #[derive(Debug)]
+    struct TestInterceptor;
+    impl Interceptor for TestInterceptor {}
+
+    #[test]
+    fn test_disable_interceptors() {
+        #[derive(Debug)]
+        struct PanicInterceptor;
+        impl Interceptor for PanicInterceptor {
+            fn read_before_transmit(
+                &self,
+                _context: &BeforeTransmitInterceptorContextRef<'_>,
+                _rc: &RuntimeComponents,
+                _cfg: &mut ConfigBag,
+            ) -> Result<(), BoxError> {
+                Err("boom".into())
+            }
+        }
+        let rc = RuntimeComponentsBuilder::for_tests()
+            .with_interceptor(SharedInterceptor::new(PanicInterceptor))
+            .with_interceptor(SharedInterceptor::new(TestInterceptor))
+            .build()
+            .unwrap();
+
+        let mut cfg = ConfigBag::base();
+        let interceptors = Interceptors::new(rc.interceptors());
+        assert_eq!(
+            interceptors
+                .into_iter()
+                .filter(|i| i.if_enabled(&cfg).is_some())
+                .count(),
+            2
+        );
+
+        Interceptors::new(rc.interceptors())
+            .read_before_transmit(&InterceptorContext::new(Input::new(5)), &rc, &mut cfg)
+            .expect_err("interceptor returns error");
+        cfg.interceptor_state()
+            .store_put(disable_interceptor::<PanicInterceptor>("test"));
+        assert_eq!(
+            Interceptors::new(rc.interceptors())
+                .into_iter()
+                .filter(|i| i.if_enabled(&cfg).is_some())
+                .count(),
+            1
+        );
+        // shouldn't error because interceptors won't run
+        Interceptors::new(rc.interceptors())
+            .read_before_transmit(&InterceptorContext::new(Input::new(5)), &rc, &mut cfg)
+            .expect("interceptor is now disabled");
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
@@ -232,7 +232,8 @@ where
     }
 }
 
-/// A interceptor wrapper to conditionally enable the interceptor based on [`DisableInterceptor`]
+/// A interceptor wrapper to conditionally enable the interceptor based on
+/// [`DisableInterceptor`](aws_smithy_runtime_api::client::interceptors::DisableInterceptor)
 struct ConditionallyEnabledInterceptor(SharedInterceptor);
 impl ConditionallyEnabledInterceptor {
     fn if_enabled(&self, cfg: &ConfigBag) -> Option<&dyn Interceptor> {

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -7,6 +7,7 @@
 #![allow(unknown_lints)]
 
 use self::auth::orchestrate_auth;
+use crate::client::interceptors::Interceptors;
 use crate::client::orchestrator::endpoints::orchestrate_endpoint;
 use crate::client::orchestrator::http::read_body;
 use crate::client::timeout::{MaybeTimeout, MaybeTimeoutConfig, TimeoutKind};
@@ -19,7 +20,6 @@ use aws_smithy_runtime_api::client::connectors::HttpConnector;
 use aws_smithy_runtime_api::client::interceptors::context::{
     Error, Input, InterceptorContext, Output, RewindResult,
 };
-use aws_smithy_runtime_api::client::interceptors::Interceptors;
 use aws_smithy_runtime_api::client::orchestrator::{
     HttpResponse, LoadedRequestBody, OrchestratorError,
 };

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -200,7 +200,10 @@ async fn try_op(
         debug!("loading request body into memory");
         let mut body = SdkBody::taken();
         mem::swap(&mut body, ctx.request_mut().expect("set above").body_mut());
-        let loaded_body = halt_on_err!([ctx] => ByteStream::new(body).collect().await).into_bytes();
+        let loaded_body = halt_on_err!([ctx] =>
+            ByteStream::new(body).collect().await.map_err(OrchestratorError::other)
+        )
+        .into_bytes();
         *ctx.request_mut().as_mut().expect("set above").body_mut() =
             SdkBody::from(loaded_body.clone());
         cfg.interceptor_state()

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/classifier.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/classifier.rs
@@ -81,8 +81,8 @@ where
         } else if let Some(error) = error.as_connector_error() {
             if error.is_timeout() || error.is_io() {
                 Some(RetryReason::Error(ErrorKind::TransientError))
-            } else if error.is_other().is_some() {
-                error.is_other().map(RetryReason::Error)
+            } else if let Some(other) = error.as_other() {
+                Some(RetryReason::Error(other))
             } else {
                 None
             }

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/classifier.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/classifier.rs
@@ -4,7 +4,6 @@
  */
 
 use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
-use aws_smithy_runtime_api::client::orchestrator::OrchestratorError;
 use aws_smithy_runtime_api::client::retries::{ClassifyRetry, RetryReason};
 use aws_smithy_types::retry::{ErrorKind, ProvideErrorKind};
 use std::borrow::Cow;
@@ -77,17 +76,18 @@ where
             Err(err) => err,
         };
 
-        match error {
-            OrchestratorError::Response { .. } | OrchestratorError::Timeout { .. } => {
+        if error.is_response_error() || error.is_timeout_error() {
+            Some(RetryReason::Error(ErrorKind::TransientError))
+        } else if let Some(error) = error.as_connector_error() {
+            if error.is_timeout() || error.is_io() {
                 Some(RetryReason::Error(ErrorKind::TransientError))
+            } else if error.is_other().is_some() {
+                error.is_other().map(RetryReason::Error)
+            } else {
+                None
             }
-            OrchestratorError::Connector { err } if err.is_timeout() || err.is_io() => {
-                Some(RetryReason::Error(ErrorKind::TransientError))
-            }
-            OrchestratorError::Connector { err } if err.is_other().is_some() => {
-                err.is_other().map(RetryReason::Error)
-            }
-            _ => None,
+        } else {
+            None
         }
     }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/classifier.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/classifier.rs
@@ -81,10 +81,8 @@ where
         } else if let Some(error) = error.as_connector_error() {
             if error.is_timeout() || error.is_io() {
                 Some(RetryReason::Error(ErrorKind::TransientError))
-            } else if let Some(other) = error.as_other() {
-                Some(RetryReason::Error(other))
             } else {
-                None
+                error.as_other().map(RetryReason::Error)
             }
         } else {
             None


### PR DESCRIPTION
This PR finishes documenting `aws-smithy-runtime-api` and also:

- Adds `Send + Sync` bounds to `Interceptor`.
- Moves `Interceptors` into `aws-smithy-runtime`.
- Expands the more complicated macros in the interceptor context wrappers.
- Makes the `OrchestratorError` an informative error according to [RFC-22](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0022_error_context_and_compatibility.md).
- Renames `ConnectorError::is_other` to `as_other` and adds an equivalent `is_other` that returns a boolean.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
