### PR TITLE
Set a region on the canary CDK stack to simplify deployment

### DIFF
--- a/tools/ci-cdk/bin/canary-only.ts
+++ b/tools/ci-cdk/bin/canary-only.ts
@@ -12,5 +12,6 @@ import { App } from "aws-cdk-lib";
 import { CanaryStack } from "../lib/aws-sdk-rust/canary-stack";
 
 const app = new App();
+const env = { region: "us-west-2" };
 
-new CanaryStack(app, "aws-sdk-rust-canary-stack", {});
+new CanaryStack(app, "aws-sdk-rust-canary-stack", { env });

--- a/tools/ci-cdk/bin/ci-cdk.ts
+++ b/tools/ci-cdk/bin/ci-cdk.ts
@@ -10,14 +10,19 @@ import { PullRequestCdnStack } from "../lib/smithy-rs/pull-request-cdn-stack";
 import { CanaryStack } from "../lib/aws-sdk-rust/canary-stack";
 import { OidcProviderStack } from "../lib/oidc-provider-stack";
 
-const app = new App();
+const app = new App({});
+const env = { region: "us-west-2" };
 
-const oidcProviderStack = new OidcProviderStack(app, "oidc-provider-stack", {});
+const oidcProviderStack = new OidcProviderStack(app, "oidc-provider-stack", {
+    env,
+});
 
 new PullRequestCdnStack(app, "smithy-rs-pull-request-cdn-stack", {
     githubActionsOidcProvider: oidcProviderStack.githubActionsOidcProvider,
+    env,
 });
 
 new CanaryStack(app, "aws-sdk-rust-canary-stack", {
     githubActionsOidcProvider: oidcProviderStack.githubActionsOidcProvider,
+    env,
 });


### PR DESCRIPTION
Previously, if you forgot to set the region, the deployment would fail with a confusing error about the OIDC provider already existing, which can easily lead down a rabbit hole.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
