### PR TITLE
Make `customize()` sync and infallible

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -291,3 +291,9 @@ message = "`SdkError` is no longer re-exported in generated server crates."
 references = ["smithy-rs#3038"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "The `customize()` method is now sync and infallible. Remove any `await`s and error handling from it to make things compile again."
+references = ["smithy-rs#3039"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "jdisanti"

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/CredentialCacheConfigTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/CredentialCacheConfigTest.kt
@@ -156,8 +156,6 @@ internal class CredentialCacheConfigTest {
                         let _ = client
                             .say_hello()
                             .customize()
-                            .await
-                            .unwrap()
                             .config_override(operation_config_override)
                             .send()
                             .await

--- a/aws/sdk/integration-tests/kms/tests/integration.rs
+++ b/aws/sdk/integration-tests/kms/tests/integration.rs
@@ -73,8 +73,6 @@ async fn generate_random() {
         .generate_random()
         .number_of_bytes(64)
         .customize()
-        .await
-        .expect("customizable")
         .mutate_request(|req| {
             // Remove the invocation ID since the signed request above doesn't have it
             req.headers_mut().remove("amz-sdk-invocation-id");
@@ -157,8 +155,6 @@ async fn generate_random_keystore_not_found() {
         .number_of_bytes(64)
         .custom_key_store_id("does not exist")
         .customize()
-        .await
-        .expect("customizable")
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1614955644))
         .user_agent_for_tests()
         .send()

--- a/aws/sdk/integration-tests/qldbsession/tests/integration.rs
+++ b/aws/sdk/integration-tests/qldbsession/tests/integration.rs
@@ -45,8 +45,6 @@ async fn signv4_use_correct_service_name() {
                 .unwrap(),
         )
         .customize()
-        .await
-        .expect("should be customizable")
         // Fix the request time and user agent so the headers are stable
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1614952162))
         .user_agent_for_tests()

--- a/aws/sdk/integration-tests/s3/tests/checksums.rs
+++ b/aws/sdk/integration-tests/s3/tests/checksums.rs
@@ -74,8 +74,6 @@ async fn test_checksum_on_streaming_response(
         .key("test.txt")
         .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
         .customize()
-        .await
-        .unwrap()
         .user_agent_for_tests()
         .send()
         .await
@@ -181,8 +179,6 @@ async fn test_checksum_on_streaming_request<'a>(
         .body(body)
         .checksum_algorithm(checksum_algorithm)
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1624036048))
         .user_agent_for_tests()
         .send()

--- a/aws/sdk/integration-tests/s3/tests/config-override.rs
+++ b/aws/sdk/integration-tests/s3/tests/config-override.rs
@@ -27,8 +27,6 @@ async fn operation_overrides_force_path_style() {
         .list_objects_v2()
         .bucket("test-bucket")
         .customize()
-        .await
-        .unwrap()
         .config_override(aws_sdk_s3::config::Config::builder().force_path_style(true))
         .send()
         .await;
@@ -45,8 +43,6 @@ async fn operation_overrides_fips() {
         .list_objects_v2()
         .bucket("test-bucket")
         .customize()
-        .await
-        .unwrap()
         .config_override(aws_sdk_s3::config::Config::builder().use_fips(true))
         .send()
         .await;
@@ -63,8 +59,6 @@ async fn operation_overrides_dual_stack() {
         .list_objects_v2()
         .bucket("test-bucket")
         .customize()
-        .await
-        .unwrap()
         .config_override(aws_sdk_s3::config::Config::builder().use_dual_stack(true))
         .send()
         .await;
@@ -85,8 +79,6 @@ async fn operation_overrides_credentials_provider() {
         .list_objects_v2()
         .bucket("test-bucket")
         .customize()
-        .await
-        .unwrap()
         .config_override(aws_sdk_s3::config::Config::builder().credentials_provider(Credentials::new(
             "test",
             "test",

--- a/aws/sdk/integration-tests/s3/tests/customizable-operation.rs
+++ b/aws/sdk/integration-tests/s3/tests/customizable-operation.rs
@@ -26,8 +26,6 @@ async fn test_s3_ops_are_customizable() {
     let op = client
         .list_buckets()
         .customize()
-        .await
-        .expect("list_buckets is customizable")
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1624036048))
         .user_agent_for_tests();
 

--- a/aws/sdk/integration-tests/s3/tests/endpoints.rs
+++ b/aws/sdk/integration-tests/s3/tests/endpoints.rs
@@ -70,8 +70,6 @@ async fn multi_region_access_points() {
         .bucket("arn:aws:s3::123456789012:accesspoint/mfzwi23gnjvgw.mrap")
         .key("blah")
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1624036048))
         .user_agent_for_tests()
         .send()
@@ -103,8 +101,6 @@ async fn s3_object_lambda() {
         .bucket("arn:aws:s3-object-lambda:us-east-100:123412341234:accesspoint/myolap")
         .key("s3.txt")
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1234567890))
         .send()
         .await

--- a/aws/sdk/integration-tests/s3/tests/ignore-invalid-xml-body-root.rs
+++ b/aws/sdk/integration-tests/s3/tests/ignore-invalid-xml-body-root.rs
@@ -56,8 +56,6 @@ async fn ignore_invalid_xml_body_root() {
         .key("test.txt")
         .object_attributes(ObjectAttributes::Checksum)
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1624036048))
         .user_agent_for_tests()
         .send()

--- a/aws/sdk/integration-tests/s3/tests/interceptors.rs
+++ b/aws/sdk/integration-tests/s3/tests/interceptors.rs
@@ -74,8 +74,6 @@ async fn interceptor_priority() {
             .bucket("test-bucket")
             .prefix("prefix~")
             .customize()
-            .await
-            .unwrap()
             .interceptor(TestInterceptor("value2"))
             .send()
             .await
@@ -103,8 +101,6 @@ async fn set_test_user_agent_through_request_mutation() {
             .bucket("test-bucket")
             .prefix("prefix~")
             .customize()
-            .await
-            .unwrap()
             .mutate_request(|request| {
                 let headers = request.headers_mut();
                 headers.insert(USER_AGENT, HeaderValue::try_from("test").unwrap());

--- a/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
+++ b/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
@@ -79,8 +79,6 @@ async fn test_s3_signer_with_naughty_string_metadata() {
 
     let _ = builder
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1624036048))
         .user_agent_for_tests()
         .send()

--- a/aws/sdk/integration-tests/s3/tests/no_auth.rs
+++ b/aws/sdk/integration-tests/s3/tests/no_auth.rs
@@ -25,8 +25,6 @@ async fn list_objects() {
         .bucket("gdc-organoid-pancreatic-phs001611-2-open")
         .max_keys(3)
         .customize()
-        .await
-        .unwrap()
         .remove_invocation_id_for_tests()
         .user_agent_for_tests()
         .send()
@@ -58,8 +56,6 @@ async fn list_objects_v2() {
         .bucket("gdc-organoid-pancreatic-phs001611-2-open")
         .max_keys(3)
         .customize()
-        .await
-        .unwrap()
         .remove_invocation_id_for_tests()
         .user_agent_for_tests()
         .send()
@@ -90,8 +86,6 @@ async fn head_object() {
         .bucket("gdc-organoid-pancreatic-phs001611-2-open")
         .key("0431cddc-a418-4a79-a34d-6c041394e8e4/a6ddcc84-8e4d-4c68-885c-2d51168eec97.FPKM-UQ.txt.gz")
         .customize()
-        .await
-        .unwrap()
         .remove_invocation_id_for_tests()
         .user_agent_for_tests()
         .send()
@@ -122,8 +116,6 @@ async fn get_object() {
         .bucket("gdc-organoid-pancreatic-phs001611-2-open")
         .key("0431cddc-a418-4a79-a34d-6c041394e8e4/a6ddcc84-8e4d-4c68-885c-2d51168eec97.FPKM-UQ.txt.gz")
         .customize()
-        .await
-        .unwrap()
         .remove_invocation_id_for_tests()
         .user_agent_for_tests()
         .send()

--- a/aws/sdk/integration-tests/s3/tests/normalize-uri-path.rs
+++ b/aws/sdk/integration-tests/s3/tests/normalize-uri-path.rs
@@ -31,8 +31,6 @@ async fn test_operation_should_not_normalize_uri_path() {
         .key("a/.././b.txt") // object key with dot segments
         .body(ByteStream::from_static("Hello, world".as_bytes()))
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1669257290))
         .user_agent_for_tests()
         .send()

--- a/aws/sdk/integration-tests/s3/tests/query-strings-are-correctly-encoded.rs
+++ b/aws/sdk/integration-tests/s3/tests/query-strings-are-correctly-encoded.rs
@@ -33,8 +33,6 @@ async fn test_s3_signer_query_string_with_all_valid_chars() {
         .bucket("test-bucket")
         .prefix(&prefix)
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1624036048))
         .user_agent_for_tests()
         .send()

--- a/aws/sdk/integration-tests/s3/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3/tests/signing-it.rs
@@ -34,8 +34,6 @@ async fn test_signer() {
         .bucket("test-bucket")
         .prefix("prefix~")
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1624036048))
         .user_agent_for_tests()
         .send()

--- a/aws/sdk/integration-tests/s3control/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3control/tests/signing-it.rs
@@ -37,8 +37,6 @@ async fn test_signer() {
         .list_access_points()
         .account_id("test-bucket")
         .customize()
-        .await
-        .unwrap()
         .request_time_for_tests(UNIX_EPOCH + Duration::from_secs(1636751225))
         .user_agent_for_tests()
         .remove_invocation_id_for_tests()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
@@ -149,7 +149,6 @@ class ClientModuleDocProvider(
 
                 let result = client.$opFnName()
                     .customize()
-                    .await?
                     .mutate_request(|req| {
                         // Add `x-example-header` with value
                         req.headers_mut()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -371,21 +371,11 @@ class FluentClientGenerator(
                     #{Operation}::orchestrate(&runtime_plugins, input).await
                 }
 
-                /// Consumes this builder, creating a customizable operation that can be modified before being
-                /// sent.
-                // TODO(enableNewSmithyRuntimeCleanup): Remove `async` and `Result` once we switch to orchestrator
-                pub async fn customize(
+                /// Consumes this builder, creating a customizable operation that can be modified before being sent.
+                pub fn customize(
                     self,
-                ) -> #{Result}<
-                    #{CustomizableOperation}<
-                        #{OperationOutput},
-                        #{OperationError},
-                        Self,
-                    >,
-                    #{SdkError}<#{OperationError}>,
-                >
-                {
-                    #{Ok}(#{CustomizableOperation}::new(self))
+                ) -> #{CustomizableOperation}<#{OperationOutput}, #{OperationError}, Self> {
+                    #{CustomizableOperation}::new(self)
                 }
                 """,
                 *orchestratorScope,

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/MetadataCustomizationTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/MetadataCustomizationTest.kt
@@ -90,8 +90,6 @@ class MetadataCustomizationTest {
                         let _ = client
                             .say_hello()
                             .customize()
-                            .await
-                            .expect("operation should be customizable")
                             .interceptor(ExtractMetadataInterceptor(::std::sync::Mutex::new(#{Some}(tx))))
                             .send()
                             .await;

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGeneratorTest.kt
@@ -118,8 +118,6 @@ internal class ConfigOverrideRuntimePluginGeneratorTest {
                         let customizable_send = client
                             .say_hello()
                             .customize()
-                            .await
-                            .unwrap()
                             .config_override(crate::config::Config::builder().http_client(http_client))
                             .send();
 


### PR DESCRIPTION
This PR addresses a TODO comment to make `customize()` sync and fallible.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
