### PR TITLE
New-type the interceptor context `Input`, `Output`, and `Error`

### DIFF
--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -365,8 +365,6 @@ mod loader {
             self
         }
 
-        // TODO(enableNewSmithyRuntimeLaunch): Remove the doc hidden from this function
-        #[doc(hidden)]
         /// Don't use credentials to sign requests.
         ///
         /// Turning off signing with credentials is necessary in some cases, such as using

--- a/aws/rust-runtime/aws-inlineable/src/glacier_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/glacier_interceptors.rs
@@ -240,9 +240,8 @@ fn compute_hash_tree(mut hashes: Vec<Digest>) -> Digest {
 #[cfg(test)]
 mod account_id_autofill_tests {
     use super::*;
-    use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
+    use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
-    use aws_smithy_types::type_erasure::TypedBox;
 
     #[test]
     fn autofill_account_id() {
@@ -258,8 +257,7 @@ mod account_id_autofill_tests {
 
         let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
         let mut cfg = ConfigBag::base();
-        let mut context =
-            InterceptorContext::new(TypedBox::new(SomeInput { account_id: None }).erase());
+        let mut context = InterceptorContext::new(Input::erase(SomeInput { account_id: None }));
         let mut context = BeforeSerializationInterceptorContextMut::from(&mut context);
         let interceptor = GlacierAccountIdAutofillInterceptor::<SomeInput>::new();
         interceptor
@@ -281,15 +279,14 @@ mod account_id_autofill_tests {
 #[cfg(test)]
 mod api_version_tests {
     use super::*;
-    use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
+    use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
-    use aws_smithy_types::type_erasure::TypedBox;
 
     #[test]
     fn api_version_interceptor() {
         let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
         let mut cfg = ConfigBag::base();
-        let mut context = InterceptorContext::new(TypedBox::new("dontcare").erase());
+        let mut context = InterceptorContext::new(Input::doesnt_matter());
         context.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
         let mut context = BeforeTransmitInterceptorContextMut::from(&mut context);
 

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -211,12 +211,11 @@ mod tests {
     use super::*;
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_runtime_api::client::interceptors::context::{
-        BeforeTransmitInterceptorContextMut, InterceptorContext,
+        BeforeTransmitInterceptorContextMut, Input, InterceptorContext,
     };
     use aws_smithy_runtime_api::client::interceptors::Interceptor;
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use aws_smithy_types::config_bag::{ConfigBag, Layer};
-    use aws_smithy_types::type_erasure::TypeErasedBox;
     use http::HeaderValue;
 
     fn expect_header<'a>(
@@ -229,7 +228,7 @@ mod tests {
     #[test]
     fn default_id_generator() {
         let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
-        let mut ctx = InterceptorContext::new(TypeErasedBox::doesnt_matter());
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.enter_serialization_phase();
         ctx.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
         let _ = ctx.take_input();
@@ -256,7 +255,7 @@ mod tests {
     #[test]
     fn custom_id_generator() {
         let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
-        let mut ctx = InterceptorContext::new(TypeErasedBox::doesnt_matter());
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.enter_serialization_phase();
         ctx.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
         let _ = ctx.take_input();

--- a/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
+++ b/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
@@ -76,9 +76,8 @@ mod tests {
     use super::*;
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_protocol_test::{assert_ok, validate_headers};
-    use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
+    use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
-    use aws_smithy_types::type_erasure::TypeErasedBox;
     use aws_types::os_shim_internal::Env;
     use http::HeaderValue;
     use proptest::{prelude::*, proptest};
@@ -152,7 +151,7 @@ mod tests {
             request = request.header(name, value);
         }
         let request = request.body(SdkBody::empty()).expect("must be valid");
-        let mut context = InterceptorContext::new(TypeErasedBox::doesnt_matter());
+        let mut context = InterceptorContext::new(Input::doesnt_matter());
         context.enter_serialization_phase();
         context.set_request(request);
         let _ = context.take_input();

--- a/aws/rust-runtime/aws-runtime/src/request_info.rs
+++ b/aws/rust-runtime/aws-runtime/src/request_info.rs
@@ -166,13 +166,12 @@ mod tests {
     use super::RequestInfoInterceptor;
     use crate::request_info::RequestPairs;
     use aws_smithy_http::body::SdkBody;
-    use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
+    use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
     use aws_smithy_runtime_api::client::interceptors::Interceptor;
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use aws_smithy_types::config_bag::{ConfigBag, Layer};
     use aws_smithy_types::retry::RetryConfig;
     use aws_smithy_types::timeout::TimeoutConfig;
-    use aws_smithy_types::type_erasure::TypeErasedBox;
     use http::HeaderValue;
     use std::time::Duration;
 
@@ -190,7 +189,7 @@ mod tests {
     #[test]
     fn test_request_pairs_for_initial_attempt() {
         let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
-        let mut context = InterceptorContext::new(TypeErasedBox::doesnt_matter());
+        let mut context = InterceptorContext::new(Input::doesnt_matter());
         context.enter_serialization_phase();
         context.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
 

--- a/aws/rust-runtime/aws-runtime/src/retries/classifier.rs
+++ b/aws/rust-runtime/aws-runtime/src/retries/classifier.rs
@@ -107,9 +107,9 @@ impl ClassifyRetry for AmzRetryAfterHeaderClassifier {
 mod test {
     use super::*;
     use aws_smithy_http::body::SdkBody;
+    use aws_smithy_runtime_api::client::interceptors::context::{Error, Input};
     use aws_smithy_types::error::ErrorMetadata;
     use aws_smithy_types::retry::{ErrorKind, ProvideErrorKind};
-    use aws_smithy_types::type_erasure::{TypeErasedBox, TypeErasedError};
     use std::fmt;
     use std::time::Duration;
 
@@ -164,8 +164,8 @@ mod test {
     #[test]
     fn classify_by_error_code() {
         let policy = AwsErrorCodeClassifier::<CodedError>::new();
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
-        ctx.set_output_or_error(Err(OrchestratorError::operation(TypeErasedError::new(
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
+        ctx.set_output_or_error(Err(OrchestratorError::operation(Error::erase(
             CodedError::new("Throttling"),
         ))));
 
@@ -174,8 +174,8 @@ mod test {
             Some(RetryReason::Error(ErrorKind::ThrottlingError))
         );
 
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
-        ctx.set_output_or_error(Err(OrchestratorError::operation(TypeErasedError::new(
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
+        ctx.set_output_or_error(Err(OrchestratorError::operation(Error::erase(
             CodedError::new("RequestTimeout"),
         ))));
         assert_eq!(
@@ -190,9 +190,9 @@ mod test {
         let err = aws_smithy_types::Error::builder().code("SlowDown").build();
         let test_response = http::Response::new("OK").map(SdkBody::from);
 
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.set_response(test_response);
-        ctx.set_output_or_error(Err(OrchestratorError::operation(TypeErasedError::new(err))));
+        ctx.set_output_or_error(Err(OrchestratorError::operation(Error::erase(err))));
 
         assert_eq!(
             policy.classify_retry(&ctx),
@@ -208,9 +208,9 @@ mod test {
             .body("retry later")
             .unwrap()
             .map(SdkBody::from);
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.set_response(res);
-        ctx.set_output_or_error(Err(OrchestratorError::operation(TypeErasedError::new(
+        ctx.set_output_or_error(Err(OrchestratorError::operation(Error::erase(
             UnmodeledError,
         ))));
 

--- a/aws/rust-runtime/aws-runtime/src/user_agent.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent.rs
@@ -110,12 +110,11 @@ impl Interceptor for UserAgentInterceptor {
 mod tests {
     use super::*;
     use aws_smithy_http::body::SdkBody;
-    use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
+    use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
     use aws_smithy_runtime_api::client::interceptors::Interceptor;
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use aws_smithy_types::config_bag::{ConfigBag, Layer};
     use aws_smithy_types::error::display::DisplayErrorContext;
-    use aws_smithy_types::type_erasure::TypeErasedBox;
 
     fn expect_header<'a>(context: &'a InterceptorContext, header_name: &str) -> &'a str {
         context
@@ -129,7 +128,7 @@ mod tests {
     }
 
     fn context() -> InterceptorContext {
-        let mut context = InterceptorContext::new(TypeErasedBox::doesnt_matter());
+        let mut context = InterceptorContext::new(Input::doesnt_matter());
         context.enter_serialization_phase();
         context.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
         let _ = context.take_input();

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -151,7 +151,6 @@ fn signing_config(
         request_ts: config
             .get::<SharedTimeSource>()
             .map(|t| t.now())
-            // TODO(enableNewSmithyRuntimeLaunch): Remove this fallback
             .unwrap_or_else(|| SharedTimeSource::default().now()),
         region,
         payload_override,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -105,10 +105,6 @@ class AwsFluentClientDecorator : ClientCodegenDecorator {
         renderClientCreation = { params ->
             rust("let mut ${params.configBuilderName} = ${params.configBuilderName};")
             if (codegenContext.smithyRuntimeMode.generateOrchestrator) {
-                // TODO(enableNewSmithyRuntimeLaunch): A builder field could not be accessed directly in the orchestrator
-                //  mode when this code change was made. smithy-rs#2792 will enable us to use getters in builders.
-                //  Make this `set_region` conditional by checking if `config_builder.region().is_none()` once the PR
-                //  has been merged to main.
                 rust("""${params.configBuilderName}.set_region(Some(crate::config::Region::new("us-east-1")));""")
             } else {
                 rust(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -336,9 +336,7 @@ class AwsPresignedFluentBuilderMethod(
                 .await
                 .map_err(|err| {
                     err.map_service_error(|err| {
-                        #{TypedBox}::<#{OperationError}>::assume_from(err.into())
-                            .expect("correct error type")
-                            .unwrap()
+                        err.downcast::<#{OperationError}>().expect("correct error type")
                     })
                 })?;
             let request = context.take_request().expect("request set before transmit");
@@ -353,7 +351,6 @@ class AwsPresignedFluentBuilderMethod(
             "SigV4PresigningRuntimePlugin" to AwsRuntimeType.presigningInterceptor(runtimeConfig)
                 .resolve("SigV4PresigningRuntimePlugin"),
             "StopPoint" to RuntimeType.smithyRuntime(runtimeConfig).resolve("client::orchestrator::StopPoint"),
-            "TypedBox" to RuntimeType.smithyTypes(runtimeConfig).resolve("type_erasure::TypedBox"),
             "USER_AGENT" to CargoDependency.Http.toType().resolve("header::USER_AGENT"),
             "alternate_presigning_serializer" to writable {
                 if (presignableOp.hasModelTransforms()) {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -414,7 +414,7 @@ class DefaultProtocolTestGenerator(
                 rust("let parsed = parsed.unwrap();")
             } else {
                 rustTemplate(
-                    """let parsed: #{Output} = *parsed.expect("should be successful response").downcast().unwrap();""",
+                    """let parsed = parsed.expect("should be successful response").downcast::<#{Output}>().unwrap();""",
                     "Output" to codegenContext.symbolProvider.toSymbol(expectedShape),
                 )
             }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
@@ -56,7 +56,6 @@ class RequestSerializerGenerator(
                     codegenContext.runtimeConfig,
                 ),
             ).resolve("HeaderSerializationSettings"),
-            "TypedBox" to smithyTypes.resolve("type_erasure::TypedBox"),
         )
     }
 
@@ -72,7 +71,7 @@ class RequestSerializerGenerator(
             impl #{RequestSerializer} for $serializerName {
                 ##[allow(unused_mut, clippy::let_and_return, clippy::needless_borrow, clippy::useless_conversion)]
                 fn serialize_input(&self, input: #{Input}, _cfg: &mut #{ConfigBag}) -> #{Result}<#{HttpRequest}, #{BoxError}> {
-                    let input = #{TypedBox}::<#{ConcreteInput}>::assume_from(input).expect("correct type").unwrap();
+                    let input = input.downcast::<#{ConcreteInput}>().expect("correct type");
                     let _header_serialization_settings = _cfg.load::<#{HeaderSerializationSettings}>().cloned().unwrap_or_default();
                     let mut request_builder = {
                         #{create_http_request}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
@@ -47,7 +47,6 @@ class ResponseDeserializerGenerator(
             "ResponseDeserializer" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::ser_de::ResponseDeserializer"),
             "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
             "SdkError" to RuntimeType.sdkError(runtimeConfig),
-            "TypedBox" to RuntimeType.smithyTypes(runtimeConfig).resolve("type_erasure::TypedBox"),
             "debug_span" to RuntimeType.Tracing.resolve("debug_span"),
             "type_erase_result" to typeEraseResult(),
         )
@@ -162,8 +161,8 @@ class ResponseDeserializerGenerator(
                 O: ::std::fmt::Debug + #{Send} + #{Sync} + 'static,
                 E: ::std::error::Error + std::fmt::Debug + #{Send} + #{Sync} + 'static,
             {
-                result.map(|output| #{TypedBox}::new(output).erase())
-                    .map_err(|error| #{TypedBox}::new(error).erase_error())
+                result.map(|output| #{Output}::erase(output))
+                    .map_err(|error| #{Error}::erase(error))
                     .map_err(#{Into}::into)
             }
             """,

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGeneratorTest.kt
@@ -174,6 +174,7 @@ internal class ConfigOverrideRuntimePluginGeneratorTest {
                     .resolve("client::retries::AlwaysRetry"),
                 "ConfigBag" to RuntimeType.smithyTypes(runtimeConfig).resolve("config_bag::ConfigBag"),
                 "ErrorKind" to RuntimeType.smithyTypes(runtimeConfig).resolve("retry::ErrorKind"),
+                "Input" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::interceptors::context::Input"),
                 "InterceptorContext" to RuntimeType.interceptorContext(runtimeConfig),
                 "Layer" to RuntimeType.smithyTypes(runtimeConfig).resolve("config_bag::Layer"),
                 "OrchestratorError" to RuntimeType.smithyRuntimeApi(runtimeConfig)
@@ -188,7 +189,6 @@ internal class ConfigOverrideRuntimePluginGeneratorTest {
                 "RuntimePlugin" to RuntimeType.runtimePlugin(runtimeConfig),
                 "ShouldAttempt" to RuntimeType.smithyRuntimeApi(runtimeConfig)
                     .resolve("client::retries::ShouldAttempt"),
-                "TypeErasedBox" to RuntimeType.smithyTypes(runtimeConfig).resolve("type_erasure::TypeErasedBox"),
             )
             rustCrate.testModule {
                 unitTest("test_operation_overrides_retry_strategy") {
@@ -201,7 +201,7 @@ internal class ConfigOverrideRuntimePluginGeneratorTest {
                             .retry_config(#{RetryConfig}::standard().with_max_attempts(3))
                             .build();
 
-                        let mut ctx = #{InterceptorContext}::new(#{TypeErasedBox}::new(()));
+                        let mut ctx = #{InterceptorContext}::new(#{Input}::doesnt_matter());
                         ctx.set_output_or_error(#{Err}(#{OrchestratorError}::other("doesn't matter")));
 
                         let mut layer = #{Layer}::new("test");

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
@@ -98,8 +98,8 @@ private class TestOperationCustomization(
                             crate::operation::say_hello::SayHelloError,
                         > = $fakeOutput;
                         fake_out
-                            .map(|o| #{TypedBox}::new(o).erase())
-                            .map_err(|e| #{OrchestratorError}::operation(#{TypedBox}::new(e).erase_error()))
+                            .map(|o| #{Output}::erase(o))
+                            .map_err(|e| #{OrchestratorError}::operation(#{Error}::erase(e)))
                     }
                 }
                 cfg.store_put(#{SharedResponseDeserializer}::new(TestDeser));
@@ -111,7 +111,6 @@ private class TestOperationCustomization(
                 "OrchestratorError" to RT.smithyRuntimeApi(rc).resolve("client::orchestrator::OrchestratorError"),
                 "Output" to RT.smithyRuntimeApi(rc).resolve("client::interceptors::context::Output"),
                 "ResponseDeserializer" to RT.smithyRuntimeApi(rc).resolve("client::ser_de::ResponseDeserializer"),
-                "TypedBox" to RT.smithyTypes(rc).resolve("type_erasure::TypedBox"),
             )
         }
     }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
@@ -10,7 +10,7 @@ use crate::client::identity::{Identity, SharedIdentityResolver};
 use crate::client::orchestrator::HttpRequest;
 use crate::client::runtime_components::{GetIdentityResolver, RuntimeComponents};
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
-use aws_smithy_types::type_erasure::{TypeErasedBox, TypedBox};
+use aws_smithy_types::type_erasure::TypeErasedBox;
 use aws_smithy_types::Document;
 use std::borrow::Cow;
 use std::fmt;
@@ -66,7 +66,7 @@ pub struct AuthSchemeOptionResolverParams(TypeErasedBox);
 impl AuthSchemeOptionResolverParams {
     /// Creates a new [`AuthSchemeOptionResolverParams`].
     pub fn new<T: fmt::Debug + Send + Sync + 'static>(params: T) -> Self {
-        Self(TypedBox::new(params).erase())
+        Self(TypeErasedBox::new(params))
     }
 
     /// Returns the underlying parameters as the type `T` if they are that type.

--- a/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
@@ -8,7 +8,7 @@
 use crate::client::orchestrator::Future;
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use aws_smithy_types::endpoint::Endpoint;
-use aws_smithy_types::type_erasure::{TypeErasedBox, TypedBox};
+use aws_smithy_types::type_erasure::TypeErasedBox;
 use std::fmt;
 use std::sync::Arc;
 
@@ -23,7 +23,7 @@ pub struct EndpointResolverParams(TypeErasedBox);
 impl EndpointResolverParams {
     /// Creates a new [`EndpointResolverParams`] from a concrete parameters instance.
     pub fn new<T: fmt::Debug + Send + Sync + 'static>(params: T) -> Self {
-        Self(TypedBox::new(params).erase())
+        Self(TypeErasedBox::new(params))
     }
 
     /// Attempts to downcast the underlying concrete parameters to `T` and return it as a reference.

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
@@ -36,13 +36,65 @@ use std::fmt::Debug;
 use std::{fmt, mem};
 use tracing::{debug, error, trace};
 
-// TODO(enableNewSmithyRuntimeLaunch): New-type `Input`/`Output`/`Error`
-/// Type-erased operation input.
-pub type Input = TypeErasedBox;
-/// Type-erased operation output.
-pub type Output = TypeErasedBox;
-/// Type-erased operation error.
-pub type Error = TypeErasedError;
+macro_rules! new_type_box {
+    ($name:ident, $doc:literal) => {
+        new_type_box!($name, TypeErasedBox, $doc, Send, Sync, fmt::Debug,);
+    };
+    ($name:ident, $underlying:ident, $doc:literal, $($additional_bound:path,)*) => {
+        #[doc = $doc]
+        #[derive(Debug)]
+        pub struct $name($underlying);
+
+        impl $name {
+            #[doc = concat!("Creates a new `", stringify!($name), "` with the provided concrete input value.")]
+            pub fn erase<T: $($additional_bound +)* Send + Sync + fmt::Debug + 'static>(input: T) -> Self {
+                Self($underlying::new(input))
+            }
+
+            #[doc = concat!("Downcasts to the concrete input value.")]
+            pub fn downcast_ref<T: $($additional_bound +)* Send + Sync + fmt::Debug + 'static>(&self) -> Option<&T> {
+                self.0.downcast_ref()
+            }
+
+            #[doc = concat!("Downcasts to the concrete input value.")]
+            pub fn downcast_mut<T: $($additional_bound +)* Send + Sync + fmt::Debug + 'static>(&mut self) -> Option<&mut T> {
+                self.0.downcast_mut()
+            }
+
+            #[doc = concat!("Downcasts to the concrete input value.")]
+            pub fn downcast<T: $($additional_bound +)* Send + Sync + fmt::Debug + 'static>(self) -> Result<T, Self> {
+                self.0.downcast::<T>().map(|v| *v).map_err(Self)
+            }
+
+            #[doc = concat!("Returns a `", stringify!($name), "` with a fake/test value with the expectation that it won't be downcast in the test.")]
+            #[cfg(feature = "test-util")]
+            pub fn doesnt_matter() -> Self {
+                Self($underlying::doesnt_matter())
+            }
+        }
+    };
+}
+
+new_type_box!(Input, "Type-erased operation input.");
+new_type_box!(Output, "Type-erased operation output.");
+new_type_box!(
+    Error,
+    TypeErasedError,
+    "Type-erased operation error.",
+    std::error::Error,
+);
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
 /// Type-erased result for an operation.
 pub type OutputOrError = Result<Output, OrchestratorError<Error>>;
 
@@ -395,23 +447,16 @@ fn try_clone(request: &HttpRequest) -> Option<HttpRequest> {
 mod tests {
     use super::*;
     use aws_smithy_http::body::SdkBody;
-    use aws_smithy_types::type_erasure::TypedBox;
     use http::header::{AUTHORIZATION, CONTENT_LENGTH};
     use http::{HeaderValue, Uri};
 
     #[test]
     fn test_success_transitions() {
-        let input = TypedBox::new("input".to_string()).erase();
-        let output = TypedBox::new("output".to_string()).erase();
+        let input = Input::doesnt_matter();
+        let output = Output::erase("output".to_string());
 
         let mut context = InterceptorContext::new(input);
-        assert_eq!(
-            "input",
-            context
-                .input()
-                .and_then(|i| i.downcast_ref::<String>())
-                .unwrap()
-        );
+        assert!(context.input().is_some());
         context.input_mut();
 
         context.enter_serialization_phase();
@@ -447,29 +492,13 @@ mod tests {
 
     #[test]
     fn test_rewind_for_retry() {
-        use std::fmt;
-        #[derive(Debug)]
-        struct Error;
-        impl fmt::Display for Error {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.write_str("don't care")
-            }
-        }
-        impl std::error::Error for Error {}
-
         let mut cfg = ConfigBag::base();
-        let input = TypedBox::new("input".to_string()).erase();
-        let output = TypedBox::new("output".to_string()).erase();
-        let error = TypedBox::new(Error).erase_error();
+        let input = Input::doesnt_matter();
+        let output = Output::erase("output".to_string());
+        let error = Error::doesnt_matter();
 
         let mut context = InterceptorContext::new(input);
-        assert_eq!(
-            "input",
-            context
-                .input()
-                .and_then(|i| i.downcast_ref::<String>())
-                .unwrap()
-        );
+        assert!(context.input().is_some());
 
         context.enter_serialization_phase();
         let _ = context.take_input();

--- a/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
@@ -18,12 +18,12 @@
 
 use crate::box_error::BoxError;
 use crate::client::interceptors::context::phase::Phase;
+use crate::client::interceptors::context::Error;
 use crate::client::interceptors::InterceptorError;
 use aws_smithy_async::future::now_or_later::NowOrLater;
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_http::result::{ConnectorError, SdkError};
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
-use aws_smithy_types::type_erasure::TypeErasedError;
 use bytes::Bytes;
 use std::fmt::Debug;
 use std::future::Future as StdFuture;
@@ -247,8 +247,8 @@ where
     }
 }
 
-impl From<TypeErasedError> for OrchestratorError<TypeErasedError> {
-    fn from(err: TypeErasedError) -> Self {
+impl From<Error> for OrchestratorError<Error> {
+    fn from(err: Error) -> Self {
         Self::operation(err)
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
@@ -368,7 +368,11 @@ mod tests {
         );
 
         Interceptors::new(rc.interceptors())
-            .read_before_transmit(&InterceptorContext::new(Input::new(5)), &rc, &mut cfg)
+            .read_before_transmit(
+                &InterceptorContext::new(Input::doesnt_matter()),
+                &rc,
+                &mut cfg,
+            )
             .expect_err("interceptor returns error");
         cfg.interceptor_state()
             .store_put(disable_interceptor::<PanicInterceptor>("test"));
@@ -381,7 +385,11 @@ mod tests {
         );
         // shouldn't error because interceptors won't run
         Interceptors::new(rc.interceptors())
-            .read_before_transmit(&InterceptorContext::new(Input::new(5)), &rc, &mut cfg)
+            .read_before_transmit(
+                &InterceptorContext::new(Input::doesnt_matter()),
+                &rc,
+                &mut cfg,
+            )
             .expect("interceptor is now disabled");
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -445,7 +445,6 @@ mod tests {
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use aws_smithy_runtime_api::client::runtime_plugin::{RuntimePlugin, RuntimePlugins};
     use aws_smithy_types::config_bag::{ConfigBag, FrozenLayer, Layer};
-    use aws_smithy_types::type_erasure::{TypeErasedBox, TypedBox};
     use std::borrow::Cow;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
@@ -465,7 +464,7 @@ mod tests {
                 .status(StatusCode::OK)
                 .body(SdkBody::empty())
                 .map_err(|err| OrchestratorError::other(Box::new(err)))
-                .map(|res| Output::new(Box::new(res))),
+                .map(|res| Output::erase(res)),
         )
     }
 
@@ -603,7 +602,7 @@ mod tests {
                 }
             }
 
-            let input = TypeErasedBox::new(Box::new(()));
+            let input = Input::doesnt_matter();
             let runtime_plugins = RuntimePlugins::new()
                 .with_client_plugin(FailingInterceptorsClientRuntimePlugin::new())
                 .with_operation_plugin(TestOperationRuntimePlugin::new())
@@ -883,7 +882,7 @@ mod tests {
                 }
             }
 
-            let input = TypeErasedBox::new(Box::new(()));
+            let input = Input::doesnt_matter();
             let runtime_plugins = RuntimePlugins::new()
                 .with_operation_plugin(TestOperationRuntimePlugin::new())
                 .with_operation_plugin(NoAuthRuntimePlugin::new())
@@ -1135,7 +1134,7 @@ mod tests {
         let context = invoke_with_stop_point(
             "test",
             "test",
-            TypedBox::new(()).erase(),
+            Input::doesnt_matter(),
             &runtime_plugins(),
             StopPoint::None,
         )
@@ -1147,7 +1146,7 @@ mod tests {
         let context = invoke_with_stop_point(
             "test",
             "test",
-            TypedBox::new(()).erase(),
+            Input::doesnt_matter(),
             &runtime_plugins(),
             StopPoint::BeforeTransmit,
         )
@@ -1233,7 +1232,7 @@ mod tests {
         let context = invoke_with_stop_point(
             "test",
             "test",
-            TypedBox::new(()).erase(),
+            Input::doesnt_matter(),
             &runtime_plugins(),
             StopPoint::BeforeTransmit,
         )

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -161,13 +161,12 @@ mod tests {
     use aws_smithy_runtime_api::client::identity::{
         Identity, IdentityResolver, SharedIdentityResolver,
     };
-    use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
+    use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
     use aws_smithy_runtime_api::client::orchestrator::{Future, HttpRequest};
     use aws_smithy_runtime_api::client::runtime_components::{
         GetIdentityResolver, RuntimeComponentsBuilder,
     };
     use aws_smithy_types::config_bag::Layer;
-    use aws_smithy_types::type_erasure::TypedBox;
     use std::collections::HashMap;
 
     #[tokio::test]
@@ -222,7 +221,7 @@ mod tests {
             }
         }
 
-        let mut ctx = InterceptorContext::new(TypedBox::new("doesnt-matter").erase());
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.enter_serialization_phase();
         ctx.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
         let _ = ctx.take_input();
@@ -268,7 +267,7 @@ mod tests {
         };
         use aws_smithy_runtime_api::client::identity::http::{Login, Token};
 
-        let mut ctx = InterceptorContext::new(TypedBox::new("doesnt-matter").erase());
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.enter_serialization_phase();
         ctx.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
         let _ = ctx.take_input();
@@ -317,7 +316,7 @@ mod tests {
         // Next, test the presence of a bearer token and absence of basic auth
         let (runtime_components, cfg) =
             config_with_identity(HTTP_BEARER_AUTH_SCHEME_ID, Token::new("t", None));
-        let mut ctx = InterceptorContext::new(TypedBox::new("doesnt-matter").erase());
+        let mut ctx = InterceptorContext::new(Input::erase("doesnt-matter"));
         ctx.enter_serialization_phase();
         ctx.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
         let _ = ctx.take_input();

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/classifier.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/classifier.rs
@@ -150,11 +150,10 @@ mod test {
         HttpStatusCodeClassifier, ModeledAsRetryableClassifier,
     };
     use aws_smithy_http::body::SdkBody;
-    use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
+    use aws_smithy_runtime_api::client::interceptors::context::{Error, Input, InterceptorContext};
     use aws_smithy_runtime_api::client::orchestrator::OrchestratorError;
     use aws_smithy_runtime_api::client::retries::{ClassifyRetry, RetryReason};
     use aws_smithy_types::retry::{ErrorKind, ProvideErrorKind};
-    use aws_smithy_types::type_erasure::{TypeErasedBox, TypeErasedError};
     use std::fmt;
 
     use super::SmithyErrorClassifier;
@@ -178,7 +177,7 @@ mod test {
             .body("error!")
             .unwrap()
             .map(SdkBody::from);
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.set_response(res);
         assert_eq!(
             policy.classify_retry(&ctx),
@@ -194,7 +193,7 @@ mod test {
             .body("error!")
             .unwrap()
             .map(SdkBody::from);
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.set_response(res);
         assert_eq!(policy.classify_retry(&ctx), None);
     }
@@ -224,8 +223,8 @@ mod test {
         impl std::error::Error for RetryableError {}
 
         let policy = ModeledAsRetryableClassifier::<RetryableError>::new();
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
-        ctx.set_output_or_error(Err(OrchestratorError::operation(TypeErasedError::new(
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
+        ctx.set_output_or_error(Err(OrchestratorError::operation(Error::erase(
             RetryableError,
         ))));
 
@@ -238,7 +237,7 @@ mod test {
     #[test]
     fn classify_response_error() {
         let policy = SmithyErrorClassifier::<UnmodeledError>::new();
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.set_output_or_error(Err(OrchestratorError::response(
             "I am a response error".into(),
         )));
@@ -251,7 +250,7 @@ mod test {
     #[test]
     fn test_timeout_error() {
         let policy = SmithyErrorClassifier::<UnmodeledError>::new();
-        let mut ctx = InterceptorContext::new(TypeErasedBox::new("doesntmatter"));
+        let mut ctx = InterceptorContext::new(Input::doesnt_matter());
         ctx.set_output_or_error(Err(OrchestratorError::timeout(
             "I am a timeout error".into(),
         )));

--- a/rust-runtime/aws-smithy-types/src/type_erasure.rs
+++ b/rust-runtime/aws-smithy-types/src/type_erasure.rs
@@ -6,125 +6,34 @@
 use std::any::Any;
 use std::error::Error as StdError;
 use std::fmt;
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-/// A [`TypeErasedBox`] with type information tracked via generics at compile-time
-///
-/// `TypedBox` is used to transition to/from a `TypeErasedBox`. A `TypedBox<T>` can only
-/// be created from a `T` or from a `TypeErasedBox` value that _is a_ `T`. Therefore, it can
-/// be assumed to be a `T` even though the underlying storage is still a `TypeErasedBox`.
-/// Since the `T` is only used in `PhantomData`, it gets compiled down to just a `TypeErasedBox`.
+/// Abstraction over `Box<dyn T + Send + Sync>` that provides `Debug` and optionally `Clone`.
 ///
 /// The orchestrator uses `TypeErasedBox` to avoid the complication of six or more generic parameters
-/// and to avoid the monomorphization that brings with it. This `TypedBox` will primarily be useful
-/// for operation-specific or service-specific interceptors that need to operate on the actual
-/// input/output/error types.
-pub struct TypedBox<T> {
-    inner: TypeErasedBox,
-    _phantom: PhantomData<T>,
-}
-
-impl<T> TypedBox<T>
-where
-    T: fmt::Debug + Send + Sync + 'static,
-{
-    /// Creates a new `TypedBox` from `inner` of type `T`
-    pub fn new(inner: T) -> Self {
-        Self {
-            inner: TypeErasedBox::new(inner),
-            _phantom: Default::default(),
-        }
-    }
-
-    /// Tries to create a `TypedBox<T>` from a `TypeErasedBox`.
-    ///
-    /// If the `TypedBox<T>` can't be created due to the `TypeErasedBox`'s value consisting
-    /// of another type, then the original `TypeErasedBox` will be returned in the `Err` variant.
-    pub fn assume_from(type_erased: TypeErasedBox) -> Result<TypedBox<T>, TypeErasedBox> {
-        if type_erased.downcast_ref::<T>().is_some() {
-            Ok(TypedBox {
-                inner: type_erased,
-                _phantom: Default::default(),
-            })
-        } else {
-            Err(type_erased)
-        }
-    }
-
-    /// Converts the `TypedBox<T>` back into `T`.
-    pub fn unwrap(self) -> T {
-        *self.inner.downcast::<T>().expect("type checked")
-    }
-
-    /// Converts the `TypedBox<T>` into a `TypeErasedBox`.
-    pub fn erase(self) -> TypeErasedBox {
-        self.inner
-    }
-}
-
-impl<T> TypedBox<T>
-where
-    T: StdError + fmt::Debug + Send + Sync + 'static,
-{
-    /// Converts `TypedBox<T>` to a `TypeErasedError` where `T` implements `Error`.
-    pub fn erase_error(self) -> TypeErasedError {
-        TypeErasedError::new(self.unwrap())
-    }
-}
-
-impl<T> fmt::Debug for TypedBox<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("TypedBox:")?;
-        (self.inner.debug)(&self.inner.field, f)
-    }
-}
-
-impl<T: fmt::Debug + Send + Sync + 'static> Deref for TypedBox<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.inner.downcast_ref().expect("type checked")
-    }
-}
-
-impl<T: fmt::Debug + Send + Sync + 'static> DerefMut for TypedBox<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.inner.downcast_mut().expect("type checked")
-    }
-}
-
-/// Abstraction over `Box<dyn T + Send + Sync>` that provides `Debug` and optionally `Clone`.
+/// and to avoid the monomorphization that brings with it.
 ///
 /// # Examples
 ///
 /// Creating a box:
 /// ```no_run
-/// use aws_smithy_types::type_erasure::{TypedBox, TypeErasedBox};
+/// use aws_smithy_types::type_erasure::TypeErasedBox;
 ///
-/// // Creating it directly:
 /// let boxed = TypeErasedBox::new("some value");
-///
-/// // Creating it from a `TypedBox`:
-/// let boxed = TypedBox::new("some value").erase();
 /// ```
 ///
 /// Downcasting a box:
 /// ```no_run
-/// # use aws_smithy_types::type_erasure::{TypedBox, TypeErasedBox};
-/// # let boxed = TypedBox::new("some value".to_string()).erase();
+/// # use aws_smithy_types::type_erasure::TypeErasedBox;
+/// # let boxed = TypeErasedBox::new("some value".to_string());
 /// let value: Option<&String> = boxed.downcast_ref::<String>();
 /// ```
 ///
 /// Converting a box back into its value:
 /// ```
-/// # use aws_smithy_types::type_erasure::{TypedBox, TypeErasedBox};
-/// let boxed = TypedBox::new("some value".to_string()).erase();
-/// let value: String = TypedBox::<String>::assume_from(boxed).expect("it is a string").unwrap();
+/// # use aws_smithy_types::type_erasure::TypeErasedBox;
+/// let boxed = TypeErasedBox::new("some value".to_string());
+/// let value: String = *boxed.downcast::<String>().expect("it is a string");
 /// ```
 pub struct TypeErasedBox {
     field: Box<dyn Any + Send + Sync>,
@@ -302,56 +211,31 @@ impl TypeErasedError {
     ) -> Option<&mut T> {
         self.field.downcast_mut()
     }
+
+    /// Returns a `TypeErasedError` with a fake/test value with the expectation that it won't be downcast in the test.
+    #[cfg(feature = "test-util")]
+    pub fn doesnt_matter() -> Self {
+        #[derive(Debug)]
+        struct FakeError;
+        impl fmt::Display for FakeError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "FakeError")
+            }
+        }
+        impl StdError for FakeError {}
+        Self::new(FakeError)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{TypeErasedBox, TypeErasedError, TypedBox};
+    use super::{TypeErasedBox, TypeErasedError};
     use std::fmt;
 
     #[derive(Debug)]
     struct Foo(&'static str);
     #[derive(Debug)]
     struct Bar(isize);
-
-    #[test]
-    fn test_typed_boxes() {
-        let foo = TypedBox::new(Foo("1"));
-        let bar = TypedBox::new(Bar(2));
-
-        assert_eq!("TypedBox:Foo(\"1\")", format!("{foo:?}"));
-        assert_eq!("TypedBox:Bar(2)", format!("{bar:?}"));
-
-        let mut foo_erased = foo.erase();
-        foo_erased
-            .downcast_mut::<Foo>()
-            .expect("I know its a Foo")
-            .0 = "3";
-
-        let bar_erased = bar.erase();
-        assert_eq!(
-            "TypeErasedBox[!Clone]:Foo(\"3\")",
-            format!("{foo_erased:?}")
-        );
-        assert_eq!("TypeErasedBox[!Clone]:Bar(2)", format!("{bar_erased:?}"));
-
-        let bar_erased = TypedBox::<Foo>::assume_from(bar_erased).expect_err("it's not a Foo");
-        let mut bar = TypedBox::<Bar>::assume_from(bar_erased).expect("it's a Bar");
-        assert_eq!(2, bar.0);
-        bar.0 += 1;
-
-        let bar = bar.unwrap();
-        assert_eq!(3, bar.0);
-
-        assert!(foo_erased.downcast_ref::<Bar>().is_none());
-        assert!(foo_erased.downcast_mut::<Bar>().is_none());
-        let mut foo_erased = foo_erased.downcast::<Bar>().expect_err("it's not a Bar");
-
-        assert_eq!("3", foo_erased.downcast_ref::<Foo>().expect("it's a Foo").0);
-        foo_erased.downcast_mut::<Foo>().expect("it's a Foo").0 = "4";
-        let foo = *foo_erased.downcast::<Foo>().expect("it's a Foo");
-        assert_eq!("4", foo.0);
-    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct TestErr {
@@ -385,10 +269,10 @@ mod tests {
     #[test]
     fn test_typed_erased_errors_can_be_unwrapped() {
         let test_err = TestErr::new("something failed!");
-        let type_erased_test_err = TypedBox::new(test_err.clone()).erase_error();
-        let actual = TypedBox::<TestErr>::assume_from(type_erased_test_err.into())
-            .expect("type erased error can be downcast into original type")
-            .unwrap();
+        let type_erased_test_err = TypeErasedError::new(test_err.clone());
+        let actual = *type_erased_test_err
+            .downcast::<TestErr>()
+            .expect("type erased error can be downcast into original type");
         assert_eq!(test_err, actual);
     }
 

--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -34,12 +34,8 @@ def main(skip_generation=False):
     os.chdir(sdk_directory)
 
     failed = False
-    # TODO(enableNewSmithyRuntimeLaunch): Remove the deny list below
     deny_list = [
-        "aws-runtime",
-        "aws-runtime-api",
-        "aws-smithy-runtime",
-        "aws-smithy-runtime-api",
+        # add crate names here to exclude them from the semver checks
     ]
     for path in os.listdir():
         eprint(f'checking {path}...', end='')


### PR DESCRIPTION
This PR creates new-types for `Input`, `Output`, and `Error` so that the type system can enforce that an output isn't given to an input and vice versa. It also removes `TypedBox` since that isn't really needed anymore.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
