### PR TITLE
Filter test inputs for presigning header exclusion proptest

### DIFF
--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -835,11 +835,24 @@ mod tests {
         );
     }
 
+    fn valid_input(input: &Vec<String>) -> bool {
+        [
+            "content-length".to_owned(),
+            "content-type".to_owned(),
+            "host".to_owned(),
+        ]
+        .iter()
+        .all(|element| !input.contains(&element))
+    }
+
     proptest! {
-       #[test]
-       fn presigning_header_exclusion_with_explicit_exclusion_list_specified(
-           excluded_headers in prop::collection::vec("[a-z]{1,20}", 1..10),
-       ) {
+        #[test]
+        fn presigning_header_exclusion_with_explicit_exclusion_list_specified(
+            excluded_headers in prop::collection::vec("[a-z]{1,20}", 1..10).prop_filter(
+                "`excluded_headers` should pass the `valid_input` check",
+                valid_input,
+            )
+        ) {
             let mut request_builder = http::Request::builder()
                 .uri("https://some-endpoint.some-region.amazonaws.com")
                 .header("content-type", "application/xml")


### PR DESCRIPTION
## Motivation and Context
During our internal build, the `aws-sigv4` crate failed on a proptest as follows:
```
Diff < left / right > :
<content-length;content-type;host
>content-length;content-type

.
minimal failing input: excluded_headers = [
    "host",
]
        successes: 74
        local rejects: 0
        global rejects: 0
', aws-sigv4/src/http_request/canonical_request.rs:838:5

failures:
    http_request::canonical_request::tests::presigning_header_exclusion_with_explicit_exclusion_list_specified
```
This says that `excluded_headers` should not contain `host`.

To address it, this PR will filter out test inputs from proptest that contain `content-length`, `content-type`, or `host` (all of which appear in the expected value for the test at line 886 in the new revision).

## Testing
No new tests have been added, relied on the existing tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
