### PR TITLE
Add lifetimes to async traits that take args by reference

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -335,3 +335,15 @@ message = "The future return types on traits `EndpointResolver` and `IdentityRes
 references = ["smithy-rs#3055"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Lifetimes have been added to `EndpointResolver` and `IdentityResolver` traits."
+references = ["smithy-rs#3061"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "jdisanti"
+
+[[smithy-rs]]
+message = "Lifetimes have been added to the `EndpointResolver` trait."
+references = ["smithy-rs#3061"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-config/external-types.toml
+++ b/aws/rust-runtime/aws-config/external-types.toml
@@ -16,7 +16,7 @@ allowed_external_types = [
    "aws_smithy_http::endpoint",
    "aws_smithy_http::endpoint::error::InvalidEndpointError",
    "aws_smithy_http::result::SdkError",
-   "aws_smithy_runtime_api::client::dns::DnsResolver",
+   "aws_smithy_runtime_api::client::dns::ResolveDns",
    "aws_smithy_runtime_api::client::dns::SharedDnsResolver",
    "aws_smithy_runtime_api::client::http::HttpClient",
    "aws_smithy_runtime_api::client::http::SharedHttpClient",

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -752,10 +752,7 @@ mod test {
     }
 
     impl ResolveDns for TestDns {
-        fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>
-        where
-            Self: 'a,
-        {
+        fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a> {
             DnsFuture::ready(Ok(self.addrs.get(name).unwrap_or(&self.fallback).clone()))
         }
     }
@@ -763,10 +760,7 @@ mod test {
     #[derive(Debug)]
     struct NeverDns;
     impl ResolveDns for NeverDns {
-        fn resolve_dns<'a>(&'a self, _name: &'a str) -> DnsFuture<'a>
-        where
-            Self: 'a,
-        {
+        fn resolve_dns<'a>(&'a self, _name: &'a str) -> DnsFuture<'a> {
             DnsFuture::new(async {
                 Never::new().await;
                 unreachable!()

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -50,7 +50,7 @@ use crate::http_credential_provider::HttpCredentialProvider;
 use crate::provider_config::ProviderConfig;
 use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
 use aws_smithy_http::endpoint::apply_endpoint;
-use aws_smithy_runtime_api::client::dns::{DnsResolver, ResolveDnsError, SharedDnsResolver};
+use aws_smithy_runtime_api::client::dns::{ResolveDns, ResolveDnsError, SharedDnsResolver};
 use aws_smithy_runtime_api::client::http::HttpConnectorSettings;
 use aws_smithy_runtime_api::shared::IntoShared;
 use aws_smithy_types::error::display::DisplayErrorContext;
@@ -272,9 +272,9 @@ impl Builder {
 
     /// Override the DNS resolver used to validate URIs
     ///
-    /// URIs must refer to loopback addresses. The [`DnsResolver`](aws_smithy_runtime_api::client::dns::DnsResolver)
-    /// is used to retrieve IP addresses for a given domain.
-    pub fn dns(mut self, dns: impl DnsResolver + 'static) -> Self {
+    /// URIs must refer to loopback addresses. The [`ResolveDns`](aws_smithy_runtime_api::client::dns::ResolveDns)
+    /// implementation is used to retrieve IP addresses for a given domain.
+    pub fn dns(mut self, dns: impl ResolveDns + 'static) -> Self {
         self.dns = Some(dns.into_shared());
         self
     }
@@ -399,7 +399,7 @@ async fn validate_full_uri(
         Ok(addr) => addr.is_loopback(),
         Err(_domain_name) => {
             let dns = dns.ok_or(InvalidFullUriErrorKind::NoDnsResolver)?;
-            dns.resolve_dns(host.to_owned())
+            dns.resolve_dns(host)
                 .await
                 .map_err(|err| InvalidFullUriErrorKind::DnsLookupFailed(ResolveDnsError::new(err)))?
                 .iter()
@@ -751,16 +751,22 @@ mod test {
         }
     }
 
-    impl DnsResolver for TestDns {
-        fn resolve_dns(&self, name: String) -> DnsFuture {
-            DnsFuture::ready(Ok(self.addrs.get(&name).unwrap_or(&self.fallback).clone()))
+    impl ResolveDns for TestDns {
+        fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>
+        where
+            Self: 'a,
+        {
+            DnsFuture::ready(Ok(self.addrs.get(name).unwrap_or(&self.fallback).clone()))
         }
     }
 
     #[derive(Debug)]
     struct NeverDns;
-    impl DnsResolver for NeverDns {
-        fn resolve_dns(&self, _name: String) -> DnsFuture {
+    impl ResolveDns for NeverDns {
+        fn resolve_dns<'a>(&'a self, _name: &'a str) -> DnsFuture<'a>
+        where
+            Self: 'a,
+        {
             DnsFuture::new(async {
                 Never::new().await;
                 unreachable!()

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -524,10 +524,7 @@ struct ImdsEndpointResolver {
 }
 
 impl EndpointResolver for ImdsEndpointResolver {
-    fn resolve_endpoint<'a>(&'a self, _: &'a EndpointResolverParams) -> EndpointFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_endpoint<'a>(&'a self, _: &'a EndpointResolverParams) -> EndpointFuture<'a> {
         EndpointFuture::new(async move {
             self.endpoint_source
                 .endpoint(self.mode_override.clone())

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -524,11 +524,13 @@ struct ImdsEndpointResolver {
 }
 
 impl EndpointResolver for ImdsEndpointResolver {
-    fn resolve_endpoint(&self, _: &EndpointResolverParams) -> EndpointFuture {
-        let this = self.clone();
+    fn resolve_endpoint<'a>(&'a self, _: &'a EndpointResolverParams) -> EndpointFuture<'a>
+    where
+        Self: 'a,
+    {
         EndpointFuture::new(async move {
-            this.endpoint_source
-                .endpoint(this.mode_override)
+            self.endpoint_source
+                .endpoint(self.mode_override.clone())
                 .await
                 .map(|uri| Endpoint::builder().url(uri.to_string()).build())
                 .map_err(|err| err.into())

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -192,10 +192,7 @@ fn parse_token_response(response: &HttpResponse, now: SystemTime) -> Result<Toke
 }
 
 impl IdentityResolver for TokenResolver {
-    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a> {
         IdentityFuture::new(async {
             let preloaded_token = self
                 .inner

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -192,23 +192,22 @@ fn parse_token_response(response: &HttpResponse, now: SystemTime) -> Result<Toke
 }
 
 impl IdentityResolver for TokenResolver {
-    fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
-        let this = self.clone();
-        IdentityFuture::new(async move {
-            let preloaded_token = this
+    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
+    where
+        Self: 'a,
+    {
+        IdentityFuture::new(async {
+            let preloaded_token = self
                 .inner
                 .cache
-                .yield_or_clear_if_expired(this.inner.time_source.now())
+                .yield_or_clear_if_expired(self.inner.time_source.now())
                 .await;
             let token = match preloaded_token {
                 Some(token) => Ok(token),
                 None => {
-                    this.inner
+                    self.inner
                         .cache
-                        .get_or_load(|| {
-                            let this = this.clone();
-                            async move { this.get_token().await }
-                        })
+                        .get_or_load(|| async { self.get_token().await })
                         .await
                 }
             }?;

--- a/aws/rust-runtime/aws-inlineable/src/endpoint_discovery.rs
+++ b/aws/rust-runtime/aws-inlineable/src/endpoint_discovery.rs
@@ -20,7 +20,9 @@ use tokio::sync::oneshot::{Receiver, Sender};
 /// Endpoint reloader
 #[must_use]
 pub struct ReloadEndpoint {
-    loader: Box<dyn Fn() -> BoxFuture<(Endpoint, SystemTime), ResolveEndpointError> + Send + Sync>,
+    loader: Box<
+        dyn Fn() -> BoxFuture<'static, (Endpoint, SystemTime), ResolveEndpointError> + Send + Sync,
+    >,
     endpoint: Arc<Mutex<Option<ExpiringEndpoint>>>,
     error: Arc<Mutex<Option<ResolveEndpointError>>>,
     rx: Receiver<()>,

--- a/aws/rust-runtime/aws-runtime/src/identity.rs
+++ b/aws/rust-runtime/aws-runtime/src/identity.rs
@@ -23,10 +23,7 @@ pub mod credentials {
     }
 
     impl IdentityResolver for CredentialsIdentityResolver {
-        fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
-        where
-            Self: 'a,
-        {
+        fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a> {
             let cache = self.credentials_cache.clone();
             IdentityFuture::new(async move {
                 let credentials = cache.as_ref().provide_cached_credentials().await?;

--- a/aws/rust-runtime/aws-runtime/src/identity.rs
+++ b/aws/rust-runtime/aws-runtime/src/identity.rs
@@ -23,7 +23,10 @@ pub mod credentials {
     }
 
     impl IdentityResolver for CredentialsIdentityResolver {
-        fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
+        fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
+        where
+            Self: 'a,
+        {
             let cache = self.credentials_cache.clone();
             IdentityFuture::new(async move {
                 let credentials = cache.as_ref().provide_cached_credentials().await?;

--- a/rust-runtime/aws-smithy-async/src/future/mod.rs
+++ b/rust-runtime/aws-smithy-async/src/future/mod.rs
@@ -15,4 +15,4 @@ pub mod rendezvous;
 pub mod timeout;
 
 /// A boxed future that outputs a `Result<T, E>`.
-pub type BoxFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send>>;
+pub type BoxFuture<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>;

--- a/rust-runtime/aws-smithy-runtime-api/src/client/dns.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/dns.rs
@@ -47,9 +47,7 @@ new_type_future! {
 /// Trait for resolving domain names
 pub trait ResolveDns: fmt::Debug + Send + Sync {
     /// Asynchronously resolve the given domain name
-    fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>
-    where
-        Self: 'a;
+    fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>;
 }
 
 /// Shared instance of [`ResolveDns`].
@@ -64,10 +62,7 @@ impl SharedDnsResolver {
 }
 
 impl ResolveDns for SharedDnsResolver {
-    fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a> {
         self.0.resolve_dns(name)
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/dns.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/dns.rs
@@ -7,14 +7,10 @@
 
 use crate::box_error::BoxError;
 use crate::impl_shared_conversions;
-use aws_smithy_async::future::now_or_later::NowOrLater;
 use std::error::Error as StdError;
 use std::fmt;
-use std::future::Future;
 use std::net::IpAddr;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 /// Error that occurs when failing to perform a DNS lookup.
 #[derive(Debug)]
@@ -43,57 +39,40 @@ impl StdError for ResolveDnsError {
     }
 }
 
-type BoxFuture<T> = aws_smithy_async::future::BoxFuture<T, ResolveDnsError>;
-
-/// New-type for the future returned by the [`DnsResolver`] trait.
-pub struct DnsFuture(NowOrLater<Result<Vec<IpAddr>, ResolveDnsError>, BoxFuture<Vec<IpAddr>>>);
-impl DnsFuture {
-    /// Create a new `DnsFuture`
-    pub fn new(
-        future: impl Future<Output = Result<Vec<IpAddr>, ResolveDnsError>> + Send + 'static,
-    ) -> Self {
-        Self(NowOrLater::new(Box::pin(future)))
-    }
-
-    /// Create a `DnsFuture` that is immediately ready
-    pub fn ready(result: Result<Vec<IpAddr>, ResolveDnsError>) -> Self {
-        Self(NowOrLater::ready(result))
-    }
-}
-impl Future for DnsFuture {
-    type Output = Result<Vec<IpAddr>, ResolveDnsError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.as_mut();
-        let inner = Pin::new(&mut this.0);
-        Future::poll(inner, cx)
-    }
+new_type_future! {
+    #[doc = "New-type for the future returned by the [`ResolveDns`] trait."]
+    pub struct DnsFuture<'a, Vec<IpAddr>, ResolveDnsError>;
 }
 
 /// Trait for resolving domain names
-pub trait DnsResolver: fmt::Debug + Send + Sync {
+pub trait ResolveDns: fmt::Debug + Send + Sync {
     /// Asynchronously resolve the given domain name
-    fn resolve_dns(&self, name: String) -> DnsFuture;
+    fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>
+    where
+        Self: 'a;
 }
 
-/// Shared DNS resolver
+/// Shared instance of [`ResolveDns`].
 #[derive(Clone, Debug)]
-pub struct SharedDnsResolver(Arc<dyn DnsResolver>);
+pub struct SharedDnsResolver(Arc<dyn ResolveDns>);
 
 impl SharedDnsResolver {
     /// Create a new `SharedDnsResolver`.
-    pub fn new(resolver: impl DnsResolver + 'static) -> Self {
+    pub fn new(resolver: impl ResolveDns + 'static) -> Self {
         Self(Arc::new(resolver))
     }
 }
 
-impl DnsResolver for SharedDnsResolver {
-    fn resolve_dns(&self, name: String) -> DnsFuture {
+impl ResolveDns for SharedDnsResolver {
+    fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>
+    where
+        Self: 'a,
+    {
         self.0.resolve_dns(name)
     }
 }
 
-impl_shared_conversions!(convert SharedDnsResolver from DnsResolver using SharedDnsResolver::new);
+impl_shared_conversions!(convert SharedDnsResolver from ResolveDns using SharedDnsResolver::new);
 
 #[cfg(test)]
 mod tests {
@@ -102,6 +81,6 @@ mod tests {
     #[test]
     fn check_send() {
         fn is_send<T: Send>() {}
-        is_send::<DnsFuture>();
+        is_send::<DnsFuture<'_>>();
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
@@ -45,9 +45,7 @@ impl Storable for EndpointResolverParams {
 /// Configurable endpoint resolver implementation.
 pub trait EndpointResolver: Send + Sync + fmt::Debug {
     /// Asynchronously resolves an endpoint to use from the given endpoint parameters.
-    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a>
-    where
-        Self: 'a;
+    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a>;
 }
 
 /// Shared endpoint resolver.
@@ -64,10 +62,7 @@ impl SharedEndpointResolver {
 }
 
 impl EndpointResolver for SharedEndpointResolver {
-    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a> {
         self.0.resolve_endpoint(params)
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
@@ -14,8 +14,8 @@ use std::fmt;
 use std::sync::Arc;
 
 new_type_future! {
-    doc = "Future for [`EndpointResolver::resolve_endpoint`].",
-    pub struct EndpointFuture<Endpoint, BoxError>,
+    #[doc = "Future for [`EndpointResolver::resolve_endpoint`]."]
+    pub struct EndpointFuture<'a, Endpoint, BoxError>;
 }
 
 /// Parameters originating from the Smithy endpoint ruleset required for endpoint resolution.
@@ -45,7 +45,9 @@ impl Storable for EndpointResolverParams {
 /// Configurable endpoint resolver implementation.
 pub trait EndpointResolver: Send + Sync + fmt::Debug {
     /// Asynchronously resolves an endpoint to use from the given endpoint parameters.
-    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> EndpointFuture;
+    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a>
+    where
+        Self: 'a;
 }
 
 /// Shared endpoint resolver.
@@ -62,7 +64,10 @@ impl SharedEndpointResolver {
 }
 
 impl EndpointResolver for SharedEndpointResolver {
-    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> EndpointFuture {
+    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a>
+    where
+        Self: 'a,
+    {
         self.0.resolve_endpoint(params)
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/http.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/http.rs
@@ -62,8 +62,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 new_type_future! {
-    doc = "Future for [`HttpConnector::call`].",
-    pub struct HttpConnectorFuture<HttpResponse, ConnectorError>,
+    #[doc = "Future for [`HttpConnector::call`]."]
+    pub struct HttpConnectorFuture<'static, HttpResponse, ConnectorError>;
 }
 
 /// Trait with a `call` function that asynchronously converts a request into a response.

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
@@ -17,8 +17,8 @@ use std::time::SystemTime;
 pub mod http;
 
 new_type_future! {
-    doc = "Future for [`IdentityResolver::resolve_identity`].",
-    pub struct IdentityFuture<Identity, BoxError>,
+    #[doc = "Future for [`IdentityResolver::resolve_identity`]."]
+    pub struct IdentityFuture<'a, Identity, BoxError>;
 }
 
 /// Resolver for identities.
@@ -34,7 +34,9 @@ new_type_future! {
 /// There is no fallback to other auth schemes in the absence of an identity.
 pub trait IdentityResolver: Send + Sync + Debug {
     /// Asynchronously resolves an identity for a request using the given config.
-    fn resolve_identity(&self, config_bag: &ConfigBag) -> IdentityFuture;
+    fn resolve_identity<'a>(&'a self, config_bag: &'a ConfigBag) -> IdentityFuture<'a>
+    where
+        Self: 'a;
 }
 
 /// Container for a shared identity resolver.
@@ -49,7 +51,10 @@ impl SharedIdentityResolver {
 }
 
 impl IdentityResolver for SharedIdentityResolver {
-    fn resolve_identity(&self, config_bag: &ConfigBag) -> IdentityFuture {
+    fn resolve_identity<'a>(&'a self, config_bag: &'a ConfigBag) -> IdentityFuture<'a>
+    where
+        Self: 'a,
+    {
         self.0.resolve_identity(config_bag)
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
@@ -34,9 +34,7 @@ new_type_future! {
 /// There is no fallback to other auth schemes in the absence of an identity.
 pub trait IdentityResolver: Send + Sync + Debug {
     /// Asynchronously resolves an identity for a request using the given config.
-    fn resolve_identity<'a>(&'a self, config_bag: &'a ConfigBag) -> IdentityFuture<'a>
-    where
-        Self: 'a;
+    fn resolve_identity<'a>(&'a self, config_bag: &'a ConfigBag) -> IdentityFuture<'a>;
 }
 
 /// Container for a shared identity resolver.
@@ -51,10 +49,7 @@ impl SharedIdentityResolver {
 }
 
 impl IdentityResolver for SharedIdentityResolver {
-    fn resolve_identity<'a>(&'a self, config_bag: &'a ConfigBag) -> IdentityFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_identity<'a>(&'a self, config_bag: &'a ConfigBag) -> IdentityFuture<'a> {
         self.0.resolve_identity(config_bag)
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
@@ -64,7 +64,10 @@ impl From<String> for Token {
 }
 
 impl IdentityResolver for Token {
-    fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
+    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
+    where
+        Self: 'a,
+    {
         IdentityFuture::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
 }
@@ -123,7 +126,10 @@ impl Login {
 }
 
 impl IdentityResolver for Login {
-    fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
+    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
+    where
+        Self: 'a,
+    {
         IdentityFuture::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
@@ -64,10 +64,7 @@ impl From<String> for Token {
 }
 
 impl IdentityResolver for Token {
-    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a> {
         IdentityFuture::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
 }
@@ -126,10 +123,7 @@ impl Login {
 }
 
 impl IdentityResolver for Login {
-    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a> {
         IdentityFuture::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -579,7 +579,10 @@ impl RuntimeComponentsBuilder {
         #[derive(Debug)]
         struct FakeEndpointResolver;
         impl EndpointResolver for FakeEndpointResolver {
-            fn resolve_endpoint(&self, _: &EndpointResolverParams) -> EndpointFuture {
+            fn resolve_endpoint<'a>(&'a self, _: &'a EndpointResolverParams) -> EndpointFuture<'a>
+            where
+                Self: 'a,
+            {
                 unreachable!("fake endpoint resolver must be overridden for this test")
             }
         }
@@ -606,7 +609,10 @@ impl RuntimeComponentsBuilder {
         #[derive(Debug)]
         struct FakeIdentityResolver;
         impl IdentityResolver for FakeIdentityResolver {
-            fn resolve_identity(&self, _: &ConfigBag) -> IdentityFuture {
+            fn resolve_identity<'a>(&'a self, _: &'a ConfigBag) -> IdentityFuture<'a>
+            where
+                Self: 'a,
+            {
                 unreachable!("fake identity resolver must be overridden for this test")
             }
         }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -579,10 +579,7 @@ impl RuntimeComponentsBuilder {
         #[derive(Debug)]
         struct FakeEndpointResolver;
         impl EndpointResolver for FakeEndpointResolver {
-            fn resolve_endpoint<'a>(&'a self, _: &'a EndpointResolverParams) -> EndpointFuture<'a>
-            where
-                Self: 'a,
-            {
+            fn resolve_endpoint<'a>(&'a self, _: &'a EndpointResolverParams) -> EndpointFuture<'a> {
                 unreachable!("fake endpoint resolver must be overridden for this test")
             }
         }
@@ -609,10 +606,7 @@ impl RuntimeComponentsBuilder {
         #[derive(Debug)]
         struct FakeIdentityResolver;
         impl IdentityResolver for FakeIdentityResolver {
-            fn resolve_identity<'a>(&'a self, _: &'a ConfigBag) -> IdentityFuture<'a>
-            where
-                Self: 'a,
-            {
+            fn resolve_identity<'a>(&'a self, _: &'a ConfigBag) -> IdentityFuture<'a> {
                 unreachable!("fake identity resolver must be overridden for this test")
             }
         }

--- a/rust-runtime/aws-smithy-runtime/src/client/dns.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/dns.rs
@@ -7,7 +7,7 @@
 
 #[cfg(all(feature = "rt-tokio", not(target_family = "wasm")))]
 mod tokio {
-    use aws_smithy_runtime_api::client::dns::{DnsFuture, DnsResolver, ResolveDnsError};
+    use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns, ResolveDnsError};
     use std::io::{Error as IoError, ErrorKind as IoErrorKind};
     use std::net::ToSocketAddrs;
 
@@ -25,8 +25,12 @@ mod tokio {
         }
     }
 
-    impl DnsResolver for TokioDnsResolver {
-        fn resolve_dns(&self, name: String) -> DnsFuture {
+    impl ResolveDns for TokioDnsResolver {
+        fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>
+        where
+            Self: 'a,
+        {
+            let name = name.to_string();
             DnsFuture::new(async move {
                 let result = tokio::task::spawn_blocking(move || (name, 0).to_socket_addrs()).await;
                 match result {

--- a/rust-runtime/aws-smithy-runtime/src/client/dns.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/dns.rs
@@ -26,10 +26,7 @@ mod tokio {
     }
 
     impl ResolveDns for TokioDnsResolver {
-        fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a>
-        where
-            Self: 'a,
-        {
+        fn resolve_dns<'a>(&'a self, name: &'a str) -> DnsFuture<'a> {
             let name = name.to_string();
             DnsFuture::new(async move {
                 let result = tokio::task::spawn_blocking(move || (name, 0).to_socket_addrs()).await;

--- a/rust-runtime/aws-smithy-runtime/src/client/http/test_util/wire.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/test_util/wire.rs
@@ -333,7 +333,7 @@ pub struct LoggingDnsResolver {
 impl Service<Name> for LoggingDnsResolver {
     type Response = Once<SocketAddr>;
     type Error = Infallible;
-    type Future = BoxFuture<Self::Response, Self::Error>;
+    type Future = BoxFuture<'static, Self::Response, Self::Error>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))

--- a/rust-runtime/aws-smithy-runtime/src/client/identity/no_auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/identity/no_auth.rs
@@ -29,10 +29,7 @@ impl NoAuthIdentityResolver {
 }
 
 impl IdentityResolver for NoAuthIdentityResolver {
-    fn resolve_identity<'a>(&'a self, _: &'a ConfigBag) -> IdentityFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_identity<'a>(&'a self, _: &'a ConfigBag) -> IdentityFuture<'a> {
         IdentityFuture::ready(Ok(Identity::new(NoAuthIdentity::new(), None)))
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/identity/no_auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/identity/no_auth.rs
@@ -29,7 +29,10 @@ impl NoAuthIdentityResolver {
 }
 
 impl IdentityResolver for NoAuthIdentityResolver {
-    fn resolve_identity(&self, _: &ConfigBag) -> IdentityFuture {
+    fn resolve_identity<'a>(&'a self, _: &'a ConfigBag) -> IdentityFuture<'a>
+    where
+        Self: 'a,
+    {
         IdentityFuture::ready(Ok(Identity::new(NoAuthIdentity::new(), None)))
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -160,7 +160,10 @@ mod tests {
         #[derive(Debug)]
         struct TestIdentityResolver;
         impl IdentityResolver for TestIdentityResolver {
-            fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
+            fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
+            where
+                Self: 'a,
+            {
                 IdentityFuture::ready(Ok(Identity::new("doesntmatter", None)))
             }
         }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -160,10 +160,7 @@ mod tests {
         #[derive(Debug)]
         struct TestIdentityResolver;
         impl IdentityResolver for TestIdentityResolver {
-            fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a>
-            where
-                Self: 'a,
-            {
+            fn resolve_identity<'a>(&'a self, _config_bag: &'a ConfigBag) -> IdentityFuture<'a> {
                 IdentityFuture::ready(Ok(Identity::new("doesntmatter", None)))
             }
         }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -46,10 +46,7 @@ impl StaticUriEndpointResolver {
 }
 
 impl EndpointResolver for StaticUriEndpointResolver {
-    fn resolve_endpoint<'a>(&'a self, _params: &'a EndpointResolverParams) -> EndpointFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_endpoint<'a>(&'a self, _params: &'a EndpointResolverParams) -> EndpointFuture<'a> {
         EndpointFuture::ready(Ok(Endpoint::builder()
             .url(self.endpoint.to_string())
             .build()))
@@ -104,10 +101,7 @@ impl<Params> EndpointResolver for DefaultEndpointResolver<Params>
 where
     Params: Debug + Send + Sync + 'static,
 {
-    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a>
-    where
-        Self: 'a,
-    {
+    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a> {
         let ep = match params.get::<Params>() {
             Some(params) => self.inner.resolve_endpoint(params).map_err(Box::new),
             None => Err(Box::new(ResolveEndpointError::message(

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -46,7 +46,10 @@ impl StaticUriEndpointResolver {
 }
 
 impl EndpointResolver for StaticUriEndpointResolver {
-    fn resolve_endpoint(&self, _params: &EndpointResolverParams) -> EndpointFuture {
+    fn resolve_endpoint<'a>(&'a self, _params: &'a EndpointResolverParams) -> EndpointFuture<'a>
+    where
+        Self: 'a,
+    {
         EndpointFuture::ready(Ok(Endpoint::builder()
             .url(self.endpoint.to_string())
             .build()))
@@ -101,7 +104,10 @@ impl<Params> EndpointResolver for DefaultEndpointResolver<Params>
 where
     Params: Debug + Send + Sync + 'static,
 {
-    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> EndpointFuture {
+    fn resolve_endpoint<'a>(&'a self, params: &'a EndpointResolverParams) -> EndpointFuture<'a>
+    where
+        Self: 'a,
+    {
         let ep = match params.get::<Params>() {
             Some(params) => self.inner.resolve_endpoint(params).map_err(Box::new),
             None => Err(Box::new(ResolveEndpointError::message(


### PR DESCRIPTION
This PR adds lifetimes to the `IdentityResolver`, `DnsResolver` (renamed to `ResolveDns`), and `EndpointResolver` traits so that lifetime gymnastics aren't needed when implementing those traits. For example, `IdentityResolver::resolve_identity` takes `&ConfigBag` as an argument, which means you have to pull things out of the ConfigBag outside of any returned async block in order for the compiler to be satisfied. This change removes that consideration and makes implementing these traits a lot easier.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
