### PR TITLE
Share HTTP connectors between providers and clients

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -665,6 +665,12 @@ references = ["smithy-rs#2865"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
 author = "david-perez"
 
+[[aws-sdk-rust]]
+message = "**Behavior change**: Credential providers now share the HTTP connector used by the SDK. If you want to keep a separate connector for clients, use `<service>::ConfigBuilder::http_connector` when constructing the client."
+references = ["aws-sdk-rust#579", "aws-sdk-rust#338"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "rcoh"
+
 [[smithy-rs]]
 message = """
 [RestJson1](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-restjson1-protocol.html#operation-error-serialization) server SDKs now serialize only the [shape name](https://smithy.io/2.0/spec/model.html#shape-id) in operation error responses. Previously (from versions 0.52.0 to 0.55.4), the full shape ID was rendered.

--- a/aws/rust-runtime/aws-config/src/default_provider/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/app_name.rs
@@ -118,12 +118,9 @@ mod tests {
     async fn profile_name_override() {
         let fs = Fs::from_slice(&[("test_config", "[profile custom]\nsdk_ua_app_id = correct")]);
         let conf = crate::from_env()
-            .configure(
-                ProviderConfig::empty()
-                    .with_fs(fs)
-                    .with_sleep(InstantSleep)
-                    .with_http_connector(no_traffic_connector()),
-            )
+            .sleep_impl(InstantSleep)
+            .fs(fs)
+            .http_connector(no_traffic_connector())
             .profile_name("custom")
             .profile_files(
                 ProfileFiles::builder()

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -303,14 +303,11 @@ impl ProviderConfig {
 
     /// Override the HTTPS connector for this configuration
     ///
-    /// **Warning**: Use of this method will prevent you from taking advantage of the HTTP connect timeouts.
-    /// Consider [`ProviderConfig::with_tcp_connector`].
-    ///
-    /// # Stability
-    /// This method is expected to change to support HTTP configuration.
-    pub fn with_http_connector(self, connector: DynConnector) -> Self {
+    /// **Note**: In order to take advantage of late-configured timeout settings, use [`HttpConnector::ConnectorFn`]
+    /// when configuring this connector.
+    pub fn with_http_connector(self, connector: impl Into<HttpConnector>) -> Self {
         ProviderConfig {
-            connector: HttpConnector::Prebuilt(Some(connector)),
+            connector: connector.into(),
             ..self
         }
     }

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -150,6 +150,21 @@ impl ProviderConfig {
         }
     }
 
+    /// Initializer for ConfigBag to avoid possibly setting incorrect defaults.
+    pub(crate) fn init(time_source: SharedTimeSource, sleep: Option<SharedAsyncSleep>) -> Self {
+        Self {
+            parsed_profile: Default::default(),
+            profile_files: ProfileFiles::default(),
+            env: Env::default(),
+            fs: Fs::default(),
+            time_source,
+            connector: HttpConnector::Prebuilt(None),
+            sleep,
+            region: None,
+            profile_name_override: None,
+        }
+    }
+
     /// Create a default provider config with the region region automatically loaded from the default chain.
     ///
     /// # Examples
@@ -270,10 +285,7 @@ impl ProviderConfig {
         self.with_region(provider_chain.region().await)
     }
 
-    // these setters are doc(hidden) because they only exist for tests
-
-    #[doc(hidden)]
-    pub fn with_fs(self, fs: Fs) -> Self {
+    pub(crate) fn with_fs(self, fs: Fs) -> Self {
         ProviderConfig {
             parsed_profile: Default::default(),
             fs,
@@ -281,8 +293,7 @@ impl ProviderConfig {
         }
     }
 
-    #[cfg(test)]
-    pub fn with_env(self, env: Env) -> Self {
+    pub(crate) fn with_env(self, env: Env) -> Self {
         ProviderConfig {
             parsed_profile: Default::default(),
             env,


### PR DESCRIPTION
## Motivation and Context
Clients using separate connectors is mostly confusing and troublesome for customers.

## Description
Change the behavior of `ConfigLoader::http_connector` to set both the client & credential provider HTTP connector.

**Note**: It is still possible to separate control clients for the credential provider. Because `HttpConnector` is used, the timeout settings can still be late-bound.

## Testing
Unit tests.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
