### PR TITLE
Move endpoint resolution into the same phase as signing

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -156,3 +156,9 @@ message = "Source defaults from the default trait instead of implicitly based on
 references = ["smithy-rs#2985"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
 author = "rcoh"
+
+[[smithy-rs]]
+message = "[Behavior Break!] Endpoint resolution moved so that it takes place _after_ the `read_before_signing`/`modify_before_signing` hooks. Previously, the endpoint would have been available to interceptors implementing these hooks. This will only affect you if you have custom interceptors that read the endpoint."
+references = ["smithy-rs#2926", "smithy-rs#2972"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "jdisanti"

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -329,12 +329,12 @@ async fn try_attempt(
 ) {
     run_interceptors!(halt_on_err: read_before_attempt(ctx, runtime_components, cfg));
 
-    halt_on_err!([ctx] => orchestrate_endpoint(ctx, runtime_components, cfg).await.map_err(OrchestratorError::other));
-
     run_interceptors!(halt_on_err: {
         modify_before_signing(ctx, runtime_components, cfg);
         read_before_signing(ctx, runtime_components, cfg);
     });
+
+    halt_on_err!([ctx] => orchestrate_endpoint(ctx, runtime_components, cfg).await.map_err(OrchestratorError::other));
 
     halt_on_err!([ctx] => orchestrate_auth(ctx, runtime_components, cfg).await.map_err(OrchestratorError::other));
 


### PR DESCRIPTION
The endpoint resolution and signing steps need to be combined in the near future. This PR moves endpoint resolution so that combining it with signing in the future won't break interceptors.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
