### PR TITLE
Cherry-picks updating MSRV to 1.70.0 from main to smithy-rs-release-0.56.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ on:
         required: false
 
 env:
-  rust_version: 1.69.0
+  rust_version: 1.70.0
   rust_toolchain_components: clippy,rustfmt
   ENCRYPTED_DOCKER_PASSWORD: ${{ secrets.ENCRYPTED_DOCKER_PASSWORD }}
   DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/claim-crate-names.yml
+++ b/.github/workflows/claim-crate-names.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.69.0
+  rust_version: 1.70.0
 
 name: Claim unpublished crate names on crates.io
 run-name: ${{ github.workflow }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,7 +8,7 @@ on:
 name: Update GitHub Pages
 
 env:
-  rust_version: 1.69.0
+  rust_version: 1.70.0
 
 # Allow only one doc pages build to run at a time for the entire smithy-rs repo
 concurrency:

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
   java_version: 11
-  rust_version: 1.69.0
+  rust_version: 1.70.0
   rust_toolchain_components: clippy,rustfmt
   apt_dependencies: libssl-dev gnuplot jq
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.69.0
+  rust_version: 1.70.0
 
 name: Release smithy-rs
 run-name: ${{ github.workflow }} ${{ inputs.semantic_version }} (${{ inputs.commit_sha }}) - ${{ inputs.dry_run && 'Dry run' || 'Production run' }}

--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.69.0
+        toolchain: 1.70.0
     - name: Delete old SDK
       run: |
     - name: Generate a fresh SDK

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,15 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Update MSRV to Rust 1.70.0"
+references = ["smithy-rs#2948"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "Velfi"
+
+[[smithy-rs]]
+message = "Update MSRV to Rust 1.70.0"
+references = ["smithy-rs#2948"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "all" }
+author = "Velfi"

--- a/aws/sdk/integration-tests/lambda/tests/request_id.rs
+++ b/aws/sdk/integration-tests/lambda/tests/request_id.rs
@@ -22,7 +22,7 @@ async fn run_test(
     let client = Client::from_conf(conf);
     let resp = client.list_functions().send().await;
     if expect_error {
-        let err = resp.err().expect("should be an error").into_service_error();
+        let err = resp.expect_err("should be an error").into_service_error();
         assert!(matches!(err, ListFunctionsError::Unhandled(_)));
         assert_eq!(Some("correct-request-id"), err.request_id());
         assert_eq!(Some("correct-request-id"), err.meta().request_id());

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -111,7 +111,7 @@ object TestWorkspace {
                 // help rust select the right version when we run cargo test
                 // TODO(https://github.com/awslabs/smithy-rs/issues/2048): load this from the msrv property using a
                 //  method as we do for runtime crate versions
-                "[toolchain]\nchannel = \"1.69.0\"\n",
+                "[toolchain]\nchannel = \"1.70.0\"\n",
             )
             // ensure there at least an empty lib.rs file to avoid broken crates
             newProject.resolve("src").mkdirs()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Rust MSRV (entered into the generated README)
-rust.msrv=1.69.0
+rust.msrv=1.70.0
 
 # To enable debug, swap out the two lines below.
 # When changing this value, be sure to run `./gradlew --stop` to kill the Gradle daemon.

--- a/rust-runtime/aws-smithy-client/src/test_connection.rs
+++ b/rust-runtime/aws-smithy-client/src/test_connection.rs
@@ -577,7 +577,7 @@ pub mod wire_mock {
                     rx.await.ok();
                     tracing::info!("server shutdown!");
                 });
-            spawn(async move { server.await });
+            spawn(server);
             Self {
                 event_log: wire_events,
                 bind_addr: listener_addr,

--- a/rust-runtime/aws-smithy-http/src/connection.rs
+++ b/rust-runtime/aws-smithy-http/src/connection.rs
@@ -94,6 +94,7 @@ mod test {
     use crate::connection::{CaptureSmithyConnection, ConnectionMetadata};
 
     #[test]
+    #[allow(clippy::redundant_clone)]
     fn retrieve_connection_metadata() {
         let retriever = CaptureSmithyConnection::new();
         let retriever_clone = retriever.clone();

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -13,7 +13,7 @@ convert-time = ["aws-smithy-types", "time"]
 
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types", optional = true }
-chrono = { version = "0.4.23", optional = true, default-features = false, features = ["std"] }
+chrono = { version = "0.4.26", optional = true, default-features = false, features = ["std"] }
 time = { version = "0.3.4", optional = true }
 
 [package.metadata.docs.rs]

--- a/rust-runtime/aws-smithy-types-convert/src/date_time.rs
+++ b/rust-runtime/aws-smithy-types-convert/src/date_time.rs
@@ -136,7 +136,7 @@ impl DateTimeExt for DateTime {
                 self.secs(),
                 self.subsec_nanos()
             ))),
-            Some(dt) => Ok(chrono::DateTime::<chrono::Utc>::from_utc(dt, chrono::Utc)),
+            Some(dt) => Ok(chrono::TimeZone::from_utc_datetime(&chrono::Utc, &dt)),
         }
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.70.0"

--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -6,7 +6,7 @@
 # This is the base Docker build image used by CI
 
 ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2
-ARG rust_stable_version=1.69.0
+ARG rust_stable_version=1.70.0
 ARG rust_nightly_version=nightly-2023-05-31
 
 FROM ${base_image} AS bare_base_image


### PR DESCRIPTION
## Motivation and Context
Cherry picks MSRV 1.70.0 upgrade ([original PR](https://github.com/awslabs/smithy-rs/pull/2948) merged to `main`)

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
