### PR TITLE
Reduce amount of logging from #[instrument]

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,15 @@ message = "Fix requests to S3 with `no_credentials` set."
 references = ["smithy-rs#2907", "aws-sdk-rust#864"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "Logging via `#[instrument]` in the `aws_smithy_runtime::client::orchestrator` module is now emitted at the `DEBUG` level to reduce the amount of logging when emitted at the `INFO` level."
+references = ["smithy-rs#2934", "aws-sdk-rust#872"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
+author = "ysaito1001"
+
+[[aws-sdk-rust]]
+message = "Logging via `#[instrument]` in the `aws_smithy_runtime::client::orchestrator` module is now emitted at the `DEBUG` level to reduce the amount of logging when emitted at the `INFO` level."
+references = ["smithy-rs#2934", "aws-sdk-rust#872"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "ysaito1001"

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -164,7 +164,7 @@ pub async fn invoke_with_stop_point(
 /// Apply configuration is responsible for apply runtime plugins to the config bag, as well as running
 /// `read_before_execution` interceptors. If a failure occurs due to config construction, `invoke`
 /// will raise it to the user. If an interceptor fails, then `invoke`
-#[instrument(skip_all, level = "trace")]
+#[instrument(skip_all, level = "debug")]
 fn apply_configuration(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,
@@ -183,7 +183,7 @@ fn apply_configuration(
         .build()?)
 }
 
-#[instrument(skip_all, level = "trace")]
+#[instrument(skip_all, level = "debug")]
 async fn try_op(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,
@@ -316,7 +316,7 @@ async fn try_op(
     }
 }
 
-#[instrument(skip_all, level = "trace")]
+#[instrument(skip_all, level = "debug")]
 async fn try_attempt(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,
@@ -404,7 +404,7 @@ async fn try_attempt(
     run_interceptors!(halt_on_err: read_after_deserialization(ctx, runtime_components, cfg));
 }
 
-#[instrument(skip_all, level = "trace")]
+#[instrument(skip_all, level = "debug")]
 async fn finally_attempt(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,
@@ -416,7 +416,7 @@ async fn finally_attempt(
     });
 }
 
-#[instrument(skip_all, level = "trace")]
+#[instrument(skip_all, level = "debug")]
 async fn finally_op(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -164,7 +164,7 @@ pub async fn invoke_with_stop_point(
 /// Apply configuration is responsible for apply runtime plugins to the config bag, as well as running
 /// `read_before_execution` interceptors. If a failure occurs due to config construction, `invoke`
 /// will raise it to the user. If an interceptor fails, then `invoke`
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "trace")]
 fn apply_configuration(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,
@@ -183,7 +183,7 @@ fn apply_configuration(
         .build()?)
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "trace")]
 async fn try_op(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,
@@ -316,7 +316,7 @@ async fn try_op(
     }
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "trace")]
 async fn try_attempt(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,
@@ -404,7 +404,7 @@ async fn try_attempt(
     run_interceptors!(halt_on_err: read_after_deserialization(ctx, runtime_components, cfg));
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "trace")]
 async fn finally_attempt(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,
@@ -416,7 +416,7 @@ async fn finally_attempt(
     });
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, level = "trace")]
 async fn finally_op(
     ctx: &mut InterceptorContext,
     cfg: &mut ConfigBag,


### PR DESCRIPTION
**Will be merged to `smithy-rs-release-0.56.x` branch**

Addresses https://github.com/awslabs/aws-sdk-rust/issues/872

## Motivation and Context
With the introduction of the orchestrator, the core functions that live in `aws-smithy-runtime/src/client/orchestrator.rs` were annotated by `#instrument`. By default this emits logs at the `INFO` level, which caused our customer to see the excessive amount of logging after switching to the latest SDK creates `0.29`.

## Description
This PR reduces the log level to `DEBUG` wherever we use `#instrument` throughout the file.

## Testing
No new tests have been added as part of this PR. [An enhancement](https://github.com/awslabs/smithy-rs/issues/2932) has been filed to check logging volume.

Here is a quick check that all instances in the file specify `trace`:
```
✗ rg "instrument"
src/client/orchestrator.rs
34:use tracing::{debug, debug_span, instrument, trace, Instrument};
160:    .instrument(debug_span!("invoke", service = %service_name, operation = %operation_name))
167:#[instrument(skip_all, level = "debug")]
186:#[instrument(skip_all, level = "debug")]
319:#[instrument(skip_all, level = "debug")]
389:                .instrument(debug_span!("read_body"))
398:    .instrument(debug_span!("deserialization"))
407:#[instrument(skip_all, level = "debug")]
419:#[instrument(skip_all, level = "debug")]
```

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
