### PR TITLE
Add `@optionalAuth` to all S3 operations

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -54,3 +54,9 @@ message = "Update MSRV to Rust 1.70.0"
 references = ["smithy-rs#2948"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "all" }
 author = "Velfi"
+
+[[aws-sdk-rust]]
+message = "Allow `no_credentials` to be used with all S3 operations."
+references = ["smithy-rs#2955", "aws-sdk-rust#878"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3Decorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3Decorator.kt
@@ -135,15 +135,9 @@ class FilterEndpointTests(
 
 // TODO(P96049742): This model transform may need to change depending on if and how the S3 model is updated.
 private class AddOptionalAuth {
-    private val s3OptionalAuthOperations = listOf(
-        ShapeId.from("com.amazonaws.s3#ListObjects"),
-        ShapeId.from("com.amazonaws.s3#ListObjectsV2"),
-        ShapeId.from("com.amazonaws.s3#HeadObject"),
-        ShapeId.from("com.amazonaws.s3#GetObject"),
-    )
-
     fun transform(model: Model) = ModelTransformer.create().mapShapes(model) { shape ->
-        if (shape is OperationShape && s3OptionalAuthOperations.contains(shape.id) && !shape.hasTrait<OptionalAuthTrait>()) {
+        // Add @optionalAuth to all S3 operations
+        if (shape is OperationShape && !shape.hasTrait<OptionalAuthTrait>()) {
             shape.toBuilder()
                 .addTrait(OptionalAuthTrait())
                 .build()


### PR DESCRIPTION
In #2907, I created an allow list of S3 operations to add `@optionalAuth` to, but this turns out to be too restrictive, as seen in https://github.com/awslabs/aws-sdk-rust/issues/878. This PR restores the original middleware behavior of allowing optional auth for all S3 operations.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
