### PR TITLE
New-type all the orchestrator futures

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -323,3 +323,15 @@ For more information, see the [guide](https://github.com/awslabs/smithy-rs/discu
 references = ["smithy-rs#2417", "smithy-rs#3018"]
 meta = { "breaking" = true, "tada" = true, "bug" = false }
 author = "Velfi"
+
+[[aws-sdk-rust]]
+message = "The future return types on traits `EndpointResolver` and `IdentityResolver` changed to new-types `EndpointFuture` and `IdentityFuture` respectively."
+references = ["smithy-rs#3055"]
+meta = { "breaking" = true, "tada" = true, "bug" = true }
+author = "jdisanti"
+
+[[smithy-rs]]
+message = "The future return types on traits `EndpointResolver` and `IdentityResolver` changed to new-types `EndpointFuture` and `IdentityFuture` respectively."
+references = ["smithy-rs#3055"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -19,9 +19,11 @@ use aws_smithy_http::result::SdkError;
 use aws_smithy_runtime::client::orchestrator::operation::Operation;
 use aws_smithy_runtime::client::retries::strategy::StandardRetryStrategy;
 use aws_smithy_runtime_api::client::auth::AuthSchemeOptionResolverParams;
-use aws_smithy_runtime_api::client::endpoint::{EndpointResolver, EndpointResolverParams};
+use aws_smithy_runtime_api::client::endpoint::{
+    EndpointFuture, EndpointResolver, EndpointResolverParams,
+};
 use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
-use aws_smithy_runtime_api::client::orchestrator::{Future, OrchestratorError, SensitiveOutput};
+use aws_smithy_runtime_api::client::orchestrator::{OrchestratorError, SensitiveOutput};
 use aws_smithy_runtime_api::client::retries::classifiers::{
     ClassifyRetry, RetryAction, SharedRetryClassifier,
 };
@@ -522,15 +524,15 @@ struct ImdsEndpointResolver {
 }
 
 impl EndpointResolver for ImdsEndpointResolver {
-    fn resolve_endpoint(&self, _: &EndpointResolverParams) -> Future<Endpoint> {
+    fn resolve_endpoint(&self, _: &EndpointResolverParams) -> EndpointFuture {
         let this = self.clone();
-        Future::new(Box::pin(async move {
+        EndpointFuture::new(async move {
             this.endpoint_source
                 .endpoint(this.mode_override)
                 .await
                 .map(|uri| Endpoint::builder().url(uri.to_string()).build())
                 .map_err(|err| err.into())
-        }))
+        })
     }
 }
 

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -25,11 +25,9 @@ use aws_smithy_runtime_api::client::auth::{
     AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Signer,
 };
 use aws_smithy_runtime_api::client::identity::{
-    Identity, IdentityResolver, SharedIdentityResolver,
+    Identity, IdentityFuture, IdentityResolver, SharedIdentityResolver,
 };
-use aws_smithy_runtime_api::client::orchestrator::{
-    Future, HttpRequest, HttpResponse, OrchestratorError,
-};
+use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, HttpResponse, OrchestratorError};
 use aws_smithy_runtime_api::client::runtime_components::{
     GetIdentityResolver, RuntimeComponents, RuntimeComponentsBuilder,
 };
@@ -194,9 +192,9 @@ fn parse_token_response(response: &HttpResponse, now: SystemTime) -> Result<Toke
 }
 
 impl IdentityResolver for TokenResolver {
-    fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
+    fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
         let this = self.clone();
-        Future::new(Box::pin(async move {
+        IdentityFuture::new(async move {
             let preloaded_token = this
                 .inner
                 .cache
@@ -217,7 +215,7 @@ impl IdentityResolver for TokenResolver {
 
             let expiry = token.expiry;
             Ok(Identity::new(token, Some(expiry)))
-        }))
+        })
     }
 }
 

--- a/aws/rust-runtime/aws-runtime/src/identity.rs
+++ b/aws/rust-runtime/aws-runtime/src/identity.rs
@@ -6,9 +6,7 @@
 /// Credentials-based identity support.
 pub mod credentials {
     use aws_credential_types::cache::SharedCredentialsCache;
-    use aws_smithy_runtime_api::box_error::BoxError;
-    use aws_smithy_runtime_api::client::identity::{Identity, IdentityResolver};
-    use aws_smithy_runtime_api::client::orchestrator::Future;
+    use aws_smithy_runtime_api::client::identity::{Identity, IdentityFuture, IdentityResolver};
     use aws_smithy_types::config_bag::ConfigBag;
 
     /// Smithy identity resolver for AWS credentials.
@@ -25,13 +23,13 @@ pub mod credentials {
     }
 
     impl IdentityResolver for CredentialsIdentityResolver {
-        fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
+        fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
             let cache = self.credentials_cache.clone();
-            Future::new(Box::pin(async move {
+            IdentityFuture::new(async move {
                 let credentials = cache.as_ref().provide_cached_credentials().await?;
                 let expiration = credentials.expiry();
-                Result::<_, BoxError>::Ok(Identity::new(credentials, expiration))
-            }))
+                Ok(Identity::new(credentials, expiration))
+            })
         }
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client.rs
@@ -3,6 +3,68 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+macro_rules! new_type_future {
+    (
+        doc = $type_docs:literal,
+        pub struct $future_name:ident<$output:ty, $err:ty>,
+    ) => {
+        pin_project_lite::pin_project! {
+            #[allow(clippy::type_complexity)]
+            #[doc = $type_docs]
+            pub struct $future_name {
+                #[pin]
+                inner: aws_smithy_async::future::now_or_later::NowOrLater<
+                    Result<$output, $err>,
+                    aws_smithy_async::future::BoxFuture<$output, $err>
+                >,
+            }
+        }
+
+        impl $future_name {
+            #[doc = concat!("Create a new `", stringify!($future_name), "` with the given future.")]
+            pub fn new<F>(future: F) -> Self
+            where
+                F: std::future::Future<Output = Result<$output, $err>> + Send + 'static,
+            {
+                Self {
+                    inner: aws_smithy_async::future::now_or_later::NowOrLater::new(Box::pin(future)),
+                }
+            }
+
+            #[doc = concat!("
+            Create a new `", stringify!($future_name), "` with the given boxed future.
+
+            Use this if you already have a boxed future to avoid double boxing it.
+            ")]
+            pub fn new_boxed(
+                future: std::pin::Pin<
+                    Box<dyn std::future::Future<Output = Result<$output, $err>> + Send>,
+                >,
+            ) -> Self {
+                Self {
+                    inner: aws_smithy_async::future::now_or_later::NowOrLater::new(future),
+                }
+            }
+
+            #[doc = concat!("Create a `", stringify!($future_name), "` that is immediately ready with the given result.")]
+            pub fn ready(result: Result<$output, $err>) -> Self {
+                Self {
+                    inner: aws_smithy_async::future::now_or_later::NowOrLater::ready(result),
+                }
+            }
+        }
+
+        impl std::future::Future for $future_name {
+            type Output = Result<$output, $err>;
+
+            fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+                let this = self.project();
+                this.inner.poll(cx)
+            }
+        }
+    };
+}
+
 pub mod dns;
 
 pub mod endpoint;

--- a/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
@@ -5,13 +5,18 @@
 
 //! APIs needed to configure endpoint resolution for clients.
 
-use crate::client::orchestrator::Future;
+use crate::box_error::BoxError;
 use crate::impl_shared_conversions;
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use aws_smithy_types::endpoint::Endpoint;
 use aws_smithy_types::type_erasure::TypeErasedBox;
 use std::fmt;
 use std::sync::Arc;
+
+new_type_future! {
+    doc = "Future for [`EndpointResolver::resolve_endpoint`].",
+    pub struct EndpointFuture<Endpoint, BoxError>,
+}
 
 /// Parameters originating from the Smithy endpoint ruleset required for endpoint resolution.
 ///
@@ -40,7 +45,7 @@ impl Storable for EndpointResolverParams {
 /// Configurable endpoint resolver implementation.
 pub trait EndpointResolver: Send + Sync + fmt::Debug {
     /// Asynchronously resolves an endpoint to use from the given endpoint parameters.
-    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> Future<Endpoint>;
+    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> EndpointFuture;
 }
 
 /// Shared endpoint resolver.
@@ -57,7 +62,7 @@ impl SharedEndpointResolver {
 }
 
 impl EndpointResolver for SharedEndpointResolver {
-    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> Future<Endpoint> {
+    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> EndpointFuture {
         self.0.resolve_endpoint(params)
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
@@ -5,8 +5,7 @@
 
 //! Identity types for HTTP auth
 
-use crate::client::identity::{Identity, IdentityResolver};
-use crate::client::orchestrator::Future;
+use crate::client::identity::{Identity, IdentityFuture, IdentityResolver};
 use aws_smithy_types::config_bag::ConfigBag;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -65,8 +64,8 @@ impl From<String> for Token {
 }
 
 impl IdentityResolver for Token {
-    fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
-        Future::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
+    fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
+        IdentityFuture::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
 }
 
@@ -124,7 +123,7 @@ impl Login {
 }
 
 impl IdentityResolver for Login {
-    fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
-        Future::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
+    fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
+        IdentityFuture::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
@@ -20,7 +20,6 @@ use crate::box_error::BoxError;
 use crate::client::interceptors::context::phase::Phase;
 use crate::client::interceptors::context::Error;
 use crate::client::interceptors::InterceptorError;
-use aws_smithy_async::future::now_or_later::NowOrLater;
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_http::result::{ConnectorError, SdkError};
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
@@ -33,18 +32,6 @@ pub type HttpRequest = http::Request<SdkBody>;
 
 /// Type alias for the HTTP response type that the orchestrator uses.
 pub type HttpResponse = http::Response<SdkBody>;
-
-/// Type alias for boxed futures that are returned from several traits since async trait functions are not stable yet (as of 2023-07-21).
-///
-/// See [the Rust blog](https://blog.rust-lang.org/inside-rust/2023/05/03/stabilizing-async-fn-in-trait.html) for
-/// more information on async functions in traits.
-pub type BoxFuture<T> = aws_smithy_async::future::BoxFuture<T, BoxError>;
-
-/// Type alias for futures that are returned from several traits since async trait functions are not stable yet (as of 2023-07-21).
-///
-/// See [the Rust blog](https://blog.rust-lang.org/inside-rust/2023/05/03/stabilizing-async-fn-in-trait.html) for
-/// more information on async functions in traits.
-pub type Future<T> = NowOrLater<Result<T, BoxError>, BoxFuture<T>>;
 
 /// Informs the orchestrator on whether or not the request body needs to be loaded into memory before transmit.
 ///

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -548,11 +548,9 @@ impl RuntimeComponentsBuilder {
     /// Creates a runtime components builder with all the required components filled in with fake (panicking) implementations.
     #[cfg(feature = "test-util")]
     pub fn for_tests() -> Self {
-        use crate::client::endpoint::EndpointResolverParams;
-        use crate::client::identity::Identity;
-        use crate::client::orchestrator::Future;
+        use crate::client::endpoint::{EndpointFuture, EndpointResolverParams};
+        use crate::client::identity::IdentityFuture;
         use aws_smithy_types::config_bag::ConfigBag;
-        use aws_smithy_types::endpoint::Endpoint;
 
         #[derive(Debug)]
         struct FakeAuthSchemeOptionResolver;
@@ -581,7 +579,7 @@ impl RuntimeComponentsBuilder {
         #[derive(Debug)]
         struct FakeEndpointResolver;
         impl EndpointResolver for FakeEndpointResolver {
-            fn resolve_endpoint(&self, _: &EndpointResolverParams) -> Future<Endpoint> {
+            fn resolve_endpoint(&self, _: &EndpointResolverParams) -> EndpointFuture {
                 unreachable!("fake endpoint resolver must be overridden for this test")
             }
         }
@@ -608,7 +606,7 @@ impl RuntimeComponentsBuilder {
         #[derive(Debug)]
         struct FakeIdentityResolver;
         impl IdentityResolver for FakeIdentityResolver {
-            fn resolve_identity(&self, _: &ConfigBag) -> Future<Identity> {
+            fn resolve_identity(&self, _: &ConfigBag) -> IdentityFuture {
                 unreachable!("fake identity resolver must be overridden for this test")
             }
         }

--- a/rust-runtime/aws-smithy-runtime/src/client/identity/no_auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/identity/no_auth.rs
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_smithy_runtime_api::client::identity::{Identity, IdentityResolver};
-use aws_smithy_runtime_api::client::orchestrator::Future;
+use aws_smithy_runtime_api::client::identity::{Identity, IdentityFuture, IdentityResolver};
 use aws_smithy_types::config_bag::ConfigBag;
 
 /// Identity for the [`NoAuthScheme`](crate::client::auth::no_auth::NoAuthScheme) auth scheme.
@@ -30,7 +29,7 @@ impl NoAuthIdentityResolver {
 }
 
 impl IdentityResolver for NoAuthIdentityResolver {
-    fn resolve_identity(&self, _: &ConfigBag) -> Future<Identity> {
-        Future::ready(Ok(Identity::new(NoAuthIdentity::new(), None)))
+    fn resolve_identity(&self, _: &ConfigBag) -> IdentityFuture {
+        IdentityFuture::ready(Ok(Identity::new(NoAuthIdentity::new(), None)))
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -145,10 +145,10 @@ mod tests {
         SharedAuthSchemeOptionResolver, Signer,
     };
     use aws_smithy_runtime_api::client::identity::{
-        Identity, IdentityResolver, SharedIdentityResolver,
+        Identity, IdentityFuture, IdentityResolver, SharedIdentityResolver,
     };
     use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
-    use aws_smithy_runtime_api::client::orchestrator::{Future, HttpRequest};
+    use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
     use aws_smithy_runtime_api::client::runtime_components::{
         GetIdentityResolver, RuntimeComponentsBuilder,
     };
@@ -160,8 +160,8 @@ mod tests {
         #[derive(Debug)]
         struct TestIdentityResolver;
         impl IdentityResolver for TestIdentityResolver {
-            fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
-                Future::ready(Ok(Identity::new("doesntmatter", None)))
+            fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
+                IdentityFuture::ready(Ok(Identity::new("doesntmatter", None)))
             }
         }
 


### PR DESCRIPTION
This PR replaces the `Future` type-alias that was pointing to `NowOrLater` with a new-type for each trait that returns a future.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
