### PR TITLE
Relax reference validation during changelog rendering

### DIFF
--- a/tools/ci-build/smithy-rs-tool-common/src/changelog.rs
+++ b/tools/ci-build/smithy-rs-tool-common/src/changelog.rs
@@ -146,7 +146,7 @@ impl HandAuthoredEntry {
         if !self.author.chars().all(|c| c.is_alphanumeric() || c == '-') {
             bail!("Author must be valid GitHub username: [a-zA-Z0-9\\-]")
         }
-        if self.references.is_empty() {
+        if validation_set == ValidationSet::Development && self.references.is_empty() {
             bail!("Changelog entry must refer to at least one pull request or issue");
         }
         if validation_set == ValidationSet::Development && self.message.len() > 800 {


### PR DESCRIPTION
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
