### PR TITLE
Re-export `RuntimeComponents` in generated clients

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,15 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "`RuntimeComponents` are now re-exported so that implementing a custom interceptor doens't require directly depending on `aws-smithy-runtime-api`."
+references = ["smithy-rs#2904", "aws-sdk-rust#862"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "jdisanti"
+
+[[smithy-rs]]
+message = "`RuntimeComponents` and `RuntimeComponentsBuilder` are now re-exported in generated clients so that implementing a custom interceptor or runtime plugin doens't require directly depending on `aws-smithy-runtime-api`."
+references = ["smithy-rs#2904"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+author = "jdisanti"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGenerator.kt
@@ -28,10 +28,12 @@ class ClientRuntimeTypesReExportGenerator(
                 """
                 pub use #{ConfigBag};
                 pub use #{Interceptor};
+                pub use #{RuntimeComponents};
                 pub use #{SharedInterceptor};
                 """,
                 "ConfigBag" to RuntimeType.configBag(rc),
                 "Interceptor" to RuntimeType.interceptor(rc),
+                "RuntimeComponents" to RuntimeType.runtimeComponents(rc),
                 "SharedInterceptor" to RuntimeType.sharedInterceptor(rc),
             )
 
@@ -40,9 +42,11 @@ class ClientRuntimeTypesReExportGenerator(
                     """
                     pub use #{runtime_plugin}::{RuntimePlugin, SharedRuntimePlugin};
                     pub use #{config_bag}::FrozenLayer;
+                    pub use #{RuntimeComponentsBuilder};
                     """,
                     "runtime_plugin" to RuntimeType.smithyRuntimeApi(rc).resolve("client::runtime_plugin"),
                     "config_bag" to RuntimeType.smithyTypes(rc).resolve("config_bag"),
+                    "RuntimeComponentsBuilder" to RuntimeType.runtimeComponentsBuilder(rc),
                 )
             }
         }


### PR DESCRIPTION
Re-export `RuntimeComponents`, and for generic clients, `RuntimeComponentsBuilder`, so that a direct dependency on `aws-smithy-runtime-api` isn't required to implement custom interceptors or runtime plugins.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
