### PR TITLE
Run non-service SDK integration tests in CI

### DIFF
--- a/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
+++ b/tools/ci-scripts/check-aws-sdk-smoketest-unit-tests
@@ -7,3 +7,10 @@
 set -eux
 cd aws-sdk-smoketest
 cargo test --all-features
+
+for test_dir in tests/*; do
+    if [ -f "${test_dir}/Cargo.toml" ]; then
+        echo "#### Testing ${test_dir}..."
+        cargo test --all-features --manifest-path "${test_dir}/Cargo.toml"
+    fi
+done


### PR DESCRIPTION
This fixes #2880.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
