### PR TITLE
Use tokio::process to allow timeouts to occur

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -427,6 +427,18 @@ references = ["smithy-rs#3043", "smithy-rs#3078"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "rcoh"
 
+[[aws-sdk-rust]]
+message = "A bug was fixed where the credentials-process provider was executing the subprocess in the worker thread, potentially stalling the runtime."
+references = ["smithy-rs#3052"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "The `credentials-process` feature was added to `aws-config`. If you currently use `no-default-features` for `aws-config`, you MUST enable this feature to use the [`CredentialProcessProvider`](https://docs.rs/aws-config/latest/aws_config/credential_process/struct.CredentialProcessProvider.html) provider directly or via `~/.aws/config`."
+references = ["smithy-rs#3052"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "rcoh"
+
 [[smithy-rs]]
 message = """
 `aws_smithy_http::operation::error::{BuildError, SerializationError}` have been moved to `aws_smithy_types::error::operation::{BuildError, SerializationError}`. Type aliases for them are left in `aws_smithy_http` for backwards compatibility but are deprecated.

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -14,8 +14,9 @@ rustls = ["aws-smithy-runtime/tls-rustls", "client-hyper"]
 allow-compilation = [] # our tests use `cargo test --all-features` and native-tls breaks CI
 rt-tokio = ["aws-smithy-async/rt-tokio", "aws-smithy-runtime/rt-tokio", "tokio/rt"]
 sso = ["dep:aws-sdk-sso", "dep:aws-sdk-ssooidc", "dep:ring", "dep:hex", "dep:zeroize", "aws-smithy-runtime-api/http-auth"]
+credentials-process = ["tokio/process"]
 
-default = ["client-hyper", "rustls", "rt-tokio"]
+default = ["client-hyper", "rustls", "rt-tokio", "credentials-process", "sso"]
 
 [dependencies]
 aws-credential-types = { path = "../../sdk/build/aws-sdk/sdk/aws-credential-types" }

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -127,6 +127,7 @@ pub mod meta;
 pub mod profile;
 pub mod provider_config;
 pub mod retry;
+mod sensitive_command;
 #[cfg(feature = "sso")]
 pub mod sso;
 pub(crate) mod standard_property;

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -262,6 +262,8 @@ pub enum ProfileFileError {
     FeatureNotEnabled {
         /// The feature or comma delimited list of features that must be enabled
         feature: Cow<'static, str>,
+        /// Additional information about the missing feature
+        message: Option<Cow<'static, str>>,
     },
 }
 
@@ -315,10 +317,11 @@ impl Display for ProfileFileError {
                 "profile `{}` did not contain credential information",
                 profile
             ),
-            ProfileFileError::FeatureNotEnabled { feature: message } => {
+            ProfileFileError::FeatureNotEnabled { feature, message } => {
+                let message = message.as_deref().unwrap_or_default();
                 write!(
                     f,
-                    "This behavior requires following cargo feature(s) enabled: {message}",
+                    "This behavior requires following cargo feature(s) enabled: {feature}. {message}",
                 )
             }
         }
@@ -488,7 +491,10 @@ mod test {
     make_test!(retry_on_error);
     make_test!(invalid_config);
     make_test!(region_override);
+    #[cfg(feature = "credentials-process")]
     make_test!(credential_process);
+    #[cfg(feature = "credentials-process")]
     make_test!(credential_process_failure);
+    #[cfg(feature = "credentials-process")]
     make_test!(credential_process_invalid);
 }

--- a/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
@@ -12,9 +12,9 @@
 //! 1-credential-per row (as opposed to a direct profile file representation which can combine
 //! multiple actions into the same profile).
 
-use crate::credential_process::CommandWithSensitiveArgs;
 use crate::profile::credentials::ProfileFileError;
 use crate::profile::{Profile, ProfileSet};
+use crate::sensitive_command::CommandWithSensitiveArgs;
 use aws_credential_types::Credentials;
 
 /// Chain of Profile Providers
@@ -408,9 +408,9 @@ fn credential_process_from_profile(
 
 #[cfg(test)]
 mod tests {
-    use crate::credential_process::CommandWithSensitiveArgs;
     use crate::profile::credentials::repr::{resolve_chain, BaseProvider, ProfileChain};
     use crate::profile::ProfileSet;
+    use crate::sensitive_command::CommandWithSensitiveArgs;
     use serde::Deserialize;
     use std::collections::HashMap;
     use std::error::Error;

--- a/aws/rust-runtime/aws-config/src/sensitive_command.rs
+++ b/aws/rust-runtime/aws-config/src/sensitive_command.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::fmt;
+
+#[derive(Clone)]
+pub(crate) struct CommandWithSensitiveArgs<T>(T);
+
+impl<T> CommandWithSensitiveArgs<T>
+where
+    T: AsRef<str>,
+{
+    pub(crate) fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn to_owned_string(&self) -> CommandWithSensitiveArgs<String> {
+        CommandWithSensitiveArgs(self.0.as_ref().to_string())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn unredacted(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl<T> fmt::Display for CommandWithSensitiveArgs<T>
+where
+    T: AsRef<str>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Security: The arguments for command must be redacted since they can be sensitive
+        let command = self.0.as_ref();
+        match command.find(char::is_whitespace) {
+            Some(index) => write!(f, "{} ** arguments redacted **", &command[0..index]),
+            None => write!(f, "{}", command),
+        }
+    }
+}
+
+impl<T> fmt::Debug for CommandWithSensitiveArgs<T>
+where
+    T: AsRef<str>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", format!("{}", self))
+    }
+}

--- a/rust-runtime/aws-smithy-runtime/src/test_util/capture_test_logs.rs
+++ b/rust-runtime/aws-smithy-runtime/src/test_util/capture_test_logs.rs
@@ -83,7 +83,8 @@ where
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.buf.lock().unwrap().extend_from_slice(buf);
         if !self.quiet {
-            self.inner.write(buf)
+            self.inner.write_all(buf)?;
+            Ok(buf.len())
         } else {
             Ok(buf.len())
         }


### PR DESCRIPTION
## Motivation and Context
The existing credentials provider was a DOS risk and didn't obey timeout settings because it used `std::timeout::spawn` but relied on a async-based timeout mechanism.

## Description
- Use `tokio::process` instead
- introduce new cargo feature

## Testing
- unit test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
