### PR TITLE
Run `--all` in precommit

### DIFF
--- a/.pre-commit-hooks/sdk-lints.sh
+++ b/.pre-commit-hooks/sdk-lints.sh
@@ -5,4 +5,4 @@
 #
 
 set -e
-cd "$(git rev-parse --show-toplevel)/tools/ci-build/sdk-lints" && cargo run -- check --license --changelog
+cd "$(git rev-parse --show-toplevel)/tools/ci-build/sdk-lints" && cargo run -- check --all


### PR DESCRIPTION
## Motivation and Context
Some lint errors don't show up until CI, this fixes that issue.
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
