### PR TITLE
Allow warnings in examples compilation

### DIFF
--- a/tools/ci-scripts/check-aws-sdk-examples
+++ b/tools/ci-scripts/check-aws-sdk-examples
@@ -13,7 +13,7 @@ cd aws-sdk/examples
 for example in *; do
     echo -e "${C_YELLOW}Checking examples/${example}...${C_RESET}"
     pushd "${example}" &>/dev/null
-    cargo check
+    RUSTFLAGS="" cargo check
     cargo clean
     popd &>/dev/null
 done


### PR DESCRIPTION
## Motivation and Context
** needs backport **

Allow warnings in examples compilation

## Description
<!--- Describe your changes in detail -->

## Testing
Verified that `RUSTFLAGS=""` works as expected.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
