### PR TITLE
Make order of expected/actual consistent in protocol tests

### DIFF
--- a/rust-runtime/aws-smithy-client/src/test_connection.rs
+++ b/rust-runtime/aws-smithy-client/src/test_connection.rs
@@ -163,7 +163,7 @@ impl ValidateRequest {
         };
         match (actual_str, expected_str) {
             (Ok(actual), Ok(expected)) => assert_ok(validate_body(actual, expected, media_type)),
-            _ => assert_eq!(actual.body().bytes(), expected.body().bytes()),
+            _ => assert_eq!(expected.body().bytes(), actual.body().bytes()),
         };
     }
 }

--- a/rust-runtime/aws-smithy-protocol-test/src/urlencoded.rs
+++ b/rust-runtime/aws-smithy-protocol-test/src/urlencoded.rs
@@ -41,16 +41,16 @@ fn rewrite_url_encoded_body(input: &str) -> String {
 }
 
 pub(crate) fn try_url_encoded_form_equivalent(
-    actual: &str,
     expected: &str,
+    actual: &str,
 ) -> Result<(), ProtocolTestFailure> {
-    let actual = rewrite_url_encoded_body(actual);
     let expected = rewrite_url_encoded_body(expected);
+    let actual = rewrite_url_encoded_body(actual);
     if actual == expected {
         Ok(())
     } else {
         Err(ProtocolTestFailure::BodyDidNotMatch {
-            comparison: pretty_comparison(&actual, &expected),
+            comparison: pretty_comparison(&expected, &actual),
             hint: "".into(),
         })
     }
@@ -71,14 +71,14 @@ mod tests {
         );
 
         assert!(try_url_encoded_form_equivalent(
-            "Action=Something&Version=test&Property=foo",
             "Action=Something&Version=test&Property=bar",
+            "Action=Something&Version=test&Property=foo",
         )
         .is_err());
 
         assert!(try_url_encoded_form_equivalent(
-            "Action=Something&Version=test&WrongProperty=foo",
             "Action=Something&Version=test&Property=foo",
+            "Action=Something&Version=test&WrongProperty=foo",
         )
         .is_err());
 
@@ -86,15 +86,15 @@ mod tests {
             Ok(()),
             try_url_encoded_form_equivalent(
                 "Action=Something&Version=test\
-                &SomeMap.1.key=foo\
-                &SomeMap.1.value=Foo\
-                &SomeMap.2.key=bar\
-                &SomeMap.2.value=Bar",
-                "Action=Something&Version=test\
                 &SomeMap.1.key=bar\
                 &SomeMap.1.value=Bar\
                 &SomeMap.2.key=foo\
                 &SomeMap.2.value=Foo",
+                "Action=Something&Version=test\
+                &SomeMap.1.key=foo\
+                &SomeMap.1.value=Foo\
+                &SomeMap.2.key=bar\
+                &SomeMap.2.value=Bar",
             )
         );
     }

--- a/rust-runtime/aws-smithy-protocol-test/src/xml.rs
+++ b/rust-runtime/aws-smithy-protocol-test/src/xml.rs
@@ -11,23 +11,25 @@ use std::fmt::Write;
 ///
 /// This will normalize documents and attempts to determine if it is OK to sort members or not by
 /// using a heuristic to determine if the tag represents a list (which should not be reordered)
-pub(crate) fn try_xml_equivalent(actual: &str, expected: &str) -> Result<(), ProtocolTestFailure> {
-    if actual == expected {
+pub(crate) fn try_xml_equivalent(expected: &str, actual: &str) -> Result<(), ProtocolTestFailure> {
+    if expected == actual {
         return Ok(());
     }
-    let norm_1 = normalize_xml(actual).map_err(|e| ProtocolTestFailure::InvalidBodyFormat {
-        expected: "actual document to be valid XML".to_string(),
-        found: format!("{}\n{}", e, actual),
-    })?;
-    let norm_2 = normalize_xml(expected).map_err(|e| ProtocolTestFailure::InvalidBodyFormat {
-        expected: "expected document to be valid XML".to_string(),
-        found: format!("{}", e),
-    })?;
-    if norm_1 == norm_2 {
+    let norm_expected =
+        normalize_xml(expected).map_err(|e| ProtocolTestFailure::InvalidBodyFormat {
+            expected: "expected document to be valid XML".to_string(),
+            found: format!("{}", e),
+        })?;
+    let norm_actual =
+        normalize_xml(actual).map_err(|e| ProtocolTestFailure::InvalidBodyFormat {
+            expected: "actual document to be valid XML".to_string(),
+            found: format!("{}\n{}", e, actual),
+        })?;
+    if norm_expected == norm_actual {
         Ok(())
     } else {
         Err(ProtocolTestFailure::BodyDidNotMatch {
-            comparison: pretty_comparison(&norm_1, &norm_2),
+            comparison: pretty_comparison(&norm_expected, &norm_actual),
             hint: "".to_string(),
         })
     }


### PR DESCRIPTION
Debugging tests is easier when the order of arguments in assertions is consistent across the board. With consistent order, you don't need to look at the line of code to know which value is the correct value. Most of the rest of the project uses expected/actual order, so this PR makes the protocol tests also use that order.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
