### PR TITLE
Make versions comparison more flexible in the fix-manifest subcommand of publisher

### DIFF
--- a/tools/ci-build/publisher/src/subcommand/fix_manifests.rs
+++ b/tools/ci-build/publisher/src/subcommand/fix_manifests.rs
@@ -255,20 +255,13 @@ fn convert_to_tilde_requirement(package_version: &semver::Version) -> Result<Str
 //
 // Each input can be either a semver-compliant version or a tilde version requirement.
 fn versions_match(prev_version: &Value, current_version: &str) -> bool {
-    fn maybe_strip_tilde(s: &str) -> &str {
-        if s.starts_with("~") {
-            &s[1..]
-        } else {
-            s
-        }
-    }
     match prev_version.as_str() {
         Some(prev_version) => {
             if prev_version == current_version {
                 return true;
             }
-            let prev_version = maybe_strip_tilde(prev_version);
-            let current_version = maybe_strip_tilde(current_version);
+            let prev_version = prev_version.strip_prefix('~').unwrap_or(prev_version);
+            let current_version = current_version.strip_prefix('~').unwrap_or(current_version);
             prev_version.starts_with(current_version) || current_version.starts_with(prev_version)
         }
         _ => false,

--- a/tools/ci-build/publisher/src/subcommand/fix_manifests.rs
+++ b/tools/ci-build/publisher/src/subcommand/fix_manifests.rs
@@ -217,7 +217,7 @@ fn update_dep(table: &mut Table, dep_name: &str, versions: &VersionView) -> Resu
     );
     match previous_version {
         None => Ok(1),
-        Some(prev_version) if prev_version.as_str() == Some(&package_version) => Ok(0),
+        Some(prev_version) if versions_match(&prev_version, &package_version) => Ok(0),
         Some(mismatched_version) => {
             tracing::warn!(expected = ?package_version, actual = ?mismatched_version, "version was set but it did not match");
             Ok(1)
@@ -249,6 +249,30 @@ fn convert_to_tilde_requirement(package_version: &semver::Version) -> Result<Str
     };
 
     Ok("~".to_string() + package_version)
+}
+
+// Determines if `prev_version` and `current_version` are considered a match
+//
+// Each input can be either a semver-compliant version or a tilde version requirement.
+fn versions_match(prev_version: &Value, current_version: &str) -> bool {
+    fn maybe_strip_tilde(s: &str) -> &str {
+        if s.starts_with("~") {
+            &s[1..]
+        } else {
+            s
+        }
+    }
+    match prev_version.as_str() {
+        Some(prev_version) => {
+            if prev_version == current_version {
+                return true;
+            }
+            let prev_version = maybe_strip_tilde(prev_version);
+            let current_version = maybe_strip_tilde(current_version);
+            prev_version.starts_with(current_version) || current_version.starts_with(prev_version)
+        }
+        _ => false,
+    }
 }
 
 fn fix_dep_sets(versions: &VersionView, metadata: &mut toml::Value) -> Result<usize> {
@@ -528,6 +552,22 @@ mod tests {
         assert!(is_example_manifest("examples/foo/bar/Cargo.toml"));
         assert!(is_example_manifest(
             "aws-sdk-rust/examples/foo/bar/Cargo.toml"
+        ));
+    }
+
+    #[test]
+    fn test_versions_match() {
+        assert!(versions_match(&Value::String("0.56.1".to_owned()), "~0.56"));
+        assert!(versions_match(&Value::String("~0.56".to_owned()), "0.56.1"));
+        assert!(!versions_match(&Value::String("~0.56".to_owned()), "~0.57"));
+        assert!(!versions_match(&Value::String("~0.57".to_owned()), "~0.56"));
+        assert!(!versions_match(
+            &Value::String("0.56.1".to_owned()),
+            "0.56.2"
+        ));
+        assert!(!versions_match(
+            &Value::String("0.56.1".to_owned()),
+            "0.57.1"
         ));
     }
 }


### PR DESCRIPTION
## Motivation and Context
Attempts to resolve [a workflow failure](https://github.com/awslabs/aws-sdk-rust/actions/runs/6395300944/job/17358637767#step:6) in `aws-sdk-rust`.

## Description
We have observed a series of `WARN`s from the `check-manifests` job. It is caused by #3009, specifically `update_dep` in the `fix-manifests` needs to be updated where it compares a version in a `Table` versus a current version being looked at. For instance, prior to the PR, `0.56.1` and `~0.56` for a crate were considered a mismatch when it should be a match according to our latest logic.

## Testing
- Added a unit test for a helper function.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
