### PR TITLE
Fix `#[warn(dead_code)]` in the SDK crate for a service with no operations defined

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGenerator.kt
@@ -48,6 +48,7 @@ class ConfigOverrideRuntimePluginGenerator(
             }
 
             impl ConfigOverrideRuntimePlugin {
+                ##[allow(dead_code)] // unused when a service does not provide any operations
                 pub(crate) fn new(
                     config_override: Builder,
                     initial_config: #{FrozenLayer},

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -197,6 +197,7 @@ class CustomizableOperationGenerator(
 
                     impl<T, E, B> CustomizableOperation<T, E, B> {
                         /// Creates a new `CustomizableOperation` from `customizable_send`.
+                        ##[allow(dead_code)] // unused when a service does not provide any operations
                         pub(crate) fn new(customizable_send: B) -> Self {
                             Self {
                                 customizable_send,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -184,6 +184,7 @@ class FluentClientGenerator(
                     ##[derive(Debug)]
                     pub(crate) struct Handle {
                         pub(crate) conf: crate::Config,
+                        ##[allow(dead_code)] // unused when a service does not provide any operations
                         pub(crate) runtime_plugins: #{RuntimePlugins},
                     }
 

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
@@ -162,4 +162,19 @@ class FluentClientGeneratorTest {
             test = test,
         )
     }
+
+    @Test
+    fun `dead-code warning should not be issued when a service has no operations`() {
+        val model = """
+            namespace com.example
+            use aws.protocols#awsJson1_0
+
+            @awsJson1_0
+            service HelloService {
+                version: "1"
+            }
+        """.asSmithyModel()
+
+        clientIntegrationTest(model)
+    }
 }


### PR DESCRIPTION
## Motivation and Context
When a service has no operations, the following places in a generated SDK issue `dead_code` warnings:
```
error: field `runtime_plugins` is never read
 --> src/client.rs:5:16
  |
3 | pub(crate) struct Handle {
  |                   ------ field in this struct
4 |     pub(crate) conf: crate::Config,
5 |     pub(crate) runtime_plugins: ::aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugins,
  |                ^^^^^^^^^^^^^^^
  |
  = note: `Handle` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
  = note: `-D dead-code` implied by `-D warnings`

error: associated function `new` is never used
  --> src/client/customize.rs:30:23
   |
28 |     impl<T, E, B> CustomizableOperation<T, E, B> {
   |     -------------------------------------------- associated function in this implementation
29 |         /// Creates a new `CustomizableOperation` from `customizable_send`.
30 |         pub(crate) fn new(customizable_send: B) -> Self {
   |                       ^^^

error: associated function `new` is never used
   --> src/config.rs:853:19
    |
852 | impl ConfigOverrideRuntimePlugin {
    | -------------------------------- associated function in this implementation
853 |     pub(crate) fn new(
    |                   ^^^
```
This PR adds `#[allow(dead_code)]` to the code generator at the corresponding places to suppress those warnings.

## Testing
- Added a new unit test to ensure that the warnings are not issued for a service with no operations.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
