### PR TITLE
Rename `signing_service` to `signing_name`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -20,7 +20,7 @@ author = "jdisanti"
 [[smithy-rs]]
 message = "`RuntimeComponents` and `RuntimeComponentsBuilder` are now re-exported in generated clients so that implementing a custom interceptor or runtime plugin doens't require directly depending on `aws-smithy-runtime-api`."
 references = ["smithy-rs#2904"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"
 
 [[smithy-rs]]
@@ -45,3 +45,9 @@ message = """Several breaking changes were made to the aws-sigv4 API to remove t
 references = ["smithy-rs#2921"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "In sigV4-related code, rename 'signing service' to 'signing name'. This aligns with the terminology used by the endpoint resolver."
+references = ["smithy-rs#2911"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "Velfi"

--- a/aws/rust-runtime/aws-endpoint/src/lib.rs
+++ b/aws/rust-runtime/aws-endpoint/src/lib.rs
@@ -14,13 +14,13 @@ use aws_smithy_types::endpoint::Endpoint as SmithyEndpoint;
 use aws_smithy_types::Document;
 
 use aws_types::region::{Region, SigningRegion};
-use aws_types::SigningService;
+use aws_types::SigningName;
 
 /// Middleware Stage to add authentication information from a Smithy endpoint into the property bag
 ///
 /// AwsAuthStage implements [`MapRequest`](MapRequest). It will:
 /// 1. Load an endpoint from the property bag
-/// 2. Set the `SigningRegion` and `SigningService` in the property bag to drive downstream
+/// 2. Set the `SigningRegion` and `SigningName` in the property bag to drive downstream
 /// signing middleware.
 #[derive(Clone, Debug)]
 pub struct AwsAuthStage;
@@ -74,21 +74,21 @@ impl MapRequest for AwsAuthStage {
             let endpoint = props
                 .get::<aws_smithy_types::endpoint::Endpoint>()
                 .ok_or(AwsAuthStageErrorKind::NoEndpointResolver)?;
-            let (signing_scope_override, signing_service_override) = smithy_to_aws(endpoint)
+            let (signing_region_override, signing_name_override) = smithy_to_aws(endpoint)
                 .map_err(|err| AwsAuthStageErrorKind::EndpointResolutionError(err))?;
 
-            if let Some(signing_scope) = signing_scope_override {
-                props.insert(signing_scope);
+            if let Some(signing_region) = signing_region_override {
+                props.insert(signing_region);
             }
-            if let Some(signing_service) = signing_service_override {
-                props.insert(signing_service);
+            if let Some(signing_name) = signing_name_override {
+                props.insert(signing_name);
             }
             Ok(http_req)
         })
     }
 }
 
-type EndpointMetadata = (Option<SigningRegion>, Option<SigningService>);
+type EndpointMetadata = (Option<SigningRegion>, Option<SigningName>);
 
 fn smithy_to_aws(value: &SmithyEndpoint) -> Result<EndpointMetadata, Box<dyn Error + Send + Sync>> {
     // look for v4 as an auth scheme
@@ -127,12 +127,12 @@ fn smithy_to_aws(value: &SmithyEndpoint) -> Result<EndpointMetadata, Box<dyn Err
         None => None,
         _ => return Err("unexpected type".into()),
     };
-    let signing_service = match v4.get("signingName") {
-        Some(Document::String(s)) => Some(SigningService::from(s.to_string())),
+    let signing_name = match v4.get("signingName") {
+        Some(Document::String(s)) => Some(SigningName::from(s.to_string())),
         None => None,
         _ => return Err("unexpected type".into()),
     };
-    Ok((signing_scope, signing_service))
+    Ok((signing_scope, signing_name))
 }
 
 #[cfg(test)]
@@ -147,7 +147,7 @@ mod test {
     use http::header::HOST;
 
     use aws_types::region::{Region, SigningRegion};
-    use aws_types::SigningService;
+    use aws_types::SigningName;
 
     use crate::AwsAuthStage;
 
@@ -162,14 +162,14 @@ mod test {
         {
             let mut props = req.properties_mut();
             props.insert(SigningRegion::from(region.clone()));
-            props.insert(SigningService::from_static("kinesis"));
+            props.insert(SigningName::from_static("kinesis"));
             props.insert(endpoint);
         };
         let req = AwsAuthStage.apply(req).expect("should succeed");
         assert_eq!(req.properties().get(), Some(&SigningRegion::from(region)));
         assert_eq!(
             req.properties().get(),
-            Some(&SigningService::from_static("kinesis"))
+            Some(&SigningName::from_static("kinesis"))
         );
 
         assert!(req.http().headers().get(HOST).is_none());
@@ -206,7 +206,7 @@ mod test {
         {
             let mut props = req.properties_mut();
             props.insert(region);
-            props.insert(SigningService::from_static("qldb"));
+            props.insert(SigningName::from_static("qldb"));
             props.insert(endpoint);
         };
         let req = AwsAuthStage.apply(req).expect("should succeed");
@@ -216,7 +216,7 @@ mod test {
         );
         assert_eq!(
             req.properties().get(),
-            Some(&SigningService::from_static("qldb-override"))
+            Some(&SigningName::from_static("qldb-override"))
         );
     }
 
@@ -229,14 +229,14 @@ mod test {
         {
             let mut props = req.properties_mut();
             props.insert(region.clone());
-            props.insert(SigningService::from_static("qldb"));
+            props.insert(SigningName::from_static("qldb"));
             props.insert(endpoint);
         };
         let req = AwsAuthStage.apply(req).expect("should succeed");
         assert_eq!(req.properties().get(), Some(&region));
         assert_eq!(
             req.properties().get(),
-            Some(&SigningService::from_static("qldb"))
+            Some(&SigningName::from_static("qldb"))
         );
     }
 }

--- a/aws/rust-runtime/aws-inlineable/tests/middleware_e2e_test.rs
+++ b/aws/rust-runtime/aws-inlineable/tests/middleware_e2e_test.rs
@@ -30,7 +30,7 @@ use aws_inlineable::middleware::DefaultMiddleware;
 use aws_sig_auth::signer::OperationSigningConfig;
 use aws_smithy_async::time::SharedTimeSource;
 use aws_types::region::SigningRegion;
-use aws_types::SigningService;
+use aws_types::SigningName;
 
 type Client<C> = aws_smithy_client::Client<C, DefaultMiddleware>;
 
@@ -94,7 +94,7 @@ fn test_operation() -> Operation<TestOperationParser, AwsResponseRetryClassifier
         );
         conf.insert(SigningRegion::from_static("test-region"));
         conf.insert(OperationSigningConfig::default_config());
-        conf.insert(SigningService::from_static("test-service-signing"));
+        conf.insert(SigningName::from_static("test-service-signing"));
         conf.insert(SharedTimeSource::new(
             UNIX_EPOCH + Duration::from_secs(1613414417),
         ));

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -18,7 +18,7 @@ use aws_smithy_runtime_api::client::runtime_components::{GetIdentityResolver, Ru
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use aws_smithy_types::Document;
 use aws_types::region::{Region, SigningRegion};
-use aws_types::SigningService;
+use aws_types::SigningName;
 use std::borrow::Cow;
 use std::error::Error as StdError;
 use std::fmt;
@@ -32,14 +32,14 @@ pub const SCHEME_ID: AuthSchemeId = AuthSchemeId::new("sigv4");
 
 struct EndpointAuthSchemeConfig {
     signing_region_override: Option<SigningRegion>,
-    signing_service_override: Option<SigningService>,
+    signing_name_override: Option<SigningName>,
 }
 
 #[derive(Debug)]
 enum SigV4SigningError {
     MissingOperationSigningConfig,
     MissingSigningRegion,
-    MissingSigningService,
+    MissingSigningName,
     WrongIdentityType(Identity),
     BadTypeInEndpointAuthSchemeConfig(&'static str),
 }
@@ -51,7 +51,7 @@ impl fmt::Display for SigV4SigningError {
         match self {
             MissingOperationSigningConfig => w("missing operation signing config for SigV4"),
             MissingSigningRegion => w("missing signing region for SigV4 signing"),
-            MissingSigningService => w("missing signing service for SigV4 signing"),
+            MissingSigningName => w("missing signing service for SigV4 signing"),
             WrongIdentityType(identity) => {
                 write!(f, "wrong identity type for SigV4: {identity:?}")
             }
@@ -70,7 +70,7 @@ impl StdError for SigV4SigningError {
         match self {
             Self::MissingOperationSigningConfig => None,
             Self::MissingSigningRegion => None,
-            Self::MissingSigningService => None,
+            Self::MissingSigningName => None,
             Self::WrongIdentityType(_) => None,
             Self::BadTypeInEndpointAuthSchemeConfig(_) => None,
         }
@@ -160,12 +160,12 @@ impl Default for SigningOptions {
 ///
 /// Although these fields MAY be customized on a per request basis, they are generally static
 /// for a given operation
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SigV4OperationSigningConfig {
     /// AWS Region to sign for.
     pub region: Option<SigningRegion>,
     /// AWS Service to sign for.
-    pub service: Option<SigningService>,
+    pub service: Option<SigningName>,
     /// Signing options.
     pub signing_options: SigningOptions,
 }
@@ -240,11 +240,11 @@ impl SigV4Signer {
                     .ok_or(SigV4SigningError::MissingSigningRegion)?
                     .as_ref(),
             )
-            .service_name(
+            .name(
                 operation_config
                     .service
                     .as_ref()
-                    .ok_or(SigV4SigningError::MissingSigningService)?
+                    .ok_or(SigV4SigningError::MissingSigningName)?
                     .as_ref(),
             )
             .time(request_timestamp)
@@ -262,16 +262,16 @@ impl SigV4Signer {
             .ok_or(SigV4SigningError::MissingOperationSigningConfig)?;
 
         let signing_region = config_bag.load::<SigningRegion>();
-        let signing_service = config_bag.load::<SigningService>();
+        let signing_name = config_bag.load::<SigningName>();
 
         let EndpointAuthSchemeConfig {
             signing_region_override,
-            signing_service_override,
+            signing_name_override,
         } = Self::extract_endpoint_auth_scheme_config(auth_scheme_endpoint_config)?;
 
         match (
             signing_region_override.or_else(|| signing_region.cloned()),
-            signing_service_override.or_else(|| signing_service.cloned()),
+            signing_name_override.or_else(|| signing_name.cloned()),
         ) {
             (None, None) => Ok(Cow::Borrowed(operation_config)),
             (region, service) => {
@@ -290,7 +290,7 @@ impl SigV4Signer {
     fn extract_endpoint_auth_scheme_config(
         endpoint_config: AuthSchemeEndpointConfig<'_>,
     ) -> Result<EndpointAuthSchemeConfig, SigV4SigningError> {
-        let (mut signing_region_override, mut signing_service_override) = (None, None);
+        let (mut signing_region_override, mut signing_name_override) = (None, None);
         if let Some(config) = endpoint_config.as_document().and_then(Document::as_object) {
             use SigV4SigningError::BadTypeInEndpointAuthSchemeConfig as UnexpectedType;
             signing_region_override = match config.get("signingRegion") {
@@ -298,15 +298,15 @@ impl SigV4Signer {
                 None => None,
                 _ => return Err(UnexpectedType("signingRegion")),
             };
-            signing_service_override = match config.get("signingName") {
-                Some(Document::String(s)) => Some(SigningService::from(s.to_string())),
+            signing_name_override = match config.get("signingName") {
+                Some(Document::String(s)) => Some(SigningName::from(s.to_string())),
                 None => None,
                 _ => return Err(UnexpectedType("signingName")),
             };
         }
         Ok(EndpointAuthSchemeConfig {
             signing_region_override,
-            signing_service_override,
+            signing_name_override,
         })
     }
 }
@@ -384,7 +384,7 @@ impl Signer for SigV4Signer {
                         _signature,
                         credentials.clone(),
                         Region::new(signing_params.region().to_string()).into(),
-                        signing_params.service_name().to_string().into(),
+                        signing_params.name().to_string().into(),
                         time_source,
                     )) as _)
                     .expect("failed to send deferred signer");
@@ -403,7 +403,7 @@ mod event_stream {
     use aws_smithy_async::time::SharedTimeSource;
     use aws_smithy_eventstream::frame::{Message, SignMessage, SignMessageError};
     use aws_types::region::SigningRegion;
-    use aws_types::SigningService;
+    use aws_types::SigningName;
 
     /// Event Stream SigV4 signing implementation.
     #[derive(Debug)]
@@ -411,7 +411,7 @@ mod event_stream {
         last_signature: String,
         credentials: Credentials,
         signing_region: SigningRegion,
-        signing_service: SigningService,
+        signing_name: SigningName,
         time: SharedTimeSource,
     }
 
@@ -420,14 +420,14 @@ mod event_stream {
             last_signature: String,
             credentials: Credentials,
             signing_region: SigningRegion,
-            signing_service: SigningService,
+            signing_name: SigningName,
             time: SharedTimeSource,
         ) -> Self {
             Self {
                 last_signature,
                 credentials,
                 signing_region,
-                signing_service,
+                signing_name,
                 time,
             }
         }
@@ -437,7 +437,7 @@ mod event_stream {
                 .access_key(self.credentials.access_key_id())
                 .secret_key(self.credentials.secret_access_key())
                 .region(self.signing_region.as_ref())
-                .service_name(self.signing_service.as_ref())
+                .name(self.signing_name.as_ref())
                 .time(self.time.now())
                 .settings(());
             builder.set_security_token(self.credentials.session_token());
@@ -472,7 +472,7 @@ mod event_stream {
         use aws_smithy_eventstream::frame::{HeaderValue, Message, SignMessage};
         use aws_types::region::Region;
         use aws_types::region::SigningRegion;
-        use aws_types::SigningService;
+        use aws_types::SigningName;
         use std::time::{Duration, UNIX_EPOCH};
 
         fn check_send_sync<T: Send + Sync>(value: T) -> T {
@@ -486,7 +486,7 @@ mod event_stream {
                 "initial-signature".into(),
                 Credentials::for_tests(),
                 SigningRegion::from(region),
-                SigningService::from_static("transcribe"),
+                SigningName::from_static("transcribe"),
                 SharedTimeSource::new(UNIX_EPOCH + Duration::new(1611160427, 0)),
             ));
             let mut signatures = Vec::new();
@@ -520,7 +520,7 @@ mod tests {
     use aws_sigv4::http_request::SigningSettings;
     use aws_smithy_types::config_bag::Layer;
     use aws_types::region::SigningRegion;
-    use aws_types::SigningService;
+    use aws_types::SigningName;
     use std::collections::HashMap;
     use std::time::{Duration, SystemTime};
     use tracing_test::traced_test;
@@ -543,7 +543,7 @@ mod tests {
         );
         let operation_config = SigV4OperationSigningConfig {
             region: Some(SigningRegion::from_static("test")),
-            service: Some(SigningService::from_static("test")),
+            service: Some(SigningName::from_static("test")),
             signing_options: SigningOptions {
                 double_uri_encode: true,
                 content_sha256_header: true,
@@ -570,7 +570,7 @@ mod tests {
         let mut layer = Layer::new("test");
         layer.store_put(SigV4OperationSigningConfig {
             region: Some(SigningRegion::from(Region::new("override-this-region"))),
-            service: Some(SigningService::from_static("override-this-service")),
+            service: Some(SigningName::from_static("override-this-service")),
             signing_options: Default::default(),
         });
         let config = Document::Object({
@@ -597,7 +597,7 @@ mod tests {
         );
         assert_eq!(
             result.service,
-            Some(SigningService::from_static("qldb-override"))
+            Some(SigningName::from_static("qldb-override"))
         );
         assert!(matches!(result, Cow::Owned(_)));
     }
@@ -607,7 +607,7 @@ mod tests {
         let mut layer = Layer::new("test");
         layer.store_put(SigV4OperationSigningConfig {
             region: Some(SigningRegion::from(Region::new("us-east-1"))),
-            service: Some(SigningService::from_static("qldb")),
+            service: Some(SigningName::from_static("qldb")),
             signing_options: Default::default(),
         });
         let cfg = ConfigBag::of_layers(vec![layer]);
@@ -619,7 +619,7 @@ mod tests {
             result.region,
             Some(SigningRegion::from(Region::new("us-east-1")))
         );
-        assert_eq!(result.service, Some(SigningService::from_static("qldb")));
+        assert_eq!(result.service, Some(SigningName::from_static("qldb")));
         assert!(matches!(result, Cow::Borrowed(_)));
     }
 }

--- a/aws/rust-runtime/aws-sig-auth/src/lib.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/lib.rs
@@ -18,7 +18,7 @@
 //! ```rust
 //! use aws_credential_types::Credentials;
 //! use aws_smithy_http::body::SdkBody;
-//! use aws_types::SigningService;
+//! use aws_types::SigningName;
 //! use aws_types::region::{Region, SigningRegion};
 //! use std::time::{Duration, SystemTime, UNIX_EPOCH};
 //! use aws_sig_auth::signer::{self, SigningError, OperationSigningConfig, HttpSignatureType, RequestConfig};
@@ -38,7 +38,7 @@
 //!     let request_config = RequestConfig {
 //!         request_ts: timestamp,
 //!         region: &SigningRegion::from(region),
-//!         service: &SigningService::from_static("rds-db"),
+//!         name: &SigningName::from_static("rds-db"),
 //!         payload_override: None,
 //!     };
 //!     let mut request = http::Request::builder()
@@ -85,7 +85,7 @@
 //! use aws_sig_auth::signer::{OperationSigningConfig, RequestConfig, SigV4Signer};
 //! use aws_smithy_http::body::SdkBody;
 //! use aws_types::region::{Region, SigningRegion};
-//! use aws_types::SigningService;
+//! use aws_types::SigningName;
 //! use std::error::Error;
 //! use std::time::SystemTime;
 //! async fn sign_request(
@@ -98,7 +98,7 @@
 //!     let request_config = RequestConfig {
 //!         request_ts: now,
 //!         region: &SigningRegion::from(region),
-//!         service: &SigningService::from_static("execute-api"),
+//!         name: &SigningName::from_static("execute-api"),
 //!         payload_override: None,
 //!     };
 //!     signer.sign(

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -14,7 +14,7 @@ use aws_credential_types::Credentials;
 use aws_sigv4::http_request::SignableBody;
 use aws_smithy_async::time::SharedTimeSource;
 use aws_types::region::SigningRegion;
-use aws_types::SigningService;
+use aws_types::SigningName;
 
 use crate::signer::{
     OperationSigningConfig, RequestConfig, SigV4Signer, SigningError, SigningRequirements,
@@ -50,7 +50,7 @@ impl AsRef<str> for Signature {
 ///
 /// Prior to signing, the following fields MUST be present in the property bag:
 /// - [`SigningRegion`](SigningRegion): The region used when signing the request, e.g. `us-east-1`
-/// - [`SigningService`](SigningService): The name of the service to use when signing the request, e.g. `dynamodb`
+/// - [`SigningName`](SigningName): The name of the service to use when signing the request, e.g. `dynamodb`
 /// - [`Credentials`](Credentials): Credentials to sign with
 /// - [`OperationSigningConfig`](OperationSigningConfig): Operation specific signing configuration, e.g.
 ///   changes to URL encoding behavior, or headers that must be omitted.
@@ -71,7 +71,7 @@ impl SigV4SigningStage {
 enum SigningStageErrorKind {
     MissingCredentials,
     MissingSigningRegion,
-    MissingSigningService,
+    MissingSigningName,
     MissingSigningConfig,
     SigningFailure(SigningError),
 }
@@ -91,7 +91,7 @@ impl Display for SigningStageError {
             MissingSigningRegion => {
                 write!(f, "no signing region in the property bag")
             }
-            MissingSigningService => {
+            MissingSigningName => {
                 write!(f, "no signing service in the property bag")
             }
             MissingSigningConfig => {
@@ -109,7 +109,7 @@ impl Error for SigningStageError {
             ErrorKind::SigningFailure(err) => Some(err),
             ErrorKind::MissingCredentials
             | ErrorKind::MissingSigningRegion
-            | ErrorKind::MissingSigningService
+            | ErrorKind::MissingSigningName
             | ErrorKind::MissingSigningConfig => None,
         }
     }
@@ -143,9 +143,9 @@ fn signing_config(
     let region = config
         .get::<SigningRegion>()
         .ok_or(SigningStageErrorKind::MissingSigningRegion)?;
-    let signing_service = config
-        .get::<SigningService>()
-        .ok_or(SigningStageErrorKind::MissingSigningService)?;
+    let name = config
+        .get::<SigningName>()
+        .ok_or(SigningStageErrorKind::MissingSigningName)?;
     let payload_override = config.get::<SignableBody<'static>>();
     let request_config = RequestConfig {
         request_ts: config
@@ -154,7 +154,7 @@ fn signing_config(
             .unwrap_or_else(|| SharedTimeSource::default().now()),
         region,
         payload_override,
-        service: signing_service,
+        name,
     };
     Ok((operation_config, request_config, credentials))
 }
@@ -195,7 +195,7 @@ impl MapRequest for SigV4SigningStage {
                         signature.as_ref().into(),
                         creds,
                         request_config.region.clone(),
-                        request_config.service.clone(),
+                        request_config.name.clone(),
                         time_override,
                     )) as _)
                     .expect("failed to send deferred signer");
@@ -221,7 +221,7 @@ mod test {
     use aws_endpoint::AwsAuthStage;
     use aws_smithy_async::time::SharedTimeSource;
     use aws_types::region::{Region, SigningRegion};
-    use aws_types::SigningService;
+    use aws_types::SigningName;
 
     use crate::middleware::{
         SigV4SigningStage, Signature, SigningStageError, SigningStageErrorKind,
@@ -239,7 +239,7 @@ mod test {
             .augment(|req, properties| {
                 properties.insert(region.clone());
                 properties.insert(UNIX_EPOCH + Duration::new(1611160427, 0));
-                properties.insert(SigningService::from_static("kinesis"));
+                properties.insert(SigningName::from_static("kinesis"));
                 properties.insert(OperationSigningConfig::default_config());
                 properties.insert(Credentials::for_tests());
                 properties.insert(SigningRegion::from(region));
@@ -273,7 +273,7 @@ mod test {
                 properties.insert::<SharedTimeSource>(SharedTimeSource::new(
                     UNIX_EPOCH + Duration::new(1611160427, 0),
                 ));
-                properties.insert(SigningService::from_static("kinesis"));
+                properties.insert(SigningName::from_static("kinesis"));
                 properties.insert(OperationSigningConfig::default_config());
                 properties.insert(Credentials::for_tests());
                 properties.insert(SigningRegion::from(region.clone()));
@@ -290,7 +290,7 @@ mod test {
             "abac477b4afabf5651079e7b9a0aa6a1a3e356a7418a81d974cdae9d4c8e5441".into(),
             Credentials::for_tests(),
             SigningRegion::from(region),
-            SigningService::from_static("kinesis"),
+            SigningName::from_static("kinesis"),
             Some(UNIX_EPOCH + Duration::new(1611160427, 0)),
         );
 
@@ -317,7 +317,7 @@ mod test {
                 conf.insert(SharedTimeSource::new(
                     UNIX_EPOCH + Duration::new(1611160427, 0),
                 ));
-                conf.insert(SigningService::from_static("kinesis"));
+                conf.insert(SigningName::from_static("kinesis"));
                 conf.insert(endpoint);
                 Result::<_, Infallible>::Ok(req)
             })

--- a/aws/rust-runtime/aws-sig-auth/src/signer.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/signer.rs
@@ -10,7 +10,7 @@ use aws_sigv4::http_request::{
 };
 use aws_smithy_http::body::SdkBody;
 use aws_types::region::SigningRegion;
-use aws_types::SigningService;
+use aws_types::SigningName;
 use std::fmt;
 use std::time::{Duration, SystemTime};
 
@@ -102,7 +102,7 @@ pub struct SigningOptions {
 pub struct RequestConfig<'a> {
     pub request_ts: SystemTime,
     pub region: &'a SigningRegion,
-    pub service: &'a SigningService,
+    pub name: &'a SigningName,
     pub payload_override: Option<&'a SignableBody<'static>>,
 }
 
@@ -175,7 +175,7 @@ impl SigV4Signer {
             .access_key(credentials.access_key_id())
             .secret_key(credentials.secret_access_key())
             .region(request_config.region.as_ref())
-            .service_name(request_config.service.as_ref())
+            .name(request_config.name.as_ref())
             .time(request_config.request_ts)
             .settings(settings);
         builder.set_security_token(credentials.session_token());
@@ -240,7 +240,7 @@ mod tests {
     use aws_credential_types::Credentials;
     use aws_sigv4::http_request::SigningSettings;
     use aws_types::region::SigningRegion;
-    use aws_types::SigningService;
+    use aws_types::SigningName;
     use std::time::{Duration, SystemTime};
     use tracing_test::traced_test;
 
@@ -263,7 +263,7 @@ mod tests {
         let request_config = RequestConfig {
             request_ts: now,
             region: &SigningRegion::from_static("test"),
-            service: &SigningService::from_static("test"),
+            name: &SigningName::from_static("test"),
             payload_override: None,
         };
         SigV4Signer::signing_params(settings, &credentials, &request_config);

--- a/aws/rust-runtime/aws-sigv4/src/event_stream.rs
+++ b/aws/rust-runtime/aws-sigv4/src/event_stream.rs
@@ -25,7 +25,7 @@
 //!     .access_key("example access key")
 //!     .secret_key("example secret key")
 //!     .region("us-east-1")
-//!     .service_name("exampleservice")
+//!     .name("exampleservice")
 //!     .time(SystemTime::now())
 //!     .settings(())
 //!     .build()
@@ -65,7 +65,7 @@ fn calculate_string_to_sign(
     writeln!(
         sts,
         "{}/{}/{}/aws4_request",
-        date_str, params.region, params.service_name
+        date_str, params.region, params.name
     )
     .unwrap();
     writeln!(sts, "{}", last_signature).unwrap();
@@ -117,8 +117,7 @@ fn sign_payload<'a>(
     // needs to exactly match the string formatted timestamp, which doesn't include sub-seconds.
     let time = truncate_subsecs(params.time);
 
-    let signing_key =
-        generate_signing_key(params.secret_key, time, params.region, params.service_name);
+    let signing_key = generate_signing_key(params.secret_key, time, params.region, params.name);
     let string_to_sign = calculate_string_to_sign(
         message_payload.as_ref().map(|v| &v[..]).unwrap_or(&[]),
         last_signature,
@@ -159,7 +158,7 @@ mod tests {
             secret_key: "fake secret key",
             security_token: None,
             region: "us-east-1",
-            service_name: "testservice",
+            name: "testservice",
             time: (UNIX_EPOCH + Duration::new(123_456_789_u64, 1234u32)),
             settings: (),
         };
@@ -197,7 +196,7 @@ mod tests {
             secret_key: "fake secret key",
             security_token: None,
             region: "us-east-1",
-            service_name: "testservice",
+            name: "testservice",
             time: (UNIX_EPOCH + Duration::new(123_456_789_u64, 1234u32)),
             settings: (),
         };

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -170,7 +170,7 @@ impl<'a> CanonicalRequest<'a> {
                     params.access_key,
                     format_date(params.time),
                     params.region,
-                    params.service_name,
+                    params.name,
                 ),
                 date_time,
                 expires: params
@@ -554,7 +554,7 @@ mod tests {
             secret_key: "test-secret-key",
             security_token: None,
             region: "test-region",
-            service_name: "testservicename",
+            name: "testservicename",
             time: parse_date_time("20210511T154045Z").unwrap(),
             settings,
         }

--- a/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
@@ -23,7 +23,7 @@
 //!     .access_key("example access key")
 //!     .secret_key("example secret key")
 //!     .region("us-east-1")
-//!     .service_name("exampleservice")
+//!     .name("exampleservice")
 //!     .time(SystemTime::now())
 //!     .settings(signing_settings)
 //!     .build()

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -215,19 +215,10 @@ fn calculate_signing_params<'a>(
     let creq = CanonicalRequest::from(request, params)?;
 
     let encoded_creq = &sha256_hex_string(creq.to_string().as_bytes());
-    let string_to_sign = StringToSign::new(
-        params.time,
-        params.region,
-        params.service_name,
-        encoded_creq,
-    )
-    .to_string();
-    let signing_key = generate_signing_key(
-        params.secret_key,
-        params.time,
-        params.region,
-        params.service_name,
-    );
+    let string_to_sign =
+        StringToSign::new(params.time, params.region, params.name, encoded_creq).to_string();
+    let signing_key =
+        generate_signing_key(params.secret_key, params.time, params.region, params.name);
     let signature = calculate_signature(signing_key, string_to_sign.as_bytes());
     tracing::trace!(canonical_request = %creq, string_to_sign = %string_to_sign, "calculated signing parameters");
 
@@ -270,20 +261,11 @@ fn calculate_signing_headers<'a>(
 
     // Step 2: https://docs.aws.amazon.com/en_pv/general/latest/gr/sigv4-create-string-to-sign.html.
     let encoded_creq = &sha256_hex_string(creq.to_string().as_bytes());
-    let sts = StringToSign::new(
-        params.time,
-        params.region,
-        params.service_name,
-        encoded_creq,
-    );
+    let sts = StringToSign::new(params.time, params.region, params.name, encoded_creq);
 
     // Step 3: https://docs.aws.amazon.com/en_pv/general/latest/gr/sigv4-calculate-signature.html
-    let signing_key = generate_signing_key(
-        params.secret_key,
-        params.time,
-        params.region,
-        params.service_name,
-    );
+    let signing_key =
+        generate_signing_key(params.secret_key, params.time, params.region, params.name);
     let signature = calculate_signature(signing_key, sts.to_string().as_bytes());
 
     // Step 4: https://docs.aws.amazon.com/en_pv/general/latest/gr/sigv4-add-signature-to-request.html
@@ -388,7 +370,7 @@ mod tests {
             secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             security_token: None,
             region: "us-east-1",
-            service_name: "service",
+            name: "service",
             time: parse_date_time("20150830T123600Z").unwrap(),
             settings,
         };
@@ -417,7 +399,7 @@ mod tests {
             secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             security_token: None,
             region: "us-east-1",
-            service_name: "service",
+            name: "service",
             time: parse_date_time("20150830T123600Z").unwrap(),
             settings,
         };
@@ -449,7 +431,7 @@ mod tests {
             secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             security_token: None,
             region: "us-east-1",
-            service_name: "service",
+            name: "service",
             time: parse_date_time("20150830T123600Z").unwrap(),
             settings,
         };
@@ -477,7 +459,7 @@ mod tests {
             secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             security_token: None,
             region: "us-east-1",
-            service_name: "service",
+            name: "service",
             time: parse_date_time("20150830T123600Z").unwrap(),
             settings,
         };
@@ -531,7 +513,7 @@ mod tests {
             secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             security_token: None,
             region: "us-east-1",
-            service_name: "service",
+            name: "service",
             time: parse_date_time("20150830T123600Z").unwrap(),
             settings,
         };
@@ -593,7 +575,7 @@ mod tests {
             secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             security_token: None,
             region: "us-east-1",
-            service_name: "service",
+            name: "service",
             time: parse_date_time("20150830T123600Z").unwrap(),
             settings,
         };
@@ -655,7 +637,7 @@ mod tests {
                 secret_key: "asdf",
                 security_token: None,
                 region: "us-east-1",
-                service_name: "foo",
+                name: "foo",
                 time: std::time::SystemTime::UNIX_EPOCH,
                 settings,
             };

--- a/aws/rust-runtime/aws-sigv4/src/lib.rs
+++ b/aws/rust-runtime/aws-sigv4/src/lib.rs
@@ -40,8 +40,10 @@ pub struct SigningParams<'a, S> {
 
     /// Region to sign for.
     pub(crate) region: &'a str,
-    /// AWS Service Name to sign for.
-    pub(crate) service_name: &'a str,
+    /// Service Name to sign for.
+    ///
+    /// NOTE: Endpoint resolution rules may specify a name that differs from the typical service name.
+    pub(crate) name: &'a str,
     /// Timestamp to use in the signature (should be `SystemTime::now()` unless testing).
     pub(crate) time: SystemTime,
 
@@ -50,14 +52,14 @@ pub struct SigningParams<'a, S> {
 }
 
 impl<'a, S> SigningParams<'a, S> {
-    /// Returns the region that will be used to sign
+    /// Returns the signing region.
     pub fn region(&self) -> &str {
         self.region
     }
 
-    /// Returns the service name that will be used to sign
-    pub fn service_name(&self) -> &str {
-        self.service_name
+    /// Returns the signing name.
+    pub fn name(&self) -> &str {
+        self.name
     }
 }
 
@@ -68,7 +70,7 @@ impl<'a, S: fmt::Debug> fmt::Debug for SigningParams<'a, S> {
             .field("secret_key", &"** redacted **")
             .field("security_token", &"** redacted **")
             .field("region", &self.region)
-            .field("service_name", &self.service_name)
+            .field("name", &self.name)
             .field("time", &self.time)
             .field("settings", &self.settings)
             .finish()
@@ -115,7 +117,7 @@ pub mod signing_params {
         secret_key: Option<&'a str>,
         security_token: Option<&'a str>,
         region: Option<&'a str>,
-        service_name: Option<&'a str>,
+        name: Option<&'a str>,
         time: Option<SystemTime>,
         settings: Option<S>,
     }
@@ -161,14 +163,14 @@ pub mod signing_params {
             self.region = region;
         }
 
-        /// Sets the service name (required)
-        pub fn service_name(mut self, service_name: &'a str) -> Self {
-            self.service_name = Some(service_name);
+        /// Sets the signing name (required)
+        pub fn name(mut self, name: &'a str) -> Self {
+            self.name = Some(name);
             self
         }
-        /// Sets the service name (required)
-        pub fn set_service_name(&mut self, service_name: Option<&'a str>) {
-            self.service_name = service_name;
+        /// Sets the signing name (required)
+        pub fn set_name(&mut self, name: Option<&'a str>) {
+            self.name = name;
         }
 
         /// Sets the time to be used in the signature (required)
@@ -205,9 +207,9 @@ pub mod signing_params {
                 region: self
                     .region
                     .ok_or_else(|| BuildError::new("region is required"))?,
-                service_name: self
-                    .service_name
-                    .ok_or_else(|| BuildError::new("service name is required"))?,
+                name: self
+                    .name
+                    .ok_or_else(|| BuildError::new("name is required"))?,
                 time: self
                     .time
                     .ok_or_else(|| BuildError::new("time is required"))?,

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -30,34 +30,34 @@ use std::borrow::Cow;
 
 /// The name of the service used to sign this request
 ///
-/// Generally, user code should never interact with `SigningService` directly
+/// Generally, user code should never interact with `SigningName` directly
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SigningService(Cow<'static, str>);
-impl AsRef<str> for SigningService {
+pub struct SigningName(Cow<'static, str>);
+impl AsRef<str> for SigningName {
     fn as_ref(&self) -> &str {
         &self.0
     }
 }
 
-impl SigningService {
-    /// Creates a `SigningService` from a static str.
-    pub fn from_static(service: &'static str) -> Self {
-        SigningService(Cow::Borrowed(service))
+impl SigningName {
+    /// Creates a `SigningName` from a static str.
+    pub fn from_static(name: &'static str) -> Self {
+        SigningName(Cow::Borrowed(name))
     }
 }
 
-impl From<String> for SigningService {
-    fn from(service: String) -> Self {
-        SigningService(Cow::Owned(service))
+impl From<String> for SigningName {
+    fn from(name: String) -> Self {
+        SigningName(Cow::Owned(name))
     }
 }
 
-impl From<&'static str> for SigningService {
-    fn from(service: &'static str) -> Self {
-        Self::from_static(service)
+impl From<&'static str> for SigningName {
+    fn from(name: &'static str) -> Self {
+        Self::from_static(name)
     }
 }
 
-impl Storable for SigningService {
+impl Storable for SigningName {
     type Storer = StoreReplace<Self>;
 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -60,10 +60,7 @@ private class AuthServiceRuntimePluginCustomization(private val codegenContext: 
     private val codegenScope by lazy {
         val awsRuntime = AwsRuntimeType.awsRuntime(runtimeConfig)
         arrayOf(
-            "SIGV4_SCHEME_ID" to awsRuntime.resolve("auth::sigv4::SCHEME_ID"),
             "SigV4AuthScheme" to awsRuntime.resolve("auth::sigv4::SigV4AuthScheme"),
-            "SigningRegion" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("region::SigningRegion"),
-            "SigningService" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("SigningService"),
             "SharedAuthScheme" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::auth::SharedAuthScheme"),
         )
     }
@@ -91,13 +88,10 @@ private class AuthOperationCustomization(private val codegenContext: ClientCodeg
     private val codegenScope by lazy {
         val awsRuntime = AwsRuntimeType.awsRuntime(runtimeConfig)
         arrayOf(
-            "HttpSignatureType" to awsRuntime.resolve("auth::sigv4::HttpSignatureType"),
-            "SIGV4_SCHEME_ID" to awsRuntime.resolve("auth::sigv4::SCHEME_ID"),
             "SigV4OperationSigningConfig" to awsRuntime.resolve("auth::sigv4::SigV4OperationSigningConfig"),
             "SigningOptions" to awsRuntime.resolve("auth::sigv4::SigningOptions"),
-            "SigningRegion" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("region::SigningRegion"),
-            "SigningService" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("SigningService"),
             "SignableBody" to AwsRuntimeType.awsSigv4(runtimeConfig).resolve("http_request::SignableBody"),
+            "Default" to RuntimeType.Default,
         )
     }
     private val serviceIndex = ServiceIndex.of(codegenContext.model)
@@ -113,6 +107,7 @@ private class AuthOperationCustomization(private val codegenContext: ClientCodeg
                     val normalizeUrlPath = !disableUriPathNormalization(codegenContext.serviceShape)
                     rustTemplate(
                         """
+                        // SigningOptions is non-exhaustive, so it can't be created with a struct expression.
                         let mut signing_options = #{SigningOptions}::default();
                         signing_options.double_uri_encode = $doubleUriEncode;
                         signing_options.content_sha256_header = $contentSha256Header;
@@ -120,9 +115,8 @@ private class AuthOperationCustomization(private val codegenContext: ClientCodeg
                         signing_options.payload_override = #{payload_override};
 
                         ${section.newLayerName}.store_put(#{SigV4OperationSigningConfig} {
-                            region: None,
-                            service: None,
                             signing_options,
+                            ..#{Default}::default()
                         });
                         """,
                         *codegenScope,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
@@ -35,9 +35,9 @@ import software.amazon.smithy.rust.codegen.core.util.isInputEventStream
 // TODO(enableNewSmithyRuntimeCleanup): Remove this decorator (superseded by SigV4AuthDecorator)
 /**
  * The SigV4SigningDecorator:
- * - adds a `signing_service()` method to `config` to return the default signing service
+ * - adds a `name()` method to `config` to return the default signing service
  * - adds a `new_event_stream_signer()` method to `config` to create an Event Stream SigV4 signer
- * - sets the `SigningService` during operation construction
+ * - sets the `SigningName` during operation construction
  * - sets a default `OperationSigningConfig` A future enhancement will customize this for specific services that need
  *   different behavior.
  */
@@ -83,7 +83,7 @@ class SigV4SigningConfig(
 ) : ConfigCustomization() {
     private val codegenScope = arrayOf(
         "Region" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("region::Region"),
-        "SigningService" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("SigningService"),
+        "SigningName" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("SigningName"),
         "SigningRegion" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("region::SigningRegion"),
     )
 
@@ -94,9 +94,9 @@ class SigV4SigningConfig(
                     """
                     /// The signature version 4 service signing name to use in the credential scope when signing requests.
                     ///
-                    /// The signing service may be overridden by the `Endpoint`, or by specifying a custom
-                    /// [`SigningService`](aws_types::SigningService) during operation construction
-                    pub fn signing_service(&self) -> &'static str {
+                    /// The signing name may be overridden by the `Endpoint`, or by specifying a custom
+                    /// [`SigningName`](aws_types::SigningName) during operation construction
+                    pub fn name(&self) -> &'static str {
                         ${sigV4Trait.name.dq()}
                     }
                     """,
@@ -105,7 +105,7 @@ class SigV4SigningConfig(
             ServiceConfig.BuilderBuild -> {
                 rustTemplate(
                     """
-                    layer.store_put(#{SigningService}::from_static(${sigV4Trait.name.dq()}));
+                    layer.store_put(#{SigningName}::from_static(${sigV4Trait.name.dq()}));
                     layer.load::<#{Region}>().cloned().map(|r| layer.store_put(#{SigningRegion}::from(r)));
                     """,
                     *codegenScope,
@@ -194,7 +194,7 @@ class SigV4SigningFeature(
                 rustTemplate(
                     """
                     ${section.request}.properties_mut().insert(signing_config);
-                    ${section.request}.properties_mut().insert(#{aws_types}::SigningService::from_static(${section.config}.signing_service()));
+                    ${section.request}.properties_mut().insert(#{aws_types}::SigningName::from_static(${section.config}.name()));
                     if let Some(region) = &${section.config}.region {
                         ${section.request}.properties_mut().insert(#{aws_types}::region::SigningRegion::from(region.clone()));
                     }

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecoratorTest.kt
@@ -32,10 +32,10 @@ internal class SigV4SigningDecoratorTest {
         )
         project.lib {
             unitTest(
-                "signing_service_override",
+                "signing_name_override",
                 """
                 let conf = crate::config::Config::builder().build();
-                assert_eq!(conf.signing_service(), "test-service");
+                assert_eq!(conf.name(), "test-service");
                 """,
             )
         }

--- a/aws/sdk/integration-tests/qldbsession/tests/integration.rs
+++ b/aws/sdk/integration-tests/qldbsession/tests/integration.rs
@@ -24,7 +24,7 @@ async fn signv4_use_correct_service_name() {
             .header("x-amz-target", "QLDBSession.SendCommand")
             .header("content-length", "49")
             .header("authorization", "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210305/us-east-1/qldb/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-security-token;x-amz-target;x-amz-user-agent, Signature=350f957e9b736ac3f636d16c59c0a3cee8c2780b0ffadc99bbca841b7f15bee4")
-            // qldbsession uses the service name 'qldb' in signature ____________________________________^^^^
+            // qldbsession uses the signing name 'qldb' in signature ____________________________________^^^^
             .header("x-amz-date", "20210305T134922Z")
             .header("x-amz-security-token", "notarealsessiontoken")
             .header("user-agent", "aws-sdk-rust/0.123.test os/windows/XPSP3 lang/rust/1.50.0")


### PR DESCRIPTION
Part of the SigV4a update. I split this out to making review simpler.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
