### PR TITLE
Update SmithyRs maintainers list

### DIFF
--- a/tools/ci-build/changelogger/smithy-rs-maintainers.txt
+++ b/tools/ci-build/changelogger/smithy-rs-maintainers.txt
@@ -5,3 +5,6 @@ jdisanti
 rcoh
 velfi
 ysaito1001
+drganjoo
+rschmitt
+rhernandez35


### PR DESCRIPTION
## Motivation and Context

Updating the list of users who are maintaining smithy-rs. 

## Description

This file is used to distinguish between internal and external contributors. Usernames of external contributors appear in the ‘Contributors’ section of the changelog.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
