### PR TITLE
Extract builderInstantiator interface to prepare for nullability changes

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenContext.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenContext.kt
@@ -9,10 +9,12 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ClientBuilderInstantiator
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.ModuleDocProvider
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 
 /**
@@ -36,4 +38,7 @@ data class ClientCodegenContext(
     model, symbolProvider, moduleDocProvider, serviceShape, protocol, settings, CodegenTarget.CLIENT,
 ) {
     val enableUserConfigurableRuntimePlugins: Boolean get() = settings.codegenConfig.enableUserConfigurableRuntimePlugins
+    override fun builderInstantiator(): BuilderInstantiator {
+        return ClientBuilderInstantiator(symbolProvider)
+    }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientBuilderInstantiator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientBuilderInstantiator.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.generators
+
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.map
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
+
+fun ClientCodegenContext.builderInstantiator(): BuilderInstantiator = ClientBuilderInstantiator(symbolProvider)
+
+class ClientBuilderInstantiator(private val symbolProvider: RustSymbolProvider) : BuilderInstantiator {
+    override fun setField(builder: String, value: Writable, field: MemberShape): Writable {
+        return setFieldBase(builder, value, field)
+    }
+
+    override fun finalizeBuilder(builder: String, shape: StructureShape, mapErr: Writable?): Writable = writable {
+        if (BuilderGenerator.hasFallibleBuilder(shape, symbolProvider)) {
+            rustTemplate(
+                "$builder.build()#{mapErr}?",
+                "mapErr" to (
+                    mapErr?.map {
+                        rust(".map_err(#T)", it)
+                    } ?: writable { }
+                    ),
+            )
+        } else {
+            rust("$builder.build()")
+        }
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientBuilderInstantiator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientBuilderInstantiator.kt
@@ -21,7 +21,7 @@ fun ClientCodegenContext.builderInstantiator(): BuilderInstantiator = ClientBuil
 
 class ClientBuilderInstantiator(private val symbolProvider: RustSymbolProvider) : BuilderInstantiator {
     override fun setField(builder: String, value: Writable, field: MemberShape): Writable {
-        return setFieldBase(builder, value, field)
+        return setFieldWithSetter(builder, value, field)
     }
 
     override fun finalizeBuilder(builder: String, shape: StructureShape, mapErr: Writable?): Writable = writable {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/ClientProtocolLoader.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/ClientProtocolLoader.kt
@@ -63,9 +63,9 @@ private class ClientAwsJsonFactory(private val version: AwsJsonVersion) :
     ProtocolGeneratorFactory<OperationGenerator, ClientCodegenContext> {
     override fun protocol(codegenContext: ClientCodegenContext): Protocol =
         if (compatibleWithAwsQuery(codegenContext.serviceShape, version)) {
-            AwsQueryCompatible(codegenContext, AwsJson(codegenContext, version))
+            AwsQueryCompatible(codegenContext, AwsJson(codegenContext, version, codegenContext.builderInstantiator()))
         } else {
-            AwsJson(codegenContext, version)
+            AwsJson(codegenContext, version, codegenContext.builderInstantiator())
         }
 
     override fun buildProtocolGenerator(codegenContext: ClientCodegenContext): OperationGenerator =

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CodegenContext.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CodegenContext.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.core.smithy
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
 
 /**
  * [CodegenContext] contains code-generation context that is _common to all_  smithy-rs plugins.
@@ -17,7 +18,7 @@ import software.amazon.smithy.model.shapes.ShapeId
  * If your data is specific to the `rust-client-codegen` client plugin, put it in [ClientCodegenContext] instead.
  * If your data is specific to the `rust-server-codegen` server plugin, put it in [ServerCodegenContext] instead.
  */
-open class CodegenContext(
+abstract class CodegenContext(
     /**
      * The smithy model.
      *
@@ -89,4 +90,6 @@ open class CodegenContext(
     fun expectModuleDocProvider(): ModuleDocProvider = checkNotNull(moduleDocProvider) {
         "A ModuleDocProvider must be set on the CodegenContext"
     }
+
+    abstract fun builderInstantiator(): BuilderInstantiator
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderInstantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderInstantiator.kt
@@ -11,7 +11,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 
-/** Abstraction for instantiating a builders.
+/** Abstraction for instantiating builders.
  *
  * Builder abstractions vary—clients MAY use `build_with_error_correction`, e.g., and builders can vary in fallibility.
  * */
@@ -19,11 +19,14 @@ interface BuilderInstantiator {
     /** Set a field on a builder. */
     fun setField(builder: String, value: Writable, field: MemberShape): Writable
 
-    /** Finalize a builder, turning into a built object (or in the case of builders-of-builders, return the builder directly).*/
+    /** Finalize a builder, turning it into a built object
+     *  - In the case of builders-of-builders, the value should be returned directly
+     *  - If an error is returned, you MUST use `mapErr` to convert the error type
+     */
     fun finalizeBuilder(builder: String, shape: StructureShape, mapErr: Writable? = null): Writable
 
     /** Set a field on a builder using the `$setterName` method. $value will be passed directly. */
-    fun setFieldBase(builder: String, value: Writable, field: MemberShape) = writable {
+    fun setFieldWithSetter(builder: String, value: Writable, field: MemberShape) = writable {
         rustTemplate("$builder = $builder.${field.setterName()}(#{value})", "value" to value)
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderInstantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderInstantiator.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy.generators
+
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+
+/** Abstraction for instantiating a builders.
+ *
+ * Builder abstractions vary—clients MAY use `build_with_error_correction`, e.g., and builders can vary in fallibility.
+ * */
+interface BuilderInstantiator {
+    /** Set a field on a builder. */
+    fun setField(builder: String, value: Writable, field: MemberShape): Writable
+
+    /** Finalize a builder, turning into a built object (or in the case of builders-of-builders, return the builder directly).*/
+    fun finalizeBuilder(builder: String, shape: StructureShape, mapErr: Writable? = null): Writable
+
+    /** Set a field on a builder using the `$setterName` method. $value will be passed directly. */
+    fun setFieldBase(builder: String, value: Writable, field: MemberShape) = writable {
+        rustTemplate("$builder = $builder.${field.setterName()}(#{value})", "value" to value)
+    }
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/AwsJson.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/AwsJson.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.serializationError
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.JsonParserGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.StructuredDataParserGenerator
@@ -122,6 +123,7 @@ class AwsJsonSerializerGenerator(
 open class AwsJson(
     val codegenContext: CodegenContext,
     val awsJsonVersion: AwsJsonVersion,
+    val builderInstantiator: BuilderInstantiator,
 ) : Protocol {
     private val runtimeConfig = codegenContext.runtimeConfig
     private val errorScope = arrayOf(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
@@ -59,13 +59,16 @@ import software.amazon.smithy.utils.StringUtils
  * Class describing a JSON parser section that can be used in a customization.
  */
 sealed class JsonParserSection(name: String) : Section(name) {
-    data class BeforeBoxingDeserializedMember(val shape: MemberShape) : JsonParserSection("BeforeBoxingDeserializedMember")
+    data class BeforeBoxingDeserializedMember(val shape: MemberShape) :
+        JsonParserSection("BeforeBoxingDeserializedMember")
 
-    data class AfterTimestampDeserializedMember(val shape: MemberShape) : JsonParserSection("AfterTimestampDeserializedMember")
+    data class AfterTimestampDeserializedMember(val shape: MemberShape) :
+        JsonParserSection("AfterTimestampDeserializedMember")
 
     data class AfterBlobDeserializedMember(val shape: MemberShape) : JsonParserSection("AfterBlobDeserializedMember")
 
-    data class AfterDocumentDeserializedMember(val shape: MemberShape) : JsonParserSection("AfterDocumentDeserializedMember")
+    data class AfterDocumentDeserializedMember(val shape: MemberShape) :
+        JsonParserSection("AfterDocumentDeserializedMember")
 }
 
 /**
@@ -100,6 +103,7 @@ class JsonParserGenerator(
     private val codegenTarget = codegenContext.target
     private val smithyJson = CargoDependency.smithyJson(runtimeConfig).toType()
     private val protocolFunctions = ProtocolFunctions(codegenContext)
+    private val builderInstantiator = codegenContext.builderInstantiator()
     private val codegenScope = arrayOf(
         "Error" to smithyJson.resolve("deserialize::error::DeserializeError"),
         "expect_blob_or_null" to smithyJson.resolve("deserialize::token::expect_blob_or_null"),
@@ -251,6 +255,7 @@ class JsonParserGenerator(
                                     deserializeMember(member)
                                 }
                             }
+
                             CodegenTarget.SERVER -> {
                                 if (symbolProvider.toSymbol(member).isOptional()) {
                                     withBlock("builder = builder.${member.setterName()}(", ");") {
@@ -508,12 +513,14 @@ class JsonParserGenerator(
                         "Builder" to symbolProvider.symbolForBuilder(shape),
                     )
                     deserializeStructInner(shape.members())
-                    // Only call `build()` if the builder is not fallible. Otherwise, return the builder.
-                    if (returnSymbolToParse.isUnconstrained) {
-                        rust("Ok(Some(builder))")
-                    } else {
-                        rust("Ok(Some(builder.build()))")
+                    val builder = builderInstantiator.finalizeBuilder(
+                        "builder", shape,
+                    ) {
+                        rustTemplate(
+                            """|err|#{Error}::custom_source("Response was invalid", err)""", *codegenScope,
+                        )
                     }
+                    rust("Ok(Some(#T))", builder)
                 }
             }
         }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -39,7 +39,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.renderUnknownVariant
 import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
@@ -101,6 +100,7 @@ class XmlBindingTraitParserGenerator(
     private val runtimeConfig = codegenContext.runtimeConfig
     private val protocolFunctions = ProtocolFunctions(codegenContext)
     private val codegenTarget = codegenContext.target
+    private val builderInstantiator = codegenContext.builderInstantiator()
 
     // The symbols we want all the time
     private val codegenScope = arrayOf(
@@ -159,6 +159,7 @@ class XmlBindingTraitParserGenerator(
                     is StructureShape -> {
                         parseStructure(shape, ctx)
                     }
+
                     is UnionShape -> parseUnion(shape, ctx)
                 }
             }
@@ -294,7 +295,10 @@ class XmlBindingTraitParserGenerator(
                 }
                 rust("$builder = $builder.${member.setterName()}($temp);")
             }
-            rustTemplate("_ => return Err(#{XmlDecodeError}::custom(\"expected ${member.xmlName()} tag\"))", *codegenScope)
+            rustTemplate(
+                "_ => return Err(#{XmlDecodeError}::custom(\"expected ${member.xmlName()} tag\"))",
+                *codegenScope,
+            )
         }
     }
 
@@ -359,19 +363,23 @@ class XmlBindingTraitParserGenerator(
                         parsePrimitiveInner(memberShape) {
                             rustTemplate("#{try_data}(&mut ${ctx.tag})?.as_ref()", *codegenScope)
                         }
+
                     is MapShape -> if (memberShape.isFlattened()) {
                         parseFlatMap(target, ctx)
                     } else {
                         parseMap(target, ctx)
                     }
+
                     is CollectionShape -> if (memberShape.isFlattened()) {
                         parseFlatList(target, ctx)
                     } else {
                         parseList(target, ctx)
                     }
+
                     is StructureShape -> {
                         parseStructure(target, ctx)
                     }
+
                     is UnionShape -> parseUnion(target, ctx)
                     else -> PANIC("Unhandled: $target")
                 }
@@ -436,10 +444,16 @@ class XmlBindingTraitParserGenerator(
                     }
                     when (target.renderUnknownVariant()) {
                         true -> rust("_unknown => base = Some(#T::${UnionGenerator.UnknownVariantName}),", symbol)
-                        false -> rustTemplate("""variant => return Err(#{XmlDecodeError}::custom(format!("unexpected union variant: {:?}", variant)))""", *codegenScope)
+                        false -> rustTemplate(
+                            """variant => return Err(#{XmlDecodeError}::custom(format!("unexpected union variant: {:?}", variant)))""",
+                            *codegenScope,
+                        )
                     }
                 }
-                rustTemplate("""base.ok_or_else(||#{XmlDecodeError}::custom("expected union, got nothing"))""", *codegenScope)
+                rustTemplate(
+                    """base.ok_or_else(||#{XmlDecodeError}::custom("expected union, got nothing"))""",
+                    *codegenScope,
+                )
             }
         }
         rust("#T(&mut ${ctx.tag})", nestedParser)
@@ -474,17 +488,17 @@ class XmlBindingTraitParserGenerator(
                 } else {
                     rust("let _ = decoder;")
                 }
-                withBlock("Ok(builder.build()", ")") {
-                    if (BuilderGenerator.hasFallibleBuilder(shape, symbolProvider)) {
-                        // NOTE:(rcoh) This branch is unreachable given the current nullability rules.
-                        // Only synthetic inputs can have fallible builders, but synthetic inputs can never be parsed
-                        // (because they're inputs, only outputs will be parsed!)
-
-                        // I'm leaving this branch here so that the binding trait parser generator would work for a server
-                        // side implementation in the future.
-                        rustTemplate(""".map_err(|_|#{XmlDecodeError}::custom("missing field"))?""", *codegenScope)
-                    }
-                }
+                val builder = builderInstantiator.finalizeBuilder(
+                    "builder",
+                    shape,
+                    mapErr = {
+                        rustTemplate(
+                            """.map_err(|_|#{XmlDecodeError}::custom("missing field"))?""",
+                            *codegenScope,
+                        )
+                    },
+                )
+                rust("Ok(#T)", builder)
             }
         }
         rust("#T(&mut ${ctx.tag})", nestedParser)
@@ -622,6 +636,7 @@ class XmlBindingTraitParserGenerator(
                     )
                 }
             }
+
             is TimestampShape -> {
                 val timestampFormat =
                     index.determineTimestampFormat(
@@ -629,7 +644,8 @@ class XmlBindingTraitParserGenerator(
                         HttpBinding.Location.DOCUMENT,
                         TimestampFormatTrait.Format.DATE_TIME,
                     )
-                val timestampFormatType = RuntimeType.parseTimestampFormat(codegenTarget, runtimeConfig, timestampFormat)
+                val timestampFormatType =
+                    RuntimeType.parseTimestampFormat(codegenTarget, runtimeConfig, timestampFormat)
                 withBlock("#T::from_str(", ")", RuntimeType.dateTime(runtimeConfig)) {
                     provider()
                     rust(", #T", timestampFormatType)
@@ -639,6 +655,7 @@ class XmlBindingTraitParserGenerator(
                     *codegenScope,
                 )
             }
+
             is BlobShape -> {
                 withBlock("#T(", ")", RuntimeType.base64Decode(runtimeConfig)) {
                     provider()
@@ -648,6 +665,7 @@ class XmlBindingTraitParserGenerator(
                     *codegenScope,
                 )
             }
+
             else -> PANIC("unexpected shape: $shape")
         }
     }
@@ -660,7 +678,10 @@ class XmlBindingTraitParserGenerator(
                     withBlock("#T::try_from(", ")", enumSymbol) {
                         provider()
                     }
-                    rustTemplate(""".map_err(|e| #{XmlDecodeError}::custom(format!("unknown variant {}", e)))?""", *codegenScope)
+                    rustTemplate(
+                        """.map_err(|e| #{XmlDecodeError}::custom(format!("unknown variant {}", e)))?""",
+                        *codegenScope,
+                    )
                 } else {
                     withBlock("#T::from(", ")", enumSymbol) {
                         provider()
@@ -674,7 +695,8 @@ class XmlBindingTraitParserGenerator(
         }
     }
 
-    private fun convertsToEnumInServer(shape: StringShape) = target == CodegenTarget.SERVER && shape.hasTrait<EnumTrait>()
+    private fun convertsToEnumInServer(shape: StringShape) =
+        target == CodegenTarget.SERVER && shape.hasTrait<EnumTrait>()
 
     private fun MemberShape.xmlName(): XmlName {
         return XmlName(xmlIndex.memberName(this))

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/DefaultBuilderInstantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/DefaultBuilderInstantiator.kt
@@ -18,7 +18,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstant
  */
 class DefaultBuilderInstantiator : BuilderInstantiator {
     override fun setField(builder: String, value: Writable, field: MemberShape): Writable {
-        return setFieldBase(builder, value, field)
+        return setFieldWithSetter(builder, value, field)
     }
 
     override fun finalizeBuilder(builder: String, shape: StructureShape, mapErr: Writable?): Writable {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/DefaultBuilderInstantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/DefaultBuilderInstantiator.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.testutil
+
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
+
+/**
+ * A Default instantiator that uses `builder.build()` in all cases. This exists to support tests in codegen-core
+ * and to serve as the base behavior for client and server instantiators.
+ */
+class DefaultBuilderInstantiator : BuilderInstantiator {
+    override fun setField(builder: String, value: Writable, field: MemberShape): Writable {
+        return setFieldBase(builder, value, field)
+    }
+
+    override fun finalizeBuilder(builder: String, shape: StructureShape, mapErr: Writable?): Writable {
+        return writable { rust("builder.build()") }
+    }
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/EventStreamTestModels.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/EventStreamTestModels.kt
@@ -145,7 +145,7 @@ object EventStreamTestModels {
             validTestUnion = """{"Foo":"hello"}""",
             validSomeError = """{"Message":"some error"}""",
             validUnmodeledError = """{"Message":"unmodeled error"}""",
-        ) { AwsJson(it, AwsJsonVersion.Json11) },
+        ) { AwsJson(it, AwsJsonVersion.Json11, builderInstantiator = DefaultBuilderInstantiator()) },
 
         //
         // restXml

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
@@ -36,6 +36,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.module
 import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticInputTrait
@@ -88,7 +89,11 @@ private object CodegenCoreTestModules {
             eventStream: UnionShape,
         ): RustModule.LeafModule = ErrorsTestModule
 
-        override fun moduleForBuilder(context: ModuleProviderContext, shape: Shape, symbol: Symbol): RustModule.LeafModule {
+        override fun moduleForBuilder(
+            context: ModuleProviderContext,
+            shape: Shape,
+            symbol: Symbol,
+        ): RustModule.LeafModule {
             val builderNamespace = RustReservedWords.escapeIfNeeded("test_" + symbol.name.toSnakeCase())
             return RustModule.new(
                 builderNamespace,
@@ -161,7 +166,7 @@ internal fun testCodegenContext(
     serviceShape: ServiceShape? = null,
     settings: CoreRustSettings = testRustSettings(),
     codegenTarget: CodegenTarget = CodegenTarget.CLIENT,
-): CodegenContext = CodegenContext(
+): CodegenContext = object : CodegenContext(
     model,
     testSymbolProvider(model),
     TestModuleDocProvider,
@@ -171,11 +176,16 @@ internal fun testCodegenContext(
     ShapeId.from("test#Protocol"),
     settings,
     codegenTarget,
-)
+) {
+    override fun builderInstantiator(): BuilderInstantiator {
+        return DefaultBuilderInstantiator()
+    }
+}
 
 /**
  * In tests, we frequently need to generate a struct, a builder, and an impl block to access said builder.
  */
+
 fun StructureShape.renderWithModelBuilder(
     model: Model,
     symbolProvider: RustSymbolProvider,

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/TestBuilderInstantiator.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/TestBuilderInstantiator.kt
@@ -1,0 +1,6 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy.generators

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/TestBuilderInstantiator.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/TestBuilderInstantiator.kt
@@ -1,6 +1,0 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
-package software.amazon.smithy.rust.codegen.core.smithy.generators

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenContext.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenContext.kt
@@ -12,6 +12,9 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.ModuleDocProvider
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
+import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerBuilderInstantiator
+import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.returnSymbolToParseFn
 
 /**
  * [ServerCodegenContext] contains code-generation context that is _specific_ to the [RustServerCodegenPlugin] plugin
@@ -35,4 +38,8 @@ data class ServerCodegenContext(
     val pubCrateConstrainedShapeSymbolProvider: PubCrateConstrainedShapeSymbolProvider,
 ) : CodegenContext(
     model, symbolProvider, moduleDocProvider, serviceShape, protocol, settings, CodegenTarget.SERVER,
-)
+) {
+    override fun builderInstantiator(): BuilderInstantiator {
+        return ServerBuilderInstantiator(symbolProvider, returnSymbolToParseFn(this))
+    }
+}

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
@@ -7,15 +7,20 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators
 
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderInstantiator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.Instantiator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.InstantiatorCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.InstantiatorSection
 import software.amazon.smithy.rust.codegen.core.smithy.isOptional
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.ReturnSymbolToParse
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.isDirectlyConstrained
 import software.amazon.smithy.rust.codegen.server.smithy.traits.isReachableFromOperationInput
@@ -86,3 +91,38 @@ fun serverInstantiator(codegenContext: CodegenContext) =
         defaultsForRequiredFields = true,
         customizations = listOf(ServerAfterInstantiatingValueConstrainItIfNecessary(codegenContext)),
     )
+
+class ServerBuilderInstantiator(
+    private val symbolProvider: RustSymbolProvider,
+    private val symbolParseFn: (Shape) -> ReturnSymbolToParse,
+) :
+    BuilderInstantiator {
+    override fun setField(builder: String, value: Writable, field: MemberShape): Writable {
+        // Server builders have the ability to have non-optional fields. When one of these fields is used,
+        // we need to use `if let(...)` to only set the field when it is present.
+        return if (!symbolProvider.toSymbol(field).isOptional()) {
+            writable {
+                val n = safeName()
+                rustTemplate(
+                    """
+                    if let Some($n) = #{value} {
+                        #{setter}
+                    }
+                    """,
+                    "value" to value, "setter" to setFieldBase(builder, writable(n), field),
+                )
+            }
+        } else {
+            setFieldBase(builder, value, field)
+        }
+    }
+
+    override fun finalizeBuilder(builder: String, shape: StructureShape, mapErr: Writable?): Writable = writable {
+        val returnSymbolToParse = symbolParseFn(shape)
+        if (returnSymbolToParse.isUnconstrained) {
+            rust(builder)
+        } else {
+            rust("$builder.build()")
+        }
+    }
+}

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
@@ -95,8 +95,7 @@ fun serverInstantiator(codegenContext: CodegenContext) =
 class ServerBuilderInstantiator(
     private val symbolProvider: RustSymbolProvider,
     private val symbolParseFn: (Shape) -> ReturnSymbolToParse,
-) :
-    BuilderInstantiator {
+) : BuilderInstantiator {
     override fun setField(builder: String, value: Writable, field: MemberShape): Writable {
         // Server builders have the ability to have non-optional fields. When one of these fields is used,
         // we need to use `if let(...)` to only set the field when it is present.
@@ -109,11 +108,11 @@ class ServerBuilderInstantiator(
                         #{setter}
                     }
                     """,
-                    "value" to value, "setter" to setFieldBase(builder, writable(n), field),
+                    "value" to value, "setter" to setFieldWithSetter(builder, writable(n), field),
                 )
             }
         } else {
-            setFieldBase(builder, value, field)
+            setFieldWithSetter(builder, value, field)
         }
     }
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocol.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocol.kt
@@ -122,7 +122,7 @@ class ServerAwsJsonProtocol(
     private val serverCodegenContext: ServerCodegenContext,
     awsJsonVersion: AwsJsonVersion,
     private val additionalParserCustomizations: List<JsonParserCustomization> = listOf(),
-) : AwsJson(serverCodegenContext, awsJsonVersion), ServerProtocol {
+) : AwsJson(serverCodegenContext, awsJsonVersion, serverCodegenContext.builderInstantiator()), ServerProtocol {
     private val runtimeConfig = codegenContext.runtimeConfig
 
     override val protocolModulePath: String
@@ -132,7 +132,12 @@ class ServerAwsJsonProtocol(
         }
 
     override fun structuredDataParser(): StructuredDataParserGenerator =
-        jsonParserGenerator(serverCodegenContext, httpBindingResolver, ::awsJsonFieldName, additionalParserCustomizations)
+        jsonParserGenerator(
+            serverCodegenContext,
+            httpBindingResolver,
+            ::awsJsonFieldName,
+            additionalParserCustomizations,
+        )
 
     override fun structuredDataSerializer(): StructuredDataSerializerGenerator =
         ServerAwsJsonSerializerGenerator(serverCodegenContext, httpBindingResolver, awsJsonVersion)
@@ -171,9 +176,11 @@ class ServerAwsJsonProtocol(
     override fun requestRejection(runtimeConfig: RuntimeConfig): RuntimeType =
         ServerCargoDependency.smithyHttpServer(runtimeConfig)
             .toType().resolve("protocol::aws_json::rejection::RequestRejection")
+
     override fun responseRejection(runtimeConfig: RuntimeConfig): RuntimeType =
         ServerCargoDependency.smithyHttpServer(runtimeConfig)
             .toType().resolve("protocol::aws_json::rejection::ResponseRejection")
+
     override fun runtimeError(runtimeConfig: RuntimeConfig): RuntimeType =
         ServerCargoDependency.smithyHttpServer(runtimeConfig)
             .toType().resolve("protocol::aws_json::runtime_error::RuntimeError")
@@ -192,7 +199,12 @@ class ServerRestJsonProtocol(
     override val protocolModulePath: String = "rest_json_1"
 
     override fun structuredDataParser(): StructuredDataParserGenerator =
-        jsonParserGenerator(serverCodegenContext, httpBindingResolver, ::restJsonFieldName, additionalParserCustomizations)
+        jsonParserGenerator(
+            serverCodegenContext,
+            httpBindingResolver,
+            ::restJsonFieldName,
+            additionalParserCustomizations,
+        )
 
     override fun structuredDataSerializer(): StructuredDataSerializerGenerator =
         ServerRestJsonSerializerGenerator(serverCodegenContext, httpBindingResolver)
@@ -257,6 +269,7 @@ class ServerRequestBeforeBoxingDeserializedMemberConvertToMaybeConstrainedJsonPa
                 rust(".map(|x| x.into())")
             }
         }
+
         else -> emptySection
     }
 }


### PR DESCRIPTION
## Motivation and Context
#1725 exposed the need for easily configuring builder behavior between client & server

## Description
- extract builderGenerator interface and attach it to `codegenContext` to avoid loads of threading it up and down

## Testing
- codegen unit tests
- [x] codegen diff audit

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
