### PR TITLE
Update changelog icons to use github emoji shortcodes

### DIFF
--- a/tools/ci-build/changelogger/src/render.rs
+++ b/tools/ci-build/changelogger/src/render.rs
@@ -175,13 +175,13 @@ fn to_md_link(reference: &Reference) -> String {
 fn render_entry(entry: &HandAuthoredEntry, mut out: &mut String) {
     let mut meta = String::new();
     if entry.meta.bug {
-        meta.push('🐛');
+        meta.push_str(":bug:");
     }
     if entry.meta.breaking {
-        meta.push('⚠');
+        meta.push_str(':warning:');
     }
     if entry.meta.tada {
-        meta.push('🎉');
+        meta.push_str(":tada:");
     }
     if !meta.is_empty() {
         meta.push(' ');
@@ -562,11 +562,11 @@ message = "Some API change"
 v0.3.0 (January 4th, 2022)
 ==========================
 **Breaking Changes:**
-- ⚠ (all, [smithy-rs#445](https://github.com/awslabs/smithy-rs/issues/445)) I made a major change to update the code generator
+- :warning: (all, [smithy-rs#445](https://github.com/awslabs/smithy-rs/issues/445)) I made a major change to update the code generator
 
 **New this release:**
-- 🎉 (all, [smithy-rs#446](https://github.com/awslabs/smithy-rs/issues/446), @external-contrib) I made a change to update the code generator
-- 🎉 (all, [smithy-rs#446](https://github.com/awslabs/smithy-rs/issues/446), @external-contrib) I made a change to update the code generator
+- :tada: (all, [smithy-rs#446](https://github.com/awslabs/smithy-rs/issues/446), @external-contrib) I made a change to update the code generator
+- :tada: (all, [smithy-rs#446](https://github.com/awslabs/smithy-rs/issues/446), @external-contrib) I made a change to update the code generator
 
     **Update guide:**
     blah blah
@@ -586,10 +586,10 @@ Thank you for your contributions! ❤
 v0.1.0 (January 4th, 2022)
 ==========================
 **Breaking Changes:**
-- ⚠ ([smithy-rs#445](https://github.com/awslabs/smithy-rs/issues/445)) I made a major change to update the AWS SDK
+- :warning: ([smithy-rs#445](https://github.com/awslabs/smithy-rs/issues/445)) I made a major change to update the AWS SDK
 
 **New this release:**
-- 🎉 ([smithy-rs#446](https://github.com/awslabs/smithy-rs/issues/446), @external-contrib) I made a change to update the code generator
+- :tada: ([smithy-rs#446](https://github.com/awslabs/smithy-rs/issues/446), @external-contrib) I made a change to update the code generator
 
 **Service Features:**
 - `aws-sdk-ec2` (0.12.0): Some API change

--- a/tools/ci-build/changelogger/src/render.rs
+++ b/tools/ci-build/changelogger/src/render.rs
@@ -178,7 +178,7 @@ fn render_entry(entry: &HandAuthoredEntry, mut out: &mut String) {
         meta.push_str(":bug:");
     }
     if entry.meta.breaking {
-        meta.push_str(':warning:');
+        meta.push_str(":warning:");
     }
     if entry.meta.tada {
         meta.push_str(":tada:");

--- a/tools/ci-build/changelogger/tests/e2e_test.rs
+++ b/tools/ci-build/changelogger/tests/e2e_test.rs
@@ -393,7 +393,7 @@ fn render_aws_sdk() {
 January 1st, 1970
 =================
 **New this release:**
-- 🐛 ([aws-sdk-rust#234](https://github.com/awslabs/aws-sdk-rust/issues/234), [smithy-rs#567](https://github.com/awslabs/smithy-rs/issues/567), @test-dev) Some other change
+- :bug: ([aws-sdk-rust#234](https://github.com/awslabs/aws-sdk-rust/issues/234), [smithy-rs#567](https://github.com/awslabs/smithy-rs/issues/567), @test-dev) Some other change
 
 **Service Features:**
 - `aws-sdk-ec2` (0.12.0): Some API change
@@ -414,7 +414,7 @@ Old entry contents
         r#"{
   "tagName": "release-1970-01-01",
   "name": "January 1st, 1970",
-  "body": "**New this release:**\n- 🐛 ([aws-sdk-rust#234](https://github.com/awslabs/aws-sdk-rust/issues/234), [smithy-rs#567](https://github.com/awslabs/smithy-rs/issues/567), @test-dev) Some other change\n\n**Service Features:**\n- `aws-sdk-ec2` (0.12.0): Some API change\n\n**Contributors**\nThank you for your contributions! ❤\n- @test-dev ([aws-sdk-rust#234](https://github.com/awslabs/aws-sdk-rust/issues/234), [smithy-rs#567](https://github.com/awslabs/smithy-rs/issues/567))\n\n",
+  "body": "**New this release:**\n- :bug: ([aws-sdk-rust#234](https://github.com/awslabs/aws-sdk-rust/issues/234), [smithy-rs#567](https://github.com/awslabs/smithy-rs/issues/567), @test-dev) Some other change\n\n**Service Features:**\n- `aws-sdk-ec2` (0.12.0): Some API change\n\n**Contributors**\nThank you for your contributions! ❤\n- @test-dev ([aws-sdk-rust#234](https://github.com/awslabs/aws-sdk-rust/issues/234), [smithy-rs#567](https://github.com/awslabs/smithy-rs/issues/567))\n\n",
   "prerelease": true
 }"#,
         release_manifest
@@ -511,7 +511,7 @@ author = "rcoh"
 January 1st, 1970
 =================
 **Breaking Changes:**
-- ⚠ (all, [smithy-rs#3](https://github.com/awslabs/smithy-rs/issues/3)) Third change - empty
+- :warning: (all, [smithy-rs#3](https://github.com/awslabs/smithy-rs/issues/3)) Third change - empty
 
 **New this release:**
 - (server, [smithy-rs#1](https://github.com/awslabs/smithy-rs/issues/1), @server-dev) First change - server


### PR DESCRIPTION
I noticed these were switched for emojis but they should be shortcodes.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
