### PR TITLE
Add additional default semantics

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
@@ -416,6 +416,8 @@ class BuilderGenerator(
                                 ")?",
                             ) { missingRequiredField(memberName) }
                         }
+                    } else if (member.isRequired && default != null) {
+                        rust(".or_else(|| Some((#T)()))", default.expr)
                     }
                 }
             }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
@@ -177,12 +177,24 @@ internal class BuilderGeneratorTest {
               @default(true)
               @required
               defaultDocument: Document
+
+              @clientOptional
+              @required
+              @default([])
+              requiredButOptional: StringList
+
+              @default(1)
+              @clientOptional
+              @required
+              reqOptInt: OneDefault
+
             }
             list StringList {
                 member: String
             }
             @default(1)
             integer OneDefault
+
         """.asSmithyModel(smithyVersion = "2.0")
 
         val provider = testSymbolProvider(
@@ -207,6 +219,7 @@ internal class BuilderGeneratorTest {
                     assert_eq!(s.an_actually_required_field(), 5);
                     assert_eq!(s.no_default(), None);
                     assert_eq!(s.default_document().as_bool().unwrap(), true);
+                    assert_eq!(s.required_but_optional, Some(vec![]));
                     """,
                     "Struct" to provider.toSymbol(shape),
                 )


### PR DESCRIPTION
> don't merge this until models are finalized with cleaned-up defaults.

Currently there are defaults that shouldn't exist which causes this change to have undesired behavior.

## Motivation and Context
Updates to the Smithy spec about default values, specifically:
- defaults should be set when the field is marked as required

## Description
An additional codepath was added to the builder generator to add default values for fields marked as required
## Testing
- New unit test
- [ ] consider codegen diff

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
