### PR TITLE
Fix re-export of `SdkError`

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -52,7 +52,7 @@ jobs:
     name: Acquire Base Image
     needs: save-docker-login-token
     if: ${{ github.event.pull_request.head.repo.full_name == 'awslabs/smithy-rs' }}
-    runs-on: ubuntu-latest
+    runs-on: smithy_ubuntu-latest_8-core
     env:
       ENCRYPTED_DOCKER_PASSWORD: ${{ needs.save-docker-login-token.outputs.docker-login-password }}
       DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -1,8 +1,21 @@
 # This workflow updates the `next` branch with freshly generated
 # code from the latest smithy-rs and models that reside in aws-sdk-rust.
+
+# Allow only one release to run at a time
+concurrency:
+  group: update-aws-sdk-next
+  cancel-in-progress: true
+
 name: Update `aws-sdk-rust/next`
 on:
   workflow_dispatch:
+    inputs:
+      generate_ref:
+        description: |
+          Which branch/commit/tag of smithy-rs to use to generate aws-sdk-rust/next. Defaults to `main`.
+        required: true
+        type: string
+        default: main
 
 jobs:
   update-next:
@@ -13,7 +26,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: awslabs/smithy-rs
-        ref: main
+        ref: ${{ inputs.generate_ref }}
         path: smithy-rs
     - name: Check out `aws-sdk-rust`
       uses: actions/checkout@v3

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,15 @@ message = "Fix requests to S3 with `no_credentials` set."
 references = ["smithy-rs#2907", "aws-sdk-rust#864"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Fixed re-exported `SdkError` type. The previous release had the wrong type for `SdkError`, which caused projects to fail to compile when upgrading."
+references = ["smithy-rs#2931", "aws-sdk-rust#875"]
+meta = { "breaking" = true, "tada" = false, "bug" = true }
+author = "jdisanti"
+
+[[smithy-rs]]
+message = "Fixed re-exported `SdkError` type. The previous release had the wrong type for `SdkError` when generating code for orchestrator mode, which caused projects to fail to compile when upgrading."
+references = ["smithy-rs#2931", "aws-sdk-rust#875"]
+meta = { "breaking" = true, "tada" = false, "bug" = true, "target" = "client" }
+author = "jdisanti"

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -247,7 +247,6 @@ tasks.register<ExecRustBuildTool>("fixExampleManifests") {
     binaryName = "sdk-versioner"
     arguments = listOf(
         "use-path-and-version-dependencies",
-        "--isolate-crates",
         "--sdk-path", sdkOutputDir.absolutePath,
         "--versions-toml", outputDir.resolve("versions.toml").absolutePath,
         outputDir.resolve("examples").absolutePath,

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import aws.sdk.AwsExamplesLayout
 import aws.sdk.AwsServices
 import aws.sdk.Membership
 import aws.sdk.discoverServices
@@ -246,22 +245,13 @@ tasks.register<ExecRustBuildTool>("fixExampleManifests") {
 
     toolPath = sdkVersionerToolPath
     binaryName = "sdk-versioner"
-    arguments = when (AwsExamplesLayout.detect(project)) {
-        AwsExamplesLayout.Flat -> listOf(
-            "use-path-and-version-dependencies",
-            "--isolate-crates",
-            "--sdk-path", "../../sdk",
-            "--versions-toml", outputDir.resolve("versions.toml").absolutePath,
-            outputDir.resolve("examples").absolutePath,
-        )
-        AwsExamplesLayout.Workspaces -> listOf(
-            "use-path-and-version-dependencies",
-            "--isolate-crates",
-            "--sdk-path", sdkOutputDir.absolutePath,
-            "--versions-toml", outputDir.resolve("versions.toml").absolutePath,
-            outputDir.resolve("examples").absolutePath,
-        )
-    }
+    arguments = listOf(
+        "use-path-and-version-dependencies",
+        "--isolate-crates",
+        "--sdk-path", sdkOutputDir.absolutePath,
+        "--versions-toml", outputDir.resolve("versions.toml").absolutePath,
+        outputDir.resolve("examples").absolutePath,
+    )
 
     outputs.dir(outputDir)
     dependsOn("relocateExamples", "generateVersionManifest")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -99,13 +99,13 @@ class RequiredCustomizations : ClientCodegenDecorator {
             rust("/// Error type returned by the client.")
             if (codegenContext.smithyRuntimeMode.generateOrchestrator) {
                 rustTemplate(
-                    "pub type SdkError<E> = #{SdkError}<E, #{R}>;",
+                    "pub type SdkError<E, R = #{R}> = #{SdkError}<E, R>;",
                     "SdkError" to RuntimeType.sdkError(rc),
                     "R" to RuntimeType.smithyRuntimeApi(rc).resolve("client::orchestrator::HttpResponse"),
                 )
             } else {
                 rustTemplate(
-                    "pub type SdkError<E> = #{SdkError}<E, #{R}>;",
+                    "pub type SdkError<E, R = #{R}> = #{SdkError}<E, R>;",
                     "SdkError" to RuntimeType.sdkError(rc),
                     "R" to RuntimeType.smithyHttp(rc).resolve("operation::Response"),
                 )

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -24,10 +24,11 @@ import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCus
 import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.core.rustlang.Feature
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customizations.AllowLintsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customizations.CrateVersionCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customizations.pubUseSmithyErrorTypes
 import software.amazon.smithy.rust.codegen.core.smithy.customizations.pubUseSmithyPrimitives
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.util.letIf
@@ -79,6 +80,8 @@ class RequiredCustomizations : ClientCodegenDecorator {
         baseCustomizations + AllowLintsCustomization()
 
     override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
+        val rc = codegenContext.runtimeConfig
+
         // Add rt-tokio feature for `ByteStream::from_path`
         rustCrate.mergeFeature(Feature("rt-tokio", true, listOf("aws-smithy-http/rt-tokio")))
 
@@ -91,7 +94,21 @@ class RequiredCustomizations : ClientCodegenDecorator {
             pubUseSmithyPrimitives(codegenContext, codegenContext.model)(this)
         }
         rustCrate.withModule(ClientRustModule.Error) {
-            pubUseSmithyErrorTypes(codegenContext)(this)
+            rustTemplate(
+                """
+                pub type SdkError<E> = #{SdkError}<E, #{SdkErrorResponse}>;
+                pub use #{DisplayErrorContext};
+                pub use #{ProvideErrorMetadata};
+                """,
+                "SdkError" to RuntimeType.smithyHttp(rc).resolve("result::SdkError"),
+                "SdkErrorResponse" to if (codegenContext.smithyRuntimeMode.generateOrchestrator) {
+                    RuntimeType.smithyRuntimeApi(rc).resolve("client::orchestrator::HttpResponse")
+                } else {
+                    RuntimeType.HttpResponse
+                },
+                "DisplayErrorContext" to RuntimeType.smithyTypes(rc).resolve("error::display::DisplayErrorContext"),
+                "ProvideErrorMetadata" to RuntimeType.smithyTypes(rc).resolve("error::metadata::ProvideErrorMetadata"),
+            )
         }
 
         ClientRustModule.Meta.also { metaModule ->

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtra.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtra.kt
@@ -9,20 +9,12 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
-import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
-import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.util.hasEventStreamMember
 import software.amazon.smithy.rust.codegen.core.util.hasStreamingMember
-import software.amazon.smithy.rust.codegen.core.util.letIf
-
-private data class PubUseType(
-    val type: RuntimeType,
-    val shouldExport: (Model) -> Boolean,
-    val alias: String? = null,
-)
 
 /** Returns true if the model has normal streaming operations (excluding event streams) */
 private fun hasStreamingOperations(model: Model): Boolean {
@@ -48,62 +40,34 @@ private fun hasBlobs(model: Model): Boolean = structUnionMembersMatchPredicate(m
 /** Returns true if the model uses any timestamp shapes */
 private fun hasDateTimes(model: Model): Boolean = structUnionMembersMatchPredicate(model, Shape::isTimestampShape)
 
-/** Returns a list of types that should be re-exported for the given model */
-internal fun pubUseTypes(codegenContext: CodegenContext, model: Model): List<RuntimeType> =
-    pubUseTypesThatShouldBeExported(codegenContext, model).map { it.type }
-
-private fun pubUseTypesThatShouldBeExported(codegenContext: CodegenContext, model: Model): List<PubUseType> {
-    val runtimeConfig = codegenContext.runtimeConfig
-    return (
-        listOf(
-            PubUseType(RuntimeType.blob(runtimeConfig), ::hasBlobs),
-            PubUseType(RuntimeType.dateTime(runtimeConfig), ::hasDateTimes),
-            PubUseType(RuntimeType.format(runtimeConfig), ::hasDateTimes, "DateTimeFormat"),
-        ) + RuntimeType.smithyHttp(runtimeConfig).let { http ->
-            listOf(
-                PubUseType(http.resolve("byte_stream::ByteStream"), ::hasStreamingOperations),
-                PubUseType(http.resolve("byte_stream::AggregatedBytes"), ::hasStreamingOperations),
-                PubUseType(http.resolve("byte_stream::error::Error"), ::hasStreamingOperations, "ByteStreamError"),
-                PubUseType(http.resolve("body::SdkBody"), ::hasStreamingOperations),
-            )
-        }
-        ).filter { pubUseType -> pubUseType.shouldExport(model) }
-}
-
 /** Adds re-export statements for Smithy primitives */
 fun pubUseSmithyPrimitives(codegenContext: CodegenContext, model: Model): Writable = writable {
-    val types = pubUseTypesThatShouldBeExported(codegenContext, model)
-    if (types.isNotEmpty()) {
-        types.forEach {
-            val useStatement = if (it.alias == null) {
-                "pub use #T;"
-            } else {
-                "pub use #T as ${it.alias};"
-            }
-            rust(useStatement, it.type)
-        }
+    val rc = codegenContext.runtimeConfig
+    if (hasBlobs(model)) {
+        rustTemplate("pub use #{Blob};", "Blob" to RuntimeType.blob(rc))
     }
-}
-
-/** Adds re-export statements for error types */
-fun pubUseSmithyErrorTypes(codegenContext: CodegenContext): Writable = writable {
-    val runtimeConfig = codegenContext.runtimeConfig
-    val reexports = listOf(
-        listOf(
-            RuntimeType.smithyHttp(runtimeConfig).let { http ->
-                PubUseType(http.resolve("result::SdkError"), { _ -> true })
-            },
-        ),
-        RuntimeType.smithyTypes(runtimeConfig).let { types ->
-            listOf(PubUseType(types.resolve("error::display::DisplayErrorContext"), { _ -> true }))
-                // Only re-export `ProvideErrorMetadata` for clients
-                .letIf(codegenContext.target == CodegenTarget.CLIENT) { list ->
-                    list +
-                        listOf(PubUseType(types.resolve("error::metadata::ProvideErrorMetadata"), { _ -> true }))
-                }
-        },
-    ).flatten()
-    reexports.forEach { reexport ->
-        rust("pub use #T;", reexport.type)
+    if (hasDateTimes(model)) {
+        rustTemplate(
+            """
+            pub use #{DateTime};
+            pub use #{Format} as DateTimeFormat;
+            """,
+            "DateTime" to RuntimeType.dateTime(rc),
+            "Format" to RuntimeType.format(rc),
+        )
+    }
+    if (hasStreamingOperations(model)) {
+        rustTemplate(
+            """
+            pub use #{ByteStream};
+            pub use #{AggregatedBytes};
+            pub use #{Error} as ByteStreamError;
+            pub use #{SdkBody};
+            """,
+            "ByteStream" to RuntimeType.smithyHttp(rc).resolve("byte_stream::ByteStream"),
+            "AggregatedBytes" to RuntimeType.smithyHttp(rc).resolve("byte_stream::AggregatedBytes"),
+            "Error" to RuntimeType.smithyHttp(rc).resolve("byte_stream::error::Error"),
+            "SdkBody" to RuntimeType.smithyHttp(rc).resolve("body::SdkBody"),
+        )
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
@@ -42,13 +42,14 @@ class ServerRequiredCustomizations : ServerCodegenDecorator {
 
         rustCrate.withModule(ServerRustModule.Types) {
             pubUseSmithyPrimitives(codegenContext, codegenContext.model)(this)
+            // TODO(enableNewSmithyRuntimeCleanup): Remove re-export of SdkError in server and add changelog entry
             rustTemplate(
                 """
-                pub type SdkError<E> = #{SdkError}<E, #{SdkErrorResponse}>;
+                pub type SdkError<E> = #{SdkError}<E, #{Response}>;
                 pub use #{DisplayErrorContext};
                 """,
                 "SdkError" to RuntimeType.smithyHttp(rc).resolve("result::SdkError"),
-                "SdkErrorResponse" to RuntimeType.HttpResponse,
+                "Response" to RuntimeType.smithyHttp(rc).resolve("operation::Response"),
                 "DisplayErrorContext" to RuntimeType.smithyTypes(rc).resolve("error::display::DisplayErrorContext"),
             )
         }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
@@ -6,10 +6,11 @@
 package software.amazon.smithy.rust.codegen.server.smithy.customizations
 
 import software.amazon.smithy.rust.codegen.core.rustlang.Feature
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customizations.AllowLintsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customizations.CrateVersionCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customizations.pubUseSmithyErrorTypes
 import software.amazon.smithy.rust.codegen.core.smithy.customizations.pubUseSmithyPrimitives
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
@@ -34,12 +35,22 @@ class ServerRequiredCustomizations : ServerCodegenDecorator {
         baseCustomizations + AllowLintsCustomization()
 
     override fun extras(codegenContext: ServerCodegenContext, rustCrate: RustCrate) {
+        val rc = codegenContext.runtimeConfig
+
         // Add rt-tokio feature for `ByteStream::from_path`
         rustCrate.mergeFeature(Feature("rt-tokio", true, listOf("aws-smithy-http/rt-tokio")))
 
         rustCrate.withModule(ServerRustModule.Types) {
             pubUseSmithyPrimitives(codegenContext, codegenContext.model)(this)
-            pubUseSmithyErrorTypes(codegenContext)(this)
+            rustTemplate(
+                """
+                pub type SdkError<E> = #{SdkError}<E, #{SdkErrorResponse}>;
+                pub use #{DisplayErrorContext};
+                """,
+                "SdkError" to RuntimeType.smithyHttp(rc).resolve("result::SdkError"),
+                "SdkErrorResponse" to RuntimeType.HttpResponse,
+                "DisplayErrorContext" to RuntimeType.smithyTypes(rc).resolve("error::display::DisplayErrorContext"),
+            )
         }
 
         rustCrate.withModule(ServerRustModule.root) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
@@ -45,7 +45,7 @@ class ServerRequiredCustomizations : ServerCodegenDecorator {
             // TODO(enableNewSmithyRuntimeCleanup): Remove re-export of SdkError in server and add changelog entry
             rustTemplate(
                 """
-                pub type SdkError<E> = #{SdkError}<E, #{Response}>;
+                pub type SdkError<E, R = #{Response}> = #{SdkError}<E, R>;
                 pub use #{DisplayErrorContext};
                 """,
                 "SdkError" to RuntimeType.smithyHttp(rc).resolve("result::SdkError"),

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -148,7 +148,7 @@ RUN cargo +${rust_nightly_version} -Z sparse-registry install mdbook-mermaid --l
 #
 # Final image
 #
-# `clang-libs` needed by SDK examples for `libxlsxwriter-sys`
+# `clang` needed by SDK examples for `libxlsxwriter-sys`
 FROM bare_base_image AS final_image
 ARG rust_stable_version
 ARG rust_nightly_version
@@ -156,7 +156,7 @@ RUN set -eux; \
     yum -y install \
         bc \
         ca-certificates \
-        clang-libs \
+        clang \
         gcc \
         git \
         java-11-amazon-corretto-headless \

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -148,6 +148,7 @@ RUN cargo +${rust_nightly_version} -Z sparse-registry install mdbook-mermaid --l
 #
 # Final image
 #
+# `clang-libs` needed by SDK examples for `libxlsxwriter-sys`
 FROM bare_base_image AS final_image
 ARG rust_stable_version
 ARG rust_nightly_version
@@ -155,6 +156,7 @@ RUN set -eux; \
     yum -y install \
         bc \
         ca-certificates \
+        clang-libs \
         gcc \
         git \
         java-11-amazon-corretto-headless \

--- a/tools/ci-scripts/check-aws-sdk-examples
+++ b/tools/ci-scripts/check-aws-sdk-examples
@@ -13,6 +13,7 @@ cd aws-sdk/examples
 for example in *; do
     echo -e "${C_YELLOW}Checking examples/${example}...${C_RESET}"
     pushd "${example}" &>/dev/null
-    cargo check && cargo clean
+    cargo check
+    cargo clean
     popd &>/dev/null
 done


### PR DESCRIPTION
`SdkError` was re-exported in generated crates with the wrong generic argument for the response type, which causes the SDK examples to fail to compile. The example breaks weren't caught due to a bug in the CI script that checks them, addressed in smithy-rs#2930.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
