### PR TITLE
Make required context parameters required

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -90,3 +90,15 @@ message = "Fix code generation for union members with the `@httpPayload` trait."
 references = ["smithy-rs#2969", "smithy-rs#1896"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "all" }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Make `bucket` required for request construction for S3. When `bucket` is not set, a **different** operation than intended can be triggered."
+references = ["smithy-rs#1668", "aws-sdk-rust#873", "smithy-rs#2964"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"
+
+[[smithy-rs]]
+message = "Required members with @contextParam are now treated as client-side required."
+references = ["smithy-rs#2964"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, target = "client" }
+author = "rcoh"

--- a/aws/sdk/integration-tests/s3/tests/bucket-required.rs
+++ b/aws/sdk/integration-tests/s3/tests/bucket-required.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_config::SdkConfig;
+use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_sdk_s3::config::{Credentials, Region};
+use aws_sdk_s3::Client;
+use aws_smithy_client::test_connection::capture_request;
+
+#[tokio::test]
+async fn dont_dispatch_when_bucket_is_unset() {
+    let (conn, rcvr) = capture_request(None);
+    let sdk_config = SdkConfig::builder()
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
+        .region(Region::new("us-east-1"))
+        .http_connector(conn.clone())
+        .build();
+    let client = Client::new(&sdk_config);
+    let err = client
+        .list_objects_v2()
+        .send()
+        .await
+        .expect_err("bucket not set");
+    assert_eq!(format!("{}", err), "failed to construct request");
+    rcvr.expect_no_request();
+}

--- a/aws/sdk/integration-tests/s3/tests/request_id.rs
+++ b/aws/sdk/integration-tests/s3/tests/request_id.rs
@@ -36,6 +36,7 @@ async fn get_request_id_from_modeled_error() {
     let err = client
         .get_object()
         .key("dontcare")
+        .bucket("dontcare")
         .send()
         .await
         .expect_err("status was 404, this is an error")
@@ -83,6 +84,7 @@ async fn get_request_id_from_unmodeled_error() {
     let client = Client::from_conf(config);
     let err = client
         .get_object()
+        .bucket("dontcare")
         .key("dontcare")
         .send()
         .await
@@ -156,6 +158,7 @@ async fn get_request_id_from_successful_streaming_response() {
     let output = client
         .get_object()
         .key("dontcare")
+        .bucket("dontcare")
         .send()
         .await
         .expect("valid successful response");
@@ -194,6 +197,7 @@ async fn conversion_to_service_error_maintains_request_id() {
     let client = Client::from_conf(config);
     let err = client
         .get_object()
+        .bucket("dontcare")
         .key("dontcare")
         .send()
         .await

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins { }
 
 allprojects {
     repositories {
-        mavenLocal()
+        /* mavenLocal() */
         mavenCentral()
         google()
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -28,9 +28,11 @@ import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
+import software.amazon.smithy.rust.codegen.core.smithy.generators.OperationBuildError
 import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.inputShape
+import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 
@@ -134,8 +136,11 @@ class EndpointParamsInterceptorGenerator(
         // lastly, allow these to be overridden by members
         memberParams.forEach { (memberShape, param) ->
             val memberName = codegenContext.symbolProvider.toMemberName(memberShape)
-            rust(
-                ".${EndpointParamsGenerator.setterName(param.name)}(_input.$memberName.clone())",
+            val member = writable("_input.$memberName.clone()").letIf(memberShape.isRequired) { ref ->
+                OperationBuildError(codegenContext.runtimeConfig).emptyOrUnset(symbolProvider, ref, memberShape)
+            }
+            rustTemplate(
+                ".${EndpointParamsGenerator.setterName(param.name)}(dbg!(#{member}))", "member" to member,
             )
         }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -28,11 +28,10 @@ import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
-import software.amazon.smithy.rust.codegen.core.smithy.generators.OperationBuildError
+import software.amazon.smithy.rust.codegen.core.smithy.generators.enforceRequired
 import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.inputShape
-import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 
@@ -136,11 +135,10 @@ class EndpointParamsInterceptorGenerator(
         // lastly, allow these to be overridden by members
         memberParams.forEach { (memberShape, param) ->
             val memberName = codegenContext.symbolProvider.toMemberName(memberShape)
-            val member = writable("_input.$memberName.clone()").letIf(memberShape.isRequired) { ref ->
-                OperationBuildError(codegenContext.runtimeConfig).emptyOrUnset(symbolProvider, ref, memberShape)
-            }
+            val member = memberShape.enforceRequired(writable("_input.$memberName.clone()"), codegenContext)
+
             rustTemplate(
-                ".${EndpointParamsGenerator.setterName(param.name)}(dbg!(#{member}))", "member" to member,
+                ".${EndpointParamsGenerator.setterName(param.name)}(#{member})", "member" to member,
             )
         }
     }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
@@ -111,6 +111,7 @@ class EndpointsDecoratorTest {
 
         structure TestOperationInput {
             @contextParam(name: "Bucket")
+            @required
             bucket: String,
             nested: NestedStructure
         }
@@ -210,6 +211,10 @@ class EndpointsDecoratorTest {
                             interceptor.called.load(Ordering::Relaxed),
                             "the interceptor should have been called"
                         );
+
+                        // bucket_name is unset and marked as required on the model, so we'll refuse to construct this request
+                        let err = client.test_operation().send().await.expect_err("param missing");
+                        assert_eq!(format!("{}", err), "failed to construct request");
                     }
                     """,
                 )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/Writable.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/Writable.kt
@@ -25,6 +25,11 @@ fun Writable.isEmpty(): Boolean {
     return writer.toString() == RustWriter.root().toString()
 }
 
+fun Writable.map(f: RustWriter.(Writable) -> Unit): Writable {
+    val self = this
+    return writable { f(self) }
+}
+
 fun Writable.isNotEmpty(): Boolean = !this.isEmpty()
 
 operator fun Writable.plus(other: Writable): Writable {
@@ -108,10 +113,12 @@ fun rustTypeParameters(
                         "#{gg:W}",
                         "gg" to typeParameter.declaration(withAngleBrackets = false),
                     )
+
                     else -> {
                         // Check if it's a writer. If it is, invoke it; Else, throw a codegen error.
                         @Suppress("UNCHECKED_CAST")
-                        val func = typeParameter as? Writable ?: throw CodegenException("Unhandled type '$typeParameter' encountered by rustTypeParameters writer")
+                        val func = typeParameter as? Writable
+                            ?: throw CodegenException("Unhandled type '$typeParameter' encountered by rustTypeParameters writer")
                         func.invoke(this)
                     }
                 }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/WritableTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/WritableTest.kt
@@ -6,6 +6,7 @@
 package software.amazon.smithy.rust.codegen.core.rustlang
 
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 
@@ -105,5 +106,14 @@ internal class RustTypeParametersTest {
             yield(writable("F"))
         }.join(writable("+"))(writer)
         writer.toString() shouldContain "A-B-CD+E+F"
+    }
+
+    @Test
+    fun `test map`() {
+        val writer = RustWriter.forModule("model")
+        val a = writable { rust("a") }
+        val b = a.map { rust("b(#T)", it) }
+        b(writer)
+        writer.toString().trim() shouldEndWith "b(a)"
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ pluginManagement {
 
 buildscript {
     repositories {
-        mavenLocal()
+        /* mavenLocal() */
         mavenCentral()
         google()
     }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
When a `@contextParam` is marked as required, we will enforce it on inputs. Since these fields may influence endpoint, omitting them can result in a different target being hit.

- #1668 
- aws-sdk-rust#873

## Description
<!--- Describe your changes in detail -->

## Testing
- [x] S3 Integration test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
