### PR TITLE
Add names to interceptors

### DIFF
--- a/aws/rust-runtime/aws-inlineable/src/apigateway_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/apigateway_interceptors.rs
@@ -18,6 +18,10 @@ use http::HeaderValue;
 pub(crate) struct AcceptHeaderInterceptor;
 
 impl Interceptor for AcceptHeaderInterceptor {
+    fn name(&self) -> &'static str {
+        "AcceptHeaderInterceptor"
+    }
+
     fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,

--- a/aws/rust-runtime/aws-inlineable/src/glacier_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/glacier_interceptors.rs
@@ -68,6 +68,10 @@ impl<I> GlacierAccountIdAutofillInterceptor<I> {
 impl<I: GlacierAccountId + Send + Sync + 'static> Interceptor
     for GlacierAccountIdAutofillInterceptor<I>
 {
+    fn name(&self) -> &'static str {
+        "GlacierAccountIdAutofillInterceptor"
+    }
+
     fn modify_before_serialization(
         &self,
         context: &mut BeforeSerializationInterceptorContextMut<'_>,
@@ -97,6 +101,10 @@ impl GlacierApiVersionInterceptor {
 }
 
 impl Interceptor for GlacierApiVersionInterceptor {
+    fn name(&self) -> &'static str {
+        "GlacierApiVersionInterceptor"
+    }
+
     fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -116,6 +124,10 @@ impl Interceptor for GlacierApiVersionInterceptor {
 pub(crate) struct GlacierTreeHashHeaderInterceptor;
 
 impl Interceptor for GlacierTreeHashHeaderInterceptor {
+    fn name(&self) -> &'static str {
+        "GlacierTreeHashHeaderInterceptor"
+    }
+
     fn modify_before_serialization(
         &self,
         _context: &mut BeforeSerializationInterceptorContextMut<'_>,

--- a/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
@@ -79,6 +79,10 @@ impl<AP> Interceptor for RequestChecksumInterceptor<AP>
 where
     AP: Fn(&Input) -> Result<Option<ChecksumAlgorithm>, BoxError> + Send + Sync,
 {
+    fn name(&self) -> &'static str {
+        "RequestChecksumInterceptor"
+    }
+
     fn read_before_serialization(
         &self,
         context: &BeforeSerializationInterceptorContextRef<'_>,

--- a/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
@@ -56,6 +56,10 @@ impl<VE> Interceptor for ResponseChecksumInterceptor<VE>
 where
     VE: Fn(&Input) -> bool + Send + Sync,
 {
+    fn name(&self) -> &'static str {
+        "ResponseChecksumInterceptor"
+    }
+
     fn read_before_serialization(
         &self,
         context: &BeforeSerializationInterceptorContextRef<'_>,

--- a/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
@@ -47,6 +47,10 @@ impl SigV4PresigningInterceptor {
 }
 
 impl Interceptor for SigV4PresigningInterceptor {
+    fn name(&self) -> &'static str {
+        "SigV4PresigningInterceptor"
+    }
+
     fn modify_before_serialization(
         &self,
         _context: &mut BeforeSerializationInterceptorContextMut<'_>,

--- a/aws/rust-runtime/aws-inlineable/src/route53_resource_id_preprocessor.rs
+++ b/aws/rust-runtime/aws-inlineable/src/route53_resource_id_preprocessor.rs
@@ -72,6 +72,10 @@ where
     G: for<'a> Fn(&'a mut T) -> &'a mut Option<String> + Send + Sync,
     T: fmt::Debug + Send + Sync + 'static,
 {
+    fn name(&self) -> &'static str {
+        "Route53ResourceIdInterceptor"
+    }
+
     fn modify_before_serialization(
         &self,
         context: &mut BeforeSerializationInterceptorContextMut<'_>,

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -93,6 +93,10 @@ impl InvocationIdInterceptor {
 }
 
 impl Interceptor for InvocationIdInterceptor {
+    fn name(&self) -> &'static str {
+        "InvocationIdInterceptor"
+    }
+
     fn modify_before_retry_loop(
         &self,
         _ctx: &mut BeforeTransmitInterceptorContextMut<'_>,

--- a/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
+++ b/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
@@ -40,6 +40,10 @@ impl RecursionDetectionInterceptor {
 }
 
 impl Interceptor for RecursionDetectionInterceptor {
+    fn name(&self) -> &'static str {
+        "RecursionDetectionInterceptor"
+    }
+
     fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,

--- a/aws/rust-runtime/aws-runtime/src/request_info.rs
+++ b/aws/rust-runtime/aws-runtime/src/request_info.rs
@@ -87,6 +87,10 @@ impl RequestInfoInterceptor {
 }
 
 impl Interceptor for RequestInfoInterceptor {
+    fn name(&self) -> &'static str {
+        "RequestInfoInterceptor"
+    }
+
     fn modify_before_transmit(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -166,13 +170,12 @@ mod tests {
     use super::RequestInfoInterceptor;
     use crate::request_info::RequestPairs;
     use aws_smithy_http::body::SdkBody;
-    use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
+    use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
     use aws_smithy_runtime_api::client::interceptors::Interceptor;
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use aws_smithy_types::config_bag::{ConfigBag, Layer};
     use aws_smithy_types::retry::RetryConfig;
     use aws_smithy_types::timeout::TimeoutConfig;
-    use aws_smithy_types::type_erasure::TypeErasedBox;
     use http::HeaderValue;
     use std::time::Duration;
 
@@ -190,7 +193,7 @@ mod tests {
     #[test]
     fn test_request_pairs_for_initial_attempt() {
         let rc = RuntimeComponentsBuilder::for_tests().build().unwrap();
-        let mut context = InterceptorContext::new(TypeErasedBox::doesnt_matter());
+        let mut context = InterceptorContext::new(Input::doesnt_matter());
         context.enter_serialization_phase();
         context.set_request(http::Request::builder().body(SdkBody::empty()).unwrap());
 

--- a/aws/rust-runtime/aws-runtime/src/user_agent.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent.rs
@@ -72,6 +72,10 @@ fn header_values(
 }
 
 impl Interceptor for UserAgentInterceptor {
+    fn name(&self) -> &'static str {
+        "UserAgentInterceptor"
+    }
+
     fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCustomizableOperationDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCustomizableOperationDecorator.kt
@@ -60,6 +60,10 @@ class CustomizableOperationTestHelpers(runtimeConfig: RuntimeConfig) :
                 where
                     F: Fn(&mut BeforeTransmitInterceptorContextMut<'_>, &mut ConfigBag) + Send + Sync + 'static,
                 {
+                    fn name(&self) -> &'static str {
+                        "TestParamsSetterInterceptor"
+                    }
+
                     fn modify_before_signing(
                         &self,
                         context: &mut BeforeTransmitInterceptorContextMut<'_>,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -74,6 +74,10 @@ class EndpointParamsInterceptorGenerator(
             struct $interceptorName;
 
             impl #{Interceptor} for $interceptorName {
+                fn name(&self) -> &'static str {
+                    ${interceptorName.dq()}
+                }
+
                 fn read_before_execution(
                     &self,
                     context: &#{BeforeSerializationInterceptorContextRef}<'_, #{Input}, #{Output}, #{Error}>,

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/MetadataCustomizationTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/MetadataCustomizationTest.kt
@@ -63,6 +63,10 @@ class MetadataCustomizationTest {
                         );
 
                         impl #{Interceptor} for ExtractMetadataInterceptor {
+                            fn name(&self) -> &'static str {
+                                "ExtractMetadataInterceptor"
+                            }
+
                             fn modify_before_signing(
                                 &self,
                                 _context: &mut #{BeforeTransmitInterceptorContextMut}<'_>,

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
@@ -206,6 +206,10 @@ class EndpointsDecoratorTest {
                             called: Arc<AtomicBool>,
                         }
                         impl Interceptor for TestInterceptor {
+                            fn name(&self) -> &'static str {
+                                "TestInterceptor"
+                            }
+
                             fn read_before_transmit(
                                 &self,
                                 _context: &BeforeTransmitInterceptorContextRef<'_>,

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingsTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingsTest.kt
@@ -237,6 +237,10 @@ internal class EndpointTraitBindingsTest {
                             last_endpoint_prefix: Arc<Mutex<Option<EndpointPrefix>>>,
                         }
                         impl Interceptor for TestInterceptor {
+                            fn name(&self) -> &'static str {
+                                "TestInterceptor"
+                            }
+
                             fn read_before_transmit(
                                 &self,
                                 _context: &BeforeTransmitInterceptorContextRef<'_>,

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
@@ -41,6 +41,10 @@ private class TestServiceRuntimePluginCustomization(
                         ##[derive(::std::fmt::Debug)]
                         struct TestInterceptor;
                         impl #{Interceptor} for TestInterceptor {
+                            fn name(&self) -> &'static str {
+                                "TestInterceptor"
+                            }
+
                             fn modify_before_retry_loop(
                                 &self,
                                 context: &mut #{BeforeTransmitInterceptorContextMut}<'_>,

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
@@ -62,7 +62,7 @@ class PythonConstrainedEnum(
             rustBlock(
                 """
                 ##[getter]
-                pub fn name(&self) -> &str
+                pub fn name(&self) -> &'static str
                 """,
             ) {
                 rustBlock("match self") {

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEnumGenerator.kt
@@ -62,7 +62,7 @@ class PythonConstrainedEnum(
             rustBlock(
                 """
                 ##[getter]
-                pub fn name(&self) -> &'static str
+                pub fn name(&self) -> &str
                 """,
             ) {
                 rustBlock("match self") {

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
@@ -65,6 +65,9 @@ macro_rules! interceptor_trait_fn {
 ///   to read in-flight request or response messages, or "read/write" hooks, which make it possible
 ///   to modify in-flight request or output messages.
 pub trait Interceptor: fmt::Debug + Send + Sync {
+    /// The name of this interceptor, used in error messages for debugging.
+    fn name(&self) -> &'static str;
+
     /// A hook called at the start of an execution, before the SDK
     /// does anything else.
     ///

--- a/rust-runtime/aws-smithy-runtime/src/client/connectors/connection_poisoning.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/connectors/connection_poisoning.rs
@@ -40,6 +40,10 @@ impl ConnectionPoisoningInterceptor {
 }
 
 impl Interceptor for ConnectionPoisoningInterceptor {
+    fn name(&self) -> &'static str {
+        "ConnectionPoisoningInterceptor"
+    }
+
     fn modify_before_transmit(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,

--- a/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
@@ -36,7 +36,7 @@ macro_rules! interceptor_impl_fn {
                 stringify!($interceptor),
                 "` interceptors"
             ));
-            let mut result: Result<(), BoxError> = Ok(());
+            let mut result: Result<(), (&str, BoxError)> = Ok(());
             let mut ctx = ctx.into();
             for interceptor in self.into_iter() {
                 if let Some(interceptor) = interceptor.if_enabled(cfg) {
@@ -44,13 +44,18 @@ macro_rules! interceptor_impl_fn {
                         interceptor.$interceptor(&mut ctx, runtime_components, cfg)
                     {
                         if let Err(last_error) = result {
-                            tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                            tracing::debug!(
+                                "{}::{}: {}",
+                                last_error.0,
+                                stringify!($interceptor),
+                                DisplayErrorContext(&*last_error.1)
+                            );
                         }
-                        result = Err(new_error);
+                        result = Err((interceptor.name(), new_error));
                     }
                 }
             }
-            result.map_err(InterceptorError::$interceptor)
+            result.map_err(|(name, err)| InterceptorError::$interceptor(name, err))
         }
     };
     (ref $interceptor:ident) => {
@@ -60,20 +65,25 @@ macro_rules! interceptor_impl_fn {
             runtime_components: &RuntimeComponents,
             cfg: &mut ConfigBag,
         ) -> Result<(), InterceptorError> {
-            let mut result: Result<(), BoxError> = Ok(());
+            let mut result: Result<(), (&str, BoxError)> = Ok(());
             let ctx = ctx.into();
             for interceptor in self.into_iter() {
                 if let Some(interceptor) = interceptor.if_enabled(cfg) {
                     if let Err(new_error) = interceptor.$interceptor(&ctx, runtime_components, cfg)
                     {
                         if let Err(last_error) = result {
-                            tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                            tracing::debug!(
+                                "{}::{}: {}",
+                                last_error.0,
+                                stringify!($interceptor),
+                                DisplayErrorContext(&*last_error.1)
+                            );
                         }
-                        result = Err(new_error);
+                        result = Err((interceptor.name(), new_error));
                     }
                 }
             }
-            result.map_err(InterceptorError::$interceptor)
+            result.map_err(|(name, err)| InterceptorError::$interceptor(name, err))
         }
     };
 }
@@ -105,19 +115,24 @@ where
             "running {} `read_before_execution` interceptors",
             if operation { "operation" } else { "client" }
         );
-        let mut result: Result<(), BoxError> = Ok(());
+        let mut result: Result<(), (&str, BoxError)> = Ok(());
         let ctx: BeforeSerializationInterceptorContextRef<'_> = ctx.into();
         for interceptor in self.into_iter() {
             if let Some(interceptor) = interceptor.if_enabled(cfg) {
                 if let Err(new_error) = interceptor.read_before_execution(&ctx, cfg) {
                     if let Err(last_error) = result {
-                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                        tracing::debug!(
+                            "{}::{}: {}",
+                            last_error.0,
+                            "read_before_execution",
+                            DisplayErrorContext(&*last_error.1)
+                        );
                     }
-                    result = Err(new_error);
+                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
-        result.map_err(InterceptorError::read_before_execution)
+        result.map_err(|(name, err)| InterceptorError::read_before_execution(name, err))
     }
 
     interceptor_impl_fn!(mut modify_before_serialization);
@@ -142,7 +157,7 @@ where
         cfg: &mut ConfigBag,
     ) -> Result<(), InterceptorError> {
         tracing::trace!("running `modify_before_attempt_completion` interceptors");
-        let mut result: Result<(), BoxError> = Ok(());
+        let mut result: Result<(), (&str, BoxError)> = Ok(());
         let mut ctx: FinalizerInterceptorContextMut<'_> = ctx.into();
         for interceptor in self.into_iter() {
             if let Some(interceptor) = interceptor.if_enabled(cfg) {
@@ -150,13 +165,18 @@ where
                     interceptor.modify_before_attempt_completion(&mut ctx, runtime_components, cfg)
                 {
                     if let Err(last_error) = result {
-                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                        tracing::debug!(
+                            "{}::{}: {}",
+                            last_error.0,
+                            "modify_before_attempt_completion",
+                            DisplayErrorContext(&*last_error.1)
+                        );
                     }
-                    result = Err(new_error);
+                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
-        result.map_err(InterceptorError::modify_before_attempt_completion)
+        result.map_err(|(name, err)| InterceptorError::modify_before_attempt_completion(name, err))
     }
 
     pub(crate) fn read_after_attempt(
@@ -166,7 +186,7 @@ where
         cfg: &mut ConfigBag,
     ) -> Result<(), InterceptorError> {
         tracing::trace!("running `read_after_attempt` interceptors");
-        let mut result: Result<(), BoxError> = Ok(());
+        let mut result: Result<(), (&str, BoxError)> = Ok(());
         let ctx: FinalizerInterceptorContextRef<'_> = ctx.into();
         for interceptor in self.into_iter() {
             if let Some(interceptor) = interceptor.if_enabled(cfg) {
@@ -174,13 +194,18 @@ where
                     interceptor.read_after_attempt(&ctx, runtime_components, cfg)
                 {
                     if let Err(last_error) = result {
-                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                        tracing::debug!(
+                            "{}::{}: {}",
+                            last_error.0,
+                            "read_after_attempt",
+                            DisplayErrorContext(&*last_error.1)
+                        );
                     }
-                    result = Err(new_error);
+                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
-        result.map_err(InterceptorError::read_after_attempt)
+        result.map_err(|(name, err)| InterceptorError::read_after_attempt(name, err))
     }
 
     pub(crate) fn modify_before_completion(
@@ -190,7 +215,7 @@ where
         cfg: &mut ConfigBag,
     ) -> Result<(), InterceptorError> {
         tracing::trace!("running `modify_before_completion` interceptors");
-        let mut result: Result<(), BoxError> = Ok(());
+        let mut result: Result<(), (&str, BoxError)> = Ok(());
         let mut ctx: FinalizerInterceptorContextMut<'_> = ctx.into();
         for interceptor in self.into_iter() {
             if let Some(interceptor) = interceptor.if_enabled(cfg) {
@@ -198,13 +223,18 @@ where
                     interceptor.modify_before_completion(&mut ctx, runtime_components, cfg)
                 {
                     if let Err(last_error) = result {
-                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                        tracing::debug!(
+                            "{}::{}: {}",
+                            last_error.0,
+                            "modify_before_completion",
+                            DisplayErrorContext(&*last_error.1)
+                        );
                     }
-                    result = Err(new_error);
+                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
-        result.map_err(InterceptorError::modify_before_completion)
+        result.map_err(|(name, err)| InterceptorError::modify_before_completion(name, err))
     }
 
     pub(crate) fn read_after_execution(
@@ -214,7 +244,7 @@ where
         cfg: &mut ConfigBag,
     ) -> Result<(), InterceptorError> {
         tracing::trace!("running `read_after_execution` interceptors");
-        let mut result: Result<(), BoxError> = Ok(());
+        let mut result: Result<(), (&str, BoxError)> = Ok(());
         let ctx: FinalizerInterceptorContextRef<'_> = ctx.into();
         for interceptor in self.into_iter() {
             if let Some(interceptor) = interceptor.if_enabled(cfg) {
@@ -222,13 +252,18 @@ where
                     interceptor.read_after_execution(&ctx, runtime_components, cfg)
                 {
                     if let Err(last_error) = result {
-                        tracing::debug!("{}", DisplayErrorContext(&*last_error));
+                        tracing::debug!(
+                            "{}::{}: {}",
+                            last_error.0,
+                            "read_after_execution",
+                            DisplayErrorContext(&*last_error.1)
+                        );
                     }
-                    result = Err(new_error);
+                    result = Err((interceptor.name(), new_error));
                 }
             }
         }
-        result.map_err(InterceptorError::read_after_execution)
+        result.map_err(|(name, err)| InterceptorError::read_after_execution(name, err))
     }
 }
 
@@ -270,6 +305,10 @@ where
     F: Fn(HttpRequest) -> Result<HttpRequest, E> + Send + Sync + 'static,
     E: StdError + Send + Sync + 'static,
 {
+    fn name(&self) -> &'static str {
+        "MapRequestInterceptor"
+    }
+
     fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -305,6 +344,10 @@ impl<F> Interceptor for MutateRequestInterceptor<F>
 where
     F: Fn(&mut HttpRequest) + Send + Sync + 'static,
 {
+    fn name(&self) -> &'static str {
+        "MutateRequestInterceptor"
+    }
+
     fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -335,13 +378,21 @@ mod tests {
 
     #[derive(Debug)]
     struct TestInterceptor;
-    impl Interceptor for TestInterceptor {}
+    impl Interceptor for TestInterceptor {
+        fn name(&self) -> &'static str {
+            "TestInterceptor"
+        }
+    }
 
     #[test]
     fn test_disable_interceptors() {
         #[derive(Debug)]
         struct PanicInterceptor;
         impl Interceptor for PanicInterceptor {
+            fn name(&self) -> &'static str {
+                "PanicInterceptor"
+            }
+
             fn read_before_transmit(
                 &self,
                 _context: &BeforeTransmitInterceptorContextRef<'_>,

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -534,6 +534,8 @@ mod tests {
             #[derive(Debug)]
             struct FailingInterceptorA;
             impl Interceptor for FailingInterceptorA {
+                fn name(&self) -> &'static str { "FailingInterceptorA" }
+
                 fn $interceptor(
                     &self,
                     _ctx: $ctx,
@@ -548,6 +550,8 @@ mod tests {
             #[derive(Debug)]
             struct FailingInterceptorB;
             impl Interceptor for FailingInterceptorB {
+                fn name(&self) -> &'static str { "FailingInterceptorB" }
+
                 fn $interceptor(
                     &self,
                     _ctx: $ctx,
@@ -562,6 +566,8 @@ mod tests {
             #[derive(Debug)]
             struct FailingInterceptorC;
             impl Interceptor for FailingInterceptorC {
+                fn name(&self) -> &'static str { "FailingInterceptorC" }
+
                 fn $interceptor(
                     &self,
                     _ctx: $ctx,
@@ -624,7 +630,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_execution_error_handling() {
-        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ReadBeforeExecution, source: Some(\"FailingInterceptorC\") } })""#.to_string();
+        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ReadBeforeExecution, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") } })""#.to_string();
         interceptor_error_handling_test!(
             read_before_execution,
             &BeforeSerializationInterceptorContextRef<'_>,
@@ -635,7 +641,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_serialization_error_handling() {
-        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ModifyBeforeSerialization, source: Some(\"FailingInterceptorC\") } })""#.to_string();
+        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ModifyBeforeSerialization, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") } })""#.to_string();
         interceptor_error_handling_test!(
             modify_before_serialization,
             &mut BeforeSerializationInterceptorContextMut<'_>,
@@ -646,7 +652,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_serialization_error_handling() {
-        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ReadBeforeSerialization, source: Some(\"FailingInterceptorC\") } })""#.to_string();
+        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ReadBeforeSerialization, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") } })""#.to_string();
         interceptor_error_handling_test!(
             read_before_serialization,
             &BeforeSerializationInterceptorContextRef<'_>,
@@ -657,7 +663,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_serialization_error_handling() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadAfterSerialization, source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadAfterSerialization, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
         interceptor_error_handling_test!(
             read_after_serialization,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -668,7 +674,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_retry_loop_error_handling() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeRetryLoop, source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeRetryLoop, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
         interceptor_error_handling_test!(
             modify_before_retry_loop,
             &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -679,7 +685,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_attempt_error_handling() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadBeforeAttempt, source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadBeforeAttempt, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
         interceptor_error_handling_test!(
             read_before_attempt,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -690,7 +696,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_signing_error_handling() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeSigning, source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeSigning, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
         interceptor_error_handling_test!(
             modify_before_signing,
             &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -701,7 +707,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_signing_error_handling() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadBeforeSigning, source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadBeforeSigning, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
         interceptor_error_handling_test!(
             read_before_signing,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -712,7 +718,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_signing_error_handling() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadAfterSigning, source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadAfterSigning, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
         interceptor_error_handling_test!(
             read_after_signing,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -723,7 +729,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_transmit_error_handling() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeTransmit, source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeTransmit, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
         interceptor_error_handling_test!(
             modify_before_transmit,
             &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -734,7 +740,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_transmit_error_handling() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadBeforeTransmit, source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ReadBeforeTransmit, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, connection: Unknown } })""#.to_string();
         interceptor_error_handling_test!(
             read_before_transmit,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -745,7 +751,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_transmit_error_handling() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterTransmit, source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterTransmit, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
         interceptor_error_handling_test!(
             read_after_transmit,
             &BeforeDeserializationInterceptorContextRef<'_>,
@@ -756,7 +762,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_deserialization_error_handling() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeDeserialization, source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeDeserialization, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
         interceptor_error_handling_test!(
             modify_before_deserialization,
             &mut BeforeDeserializationInterceptorContextMut<'_>,
@@ -767,7 +773,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_deserialization_error_handling() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadBeforeDeserialization, source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadBeforeDeserialization, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
         interceptor_error_handling_test!(
             read_before_deserialization,
             &BeforeDeserializationInterceptorContextRef<'_>,
@@ -778,7 +784,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_deserialization_error_handling() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterDeserialization, source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterDeserialization, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
         interceptor_error_handling_test!(
             read_after_deserialization,
             &AfterDeserializationInterceptorContextRef<'_>,
@@ -789,7 +795,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_attempt_completion_error_handling() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
         interceptor_error_handling_test!(
             modify_before_attempt_completion,
             &mut FinalizerInterceptorContextMut<'_>,
@@ -800,7 +806,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_attempt_error_handling() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterAttempt, source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterAttempt, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
         interceptor_error_handling_test!(
             read_after_attempt,
             &FinalizerInterceptorContextRef<'_>,
@@ -811,7 +817,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_completion_error_handling() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeCompletion, source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeCompletion, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
         interceptor_error_handling_test!(
             modify_before_completion,
             &mut FinalizerInterceptorContextMut<'_>,
@@ -822,7 +828,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_execution_error_handling() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterExecution, source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterExecution, interceptor_name: Some(\"FailingInterceptorC\"), source: Some(\"FailingInterceptorC\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
         interceptor_error_handling_test!(
             read_after_execution,
             &FinalizerInterceptorContextRef<'_>,
@@ -841,6 +847,8 @@ mod tests {
             #[derive(Debug)]
             struct OriginInterceptor;
             impl Interceptor for OriginInterceptor {
+                fn name(&self) -> &'static str { "OriginInterceptor" }
+
                 fn $origin_interceptor(
                     &self,
                     _ctx: $origin_ctx,
@@ -855,6 +863,8 @@ mod tests {
             #[derive(Debug)]
             struct DestinationInterceptor;
             impl Interceptor for DestinationInterceptor {
+                fn name(&self) -> &'static str { "DestinationInterceptor" }
+
                 fn $destination_interceptor(
                     &self,
                     _ctx: $destination_ctx,
@@ -902,7 +912,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_execution_error_causes_jump_to_modify_before_completion() {
-        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ModifyBeforeCompletion, source: Some(\"DestinationInterceptor\") } })""#.to_string();
+        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ModifyBeforeCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") } })""#.to_string();
         interceptor_error_redirection_test!(
             read_before_execution,
             &BeforeSerializationInterceptorContextRef<'_>,
@@ -915,7 +925,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_serialization_error_causes_jump_to_modify_before_completion() {
-        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ModifyBeforeCompletion, source: Some(\"DestinationInterceptor\") } })""#.to_string();
+        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ModifyBeforeCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") } })""#.to_string();
         interceptor_error_redirection_test!(
             modify_before_serialization,
             &mut BeforeSerializationInterceptorContextMut<'_>,
@@ -928,7 +938,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_serialization_error_causes_jump_to_modify_before_completion() {
-        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ModifyBeforeCompletion, source: Some(\"DestinationInterceptor\") } })""#.to_string();
+        let expected = r#""ConstructionFailure(ConstructionFailure { source: InterceptorError { kind: ModifyBeforeCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") } })""#.to_string();
         interceptor_error_redirection_test!(
             read_before_serialization,
             &BeforeSerializationInterceptorContextRef<'_>,
@@ -941,7 +951,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_serialization_error_causes_jump_to_modify_before_completion() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeCompletion, source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
         interceptor_error_redirection_test!(
             read_after_serialization,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -954,7 +964,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_retry_loop_error_causes_jump_to_modify_before_completion() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeCompletion, source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
         interceptor_error_redirection_test!(
             modify_before_retry_loop,
             &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -967,7 +977,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_attempt_error_causes_jump_to_modify_before_attempt_completion() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
         interceptor_error_redirection_test!(
             read_before_attempt,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -980,7 +990,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_signing_error_causes_jump_to_modify_before_attempt_completion() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
         interceptor_error_redirection_test!(
             modify_before_signing,
             &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -993,7 +1003,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_signing_error_causes_jump_to_modify_before_attempt_completion() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
         interceptor_error_redirection_test!(
             read_before_signing,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -1006,7 +1016,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_signing_error_causes_jump_to_modify_before_attempt_completion() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
         interceptor_error_redirection_test!(
             read_after_signing,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -1019,7 +1029,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_transmit_error_causes_jump_to_modify_before_attempt_completion() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
         interceptor_error_redirection_test!(
             modify_before_transmit,
             &mut BeforeTransmitInterceptorContextMut<'_>,
@@ -1032,7 +1042,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_before_transmit_error_causes_jump_to_modify_before_attempt_completion() {
-        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
+        let expected = r#""DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, connection: Unknown } })""#.to_string();
         interceptor_error_redirection_test!(
             read_before_transmit,
             &BeforeTransmitInterceptorContextRef<'_>,
@@ -1045,7 +1055,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_read_after_transmit_error_causes_jump_to_modify_before_attempt_completion() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
         interceptor_error_redirection_test!(
             read_after_transmit,
             &BeforeDeserializationInterceptorContextRef<'_>,
@@ -1059,7 +1069,7 @@ mod tests {
     #[traced_test]
     async fn test_modify_before_deserialization_error_causes_jump_to_modify_before_attempt_completion(
     ) {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
         interceptor_error_redirection_test!(
             modify_before_deserialization,
             &mut BeforeDeserializationInterceptorContextMut<'_>,
@@ -1073,7 +1083,7 @@ mod tests {
     #[traced_test]
     async fn test_read_before_deserialization_error_causes_jump_to_modify_before_attempt_completion(
     ) {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(None), retryable: true } } })""#.to_string();
         interceptor_error_redirection_test!(
             read_before_deserialization,
             &BeforeDeserializationInterceptorContextRef<'_>,
@@ -1087,7 +1097,7 @@ mod tests {
     #[traced_test]
     async fn test_read_after_deserialization_error_causes_jump_to_modify_before_attempt_completion()
     {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ModifyBeforeAttemptCompletion, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
         interceptor_error_redirection_test!(
             read_after_deserialization,
             &AfterDeserializationInterceptorContextRef<'_>,
@@ -1100,7 +1110,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_attempt_completion_error_causes_jump_to_read_after_attempt() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterAttempt, source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterAttempt, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
         interceptor_error_redirection_test!(
             modify_before_attempt_completion,
             &mut FinalizerInterceptorContextMut<'_>,
@@ -1113,7 +1123,7 @@ mod tests {
     #[tokio::test]
     #[traced_test]
     async fn test_modify_before_completion_error_causes_jump_to_read_after_execution() {
-        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterExecution, source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
+        let expected = r#""ResponseError(ResponseError { source: InterceptorError { kind: ReadAfterExecution, interceptor_name: Some(\"DestinationInterceptor\"), source: Some(\"DestinationInterceptor\") }, raw: Response { status: 200, version: HTTP/1.1, headers: {}, body: SdkBody { inner: Once(Some(b\"\")), retryable: true } } })""#.to_string();
         interceptor_error_redirection_test!(
             modify_before_completion,
             &mut FinalizerInterceptorContextMut<'_>,
@@ -1171,6 +1181,10 @@ mod tests {
         }
 
         impl Interceptor for TestInterceptor {
+            fn name(&self) -> &'static str {
+                "TestInterceptor"
+            }
+
             fn modify_before_retry_loop(
                 &self,
                 _context: &mut BeforeTransmitInterceptorContextMut<'_>,

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/interceptors/service_clock_skew.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/interceptors/service_clock_skew.rs
@@ -66,6 +66,10 @@ fn extract_time_sent_from_response(
 }
 
 impl Interceptor for ServiceClockSkewInterceptor {
+    fn name(&self) -> &'static str {
+        "ServiceClockSkewInterceptor"
+    }
+
     fn modify_before_deserialization(
         &self,
         ctx: &mut BeforeDeserializationInterceptorContextMut<'_>,

--- a/rust-runtime/inlineable/src/client_http_checksum_required.rs
+++ b/rust-runtime/inlineable/src/client_http_checksum_required.rs
@@ -39,6 +39,10 @@ impl RuntimePlugin for HttpChecksumRequiredRuntimePlugin {
 struct HttpChecksumRequiredInterceptor;
 
 impl Interceptor for HttpChecksumRequiredInterceptor {
+    fn name(&self) -> &'static str {
+        "HttpChecksumRequiredInterceptor"
+    }
+
     fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,

--- a/rust-runtime/inlineable/src/client_idempotency_token.rs
+++ b/rust-runtime/inlineable/src/client_idempotency_token.rs
@@ -56,6 +56,10 @@ impl<S> Interceptor for IdempotencyTokenInterceptor<S>
 where
     S: Fn(IdempotencyTokenProvider, &mut Input) + Send + Sync,
 {
+    fn name(&self) -> &'static str {
+        "IdempotencyTokenInterceptor"
+    }
+
     fn modify_before_serialization(
         &self,
         context: &mut BeforeSerializationInterceptorContextMut<'_>,


### PR DESCRIPTION
This PR adds a `name` function to the `Interceptor` trait so that interceptor errors are easier to narrow down.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
