### PR TITLE
Generate better docs when fields are required

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -14,7 +14,7 @@
 [[smithy-rs]]
 message = "It's now possible to nest runtime components with the `RuntimePlugin` trait. A `current_components` argument was added to the `runtime_components` method so that components configured from previous runtime plugins can be referenced in the current runtime plugin. Ordering of runtime plugins was also introduced via a new `RuntimePlugin::order` method."
 references = ["smithy-rs#2909"]
-meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client"}
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"
 
 [[aws-sdk-rust]]
@@ -176,4 +176,10 @@ author = "rschmitt"
 message = "Source defaults from the default trait instead of implicitly based on type. This has minimal changes in the generated code."
 references = ["smithy-rs#2985"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
+author = "rcoh"
+
+[[smithy-rs]]
+message = "Produce better docs when items are marked @required"
+references = ["smithy-rs#2996"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "rcoh"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -528,7 +528,7 @@ private fun generateOperationShapeDocs(
             else -> "(undocumented)"
         }
 
-        "[`$builderInputDoc`]($builderInputLink) / [`$builderSetterDoc`]($builderSetterLink): $docs"
+        "[`$builderInputDoc`]($builderInputLink) / [`$builderSetterDoc`]($builderSetterLink):<br>required: **${memberShape.isRequired}**<br>$docs<br>"
     }
 }
 


### PR DESCRIPTION
## Motivation and Context
With required builders, builders return errors in more cases now. This clearly indicates which fields that the service considers required.

## Description
Add more docs for required status.
<img width="1037" alt="Screenshot 2023-09-22 at 3 38 42 PM" src="https://github.com/awslabs/smithy-rs/assets/492903/082b4950-7edd-4f25-9081-a3c9fe3f870a">
<img width="998" alt="Screenshot 2023-09-22 at 3 39 01 PM" src="https://github.com/awslabs/smithy-rs/assets/492903/98acd359-5572-4e01-afba-7af5b0264d18">

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
