### PR TITLE
Clean up the pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,19 +6,6 @@ repos:
   - id: end-of-file-fixer
     exclude: ^aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/
   - id: trailing-whitespace
-- repo: local
-  hooks:
-  - id: kotlin-block-quotes
-    name: Kotlin Block Quotes
-    entry: ./.pre-commit-hooks/kotlin-block-quotes.py
-    language: python
-    files: ^.*\.kt$
-  - id: license-header-check
-    name: License Header Check
-    entry: ./.pre-commit-hooks/license-header.sh
-    language: system
-    files: ^.*$
-    pass_filenames: false
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.10.0
   hooks:
@@ -29,3 +16,16 @@ repos:
   - id: pretty-format-rust
     entry: rustfmt --edition 2021
     files: ^.*\.rs$
+- repo: local
+  hooks:
+  - id: kotlin-block-quotes
+    name: Kotlin Block Quotes
+    entry: ./.pre-commit-hooks/kotlin-block-quotes.py
+    language: python
+    files: ^.*\.kt$
+  - id: sdk-lints-check
+    name: sdk-lints
+    entry: ./.pre-commit-hooks/sdk-lints.sh
+    language: system
+    files: ^.*$
+    pass_filenames: false

--- a/.pre-commit-hooks/sdk-lints.sh
+++ b/.pre-commit-hooks/sdk-lints.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-set -e
-
 #
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -e
 cd "$(git rev-parse --show-toplevel)/tools/ci-build/sdk-lints" && cargo run -- check --license --changelog


### PR DESCRIPTION
Update the name of the `sdk-lints` check since it checks more than just license headers now, and make it run at the end so that KTLint runs and fixes files even if there's an invalid changelog entry.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
