### PR TITLE
Add endpoint params to debug logs

### DIFF
--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -121,6 +121,7 @@ pub(super) async fn orchestrate_endpoint(
         .load::<EndpointResolverParams>()
         .expect("endpoint resolver params must be set");
     let endpoint_prefix = cfg.load::<EndpointPrefix>();
+    tracing::debug!(endpoint_params = ?params, endpoint_prefix = ?endpoint_prefix, "resolving endpoint");
     let request = ctx.request_mut().expect("set during serialization");
 
     let endpoint = runtime_components


### PR DESCRIPTION
Debugging endpoint resolution can be difficult when the params being used during resolution aren't logged. This PR adds that logging.

Example output below. It doesn't ordinarily have newlines and indentation. I added those for clarity.
```
2023-08-22T00:27:54.363727Z DEBUG
invoke{service=s3 operation=ListObjectsV2}:try_op:try_attempt:
aws_smithy_runtime::client::orchestrator::endpoints: resolving endpoint
endpoint_params=EndpointResolverParams(TypeErasedBox[!Clone]:Params {
  bucket: Some("test-bucket"),
  region: Some("us-east-1"),
  use_fips: false,
  use_dual_stack: false,
  endpoint: None,
  force_path_style: false,
  accelerate: false,
  use_global_endpoint: false,
  use_object_lambda_endpoint: None,
  disable_access_points: None,
  disable_multi_region_access_points: false,
  use_arn_region: None
})
endpoint_prefix=None
```

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
