### PR TITLE
Rename orchestrator traits to be verbs

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -327,11 +327,34 @@ author = "Velfi"
 [[aws-sdk-rust]]
 message = "The future return types on traits `EndpointResolver` and `IdentityResolver` changed to new-types `EndpointFuture` and `IdentityFuture` respectively."
 references = ["smithy-rs#3055"]
-meta = { "breaking" = true, "tada" = true, "bug" = true }
+meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "jdisanti"
 
 [[smithy-rs]]
 message = "The future return types on traits `EndpointResolver` and `IdentityResolver` changed to new-types `EndpointFuture` and `IdentityFuture` respectively."
 references = ["smithy-rs#3055"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = """Several traits have been renamed from noun form to verb form to be more idiomatic:
+- `EndpointResolver` -> `ResolveEndpoint`
+- `Interceptor` -> `Intercept`
+"""
+references = ["smithy-rs#3065"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "jdisanti"
+
+[[smithy-rs]]
+message = """Several traits have been renamed from noun form to verb form to be more idiomatic:
+- `AuthSchemeOptionResolver` -> `ResolveAuthSchemeOptions`
+- `EndpointResolver` -> `ResolveEndpoint`
+- `IdentityResolver` -> `ResolveIdentity`
+- `Signer` -> `Sign`
+- `RequestSerializer` -> `SerializeRequest`
+- `ResponseDeserializer` -> `DeserializeResponse`
+- `Interceptor` -> `Intercept`
+"""
+references = ["smithy-rs#3065"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -272,7 +272,7 @@ impl Builder {
 
     /// Override the DNS resolver used to validate URIs
     ///
-    /// URIs must refer to loopback addresses. The [`DnsResolver`](aws_smithy_runtime_api::client::dns::DnsResolver)
+    /// URIs must refer to loopback addresses. The [`ResolveDns`](aws_smithy_runtime_api::client::dns::ResolveDns)
     /// is used to retrieve IP addresses for a given domain.
     pub fn dns(mut self, dns: impl ResolveDns + 'static) -> Self {
         self.dns = Some(dns.into_shared());

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -50,7 +50,7 @@ use crate::http_credential_provider::HttpCredentialProvider;
 use crate::provider_config::ProviderConfig;
 use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
 use aws_smithy_http::endpoint::apply_endpoint;
-use aws_smithy_runtime_api::client::dns::{DnsResolver, ResolveDnsError, SharedDnsResolver};
+use aws_smithy_runtime_api::client::dns::{ResolveDns, ResolveDnsError, SharedDnsResolver};
 use aws_smithy_runtime_api::client::http::HttpConnectorSettings;
 use aws_smithy_runtime_api::shared::IntoShared;
 use aws_smithy_types::error::display::DisplayErrorContext;
@@ -274,7 +274,7 @@ impl Builder {
     ///
     /// URIs must refer to loopback addresses. The [`DnsResolver`](aws_smithy_runtime_api::client::dns::DnsResolver)
     /// is used to retrieve IP addresses for a given domain.
-    pub fn dns(mut self, dns: impl DnsResolver + 'static) -> Self {
+    pub fn dns(mut self, dns: impl ResolveDns + 'static) -> Self {
         self.dns = Some(dns.into_shared());
         self
     }
@@ -751,7 +751,7 @@ mod test {
         }
     }
 
-    impl DnsResolver for TestDns {
+    impl ResolveDns for TestDns {
         fn resolve_dns(&self, name: String) -> DnsFuture {
             DnsFuture::ready(Ok(self.addrs.get(&name).unwrap_or(&self.fallback).clone()))
         }
@@ -759,7 +759,7 @@ mod test {
 
     #[derive(Debug)]
     struct NeverDns;
-    impl DnsResolver for NeverDns {
+    impl ResolveDns for NeverDns {
         fn resolve_dns(&self, _name: String) -> DnsFuture {
             DnsFuture::new(async {
                 Never::new().await;

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -20,7 +20,7 @@ use aws_smithy_runtime::client::orchestrator::operation::Operation;
 use aws_smithy_runtime::client::retries::strategy::StandardRetryStrategy;
 use aws_smithy_runtime_api::client::auth::AuthSchemeOptionResolverParams;
 use aws_smithy_runtime_api::client::endpoint::{
-    EndpointFuture, EndpointResolver, EndpointResolverParams,
+    EndpointFuture, EndpointResolverParams, ResolveEndpoint,
 };
 use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
 use aws_smithy_runtime_api::client::orchestrator::{OrchestratorError, SensitiveOutput};
@@ -523,7 +523,7 @@ struct ImdsEndpointResolver {
     mode_override: Option<EndpointMode>,
 }
 
-impl EndpointResolver for ImdsEndpointResolver {
+impl ResolveEndpoint for ImdsEndpointResolver {
     fn resolve_endpoint(&self, _: &EndpointResolverParams) -> EndpointFuture {
         let this = self.clone();
         EndpointFuture::new(async move {

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -22,7 +22,7 @@ use aws_smithy_runtime::client::orchestrator::operation::Operation;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::static_resolver::StaticAuthSchemeOptionResolver;
 use aws_smithy_runtime_api::client::auth::{
-    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Signer,
+    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Sign,
 };
 use aws_smithy_runtime_api::client::identity::{
     Identity, IdentityFuture, ResolveIdentity, SharedIdentityResolver,
@@ -244,7 +244,7 @@ impl AuthScheme for TokenAuthScheme {
         identity_resolvers.identity_resolver(IMDS_TOKEN_AUTH_SCHEME)
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         &self.signer
     }
 }
@@ -252,7 +252,7 @@ impl AuthScheme for TokenAuthScheme {
 #[derive(Debug)]
 struct TokenSigner;
 
-impl Signer for TokenSigner {
+impl Sign for TokenSigner {
     fn sign_http_request(
         &self,
         request: &mut HttpRequest,

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -25,7 +25,7 @@ use aws_smithy_runtime_api::client::auth::{
     AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Signer,
 };
 use aws_smithy_runtime_api::client::identity::{
-    Identity, IdentityFuture, IdentityResolver, SharedIdentityResolver,
+    Identity, IdentityFuture, ResolveIdentity, SharedIdentityResolver,
 };
 use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, HttpResponse, OrchestratorError};
 use aws_smithy_runtime_api::client::runtime_components::{
@@ -191,7 +191,7 @@ fn parse_token_response(response: &HttpResponse, now: SystemTime) -> Result<Toke
     })
 }
 
-impl IdentityResolver for TokenResolver {
+impl ResolveIdentity for TokenResolver {
     fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
         let this = self.clone();
         IdentityFuture::new(async move {

--- a/aws/rust-runtime/aws-inlineable/src/apigateway_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/apigateway_interceptors.rs
@@ -7,7 +7,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use http::header::ACCEPT;
@@ -17,7 +17,7 @@ use http::HeaderValue;
 #[derive(Debug, Default)]
 pub(crate) struct AcceptHeaderInterceptor;
 
-impl Interceptor for AcceptHeaderInterceptor {
+impl Intercept for AcceptHeaderInterceptor {
     fn name(&self) -> &'static str {
         "AcceptHeaderInterceptor"
     }

--- a/aws/rust-runtime/aws-inlineable/src/glacier_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/glacier_interceptors.rs
@@ -14,7 +14,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextMut, BeforeTransmitInterceptorContextMut,
 };
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::orchestrator::LoadedRequestBody;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
@@ -65,7 +65,7 @@ impl<I> GlacierAccountIdAutofillInterceptor<I> {
     }
 }
 
-impl<I: GlacierAccountId + Send + Sync + 'static> Interceptor
+impl<I: GlacierAccountId + Send + Sync + 'static> Intercept
     for GlacierAccountIdAutofillInterceptor<I>
 {
     fn name(&self) -> &'static str {
@@ -100,7 +100,7 @@ impl GlacierApiVersionInterceptor {
     }
 }
 
-impl Interceptor for GlacierApiVersionInterceptor {
+impl Intercept for GlacierApiVersionInterceptor {
     fn name(&self) -> &'static str {
         "GlacierApiVersionInterceptor"
     }
@@ -123,7 +123,7 @@ impl Interceptor for GlacierApiVersionInterceptor {
 #[derive(Debug, Default)]
 pub(crate) struct GlacierTreeHashHeaderInterceptor;
 
-impl Interceptor for GlacierTreeHashHeaderInterceptor {
+impl Intercept for GlacierTreeHashHeaderInterceptor {
     fn name(&self) -> &'static str {
         "GlacierTreeHashHeaderInterceptor"
     }

--- a/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_request_checksum.rs
@@ -18,7 +18,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextRef, BeforeTransmitInterceptorContextMut, Input,
 };
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Layer, Storable, StoreReplace};
 use http::HeaderValue;
@@ -75,7 +75,7 @@ impl<AP> RequestChecksumInterceptor<AP> {
     }
 }
 
-impl<AP> Interceptor for RequestChecksumInterceptor<AP>
+impl<AP> Intercept for RequestChecksumInterceptor<AP>
 where
     AP: Fn(&Input) -> Result<Option<ChecksumAlgorithm>, BoxError> + Send + Sync,
 {

--- a/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_response_checksum.rs
@@ -13,7 +13,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeDeserializationInterceptorContextMut, BeforeSerializationInterceptorContextRef, Input,
 };
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Layer, Storable, StoreReplace};
 use http::HeaderValue;
@@ -52,7 +52,7 @@ impl<VE> ResponseChecksumInterceptor<VE> {
     }
 }
 
-impl<VE> Interceptor for ResponseChecksumInterceptor<VE>
+impl<VE> Intercept for ResponseChecksumInterceptor<VE>
 where
     VE: Fn(&Input) -> bool + Send + Sync,
 {

--- a/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
@@ -19,7 +19,7 @@ use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextMut, BeforeTransmitInterceptorContextMut,
 };
 use aws_smithy_runtime_api::client::interceptors::{
-    disable_interceptor, Interceptor, SharedInterceptor,
+    disable_interceptor, Intercept, SharedInterceptor,
 };
 use aws_smithy_runtime_api::client::retries::SharedRetryStrategy;
 use aws_smithy_runtime_api::client::runtime_components::{
@@ -46,7 +46,7 @@ impl SigV4PresigningInterceptor {
     }
 }
 
-impl Interceptor for SigV4PresigningInterceptor {
+impl Intercept for SigV4PresigningInterceptor {
     fn name(&self) -> &'static str {
         "SigV4PresigningInterceptor"
     }

--- a/aws/rust-runtime/aws-inlineable/src/route53_resource_id_preprocessor.rs
+++ b/aws/rust-runtime/aws-inlineable/src/route53_resource_id_preprocessor.rs
@@ -7,7 +7,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use std::fmt;
@@ -67,7 +67,7 @@ where
     }
 }
 
-impl<G, T> Interceptor for Route53ResourceIdInterceptor<G, T>
+impl<G, T> Intercept for Route53ResourceIdInterceptor<G, T>
 where
     G: for<'a> Fn(&'a mut T) -> &'a mut Option<String> + Send + Sync,
     T: fmt::Debug + Send + Sync + 'static,

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -14,7 +14,7 @@ use aws_sigv4::http_request::{
 use aws_sigv4::sign::v4;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::{
-    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Signer,
+    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Sign,
 };
 use aws_smithy_runtime_api::client::identity::{Identity, SharedIdentityResolver};
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
@@ -56,7 +56,7 @@ impl AuthScheme for SigV4AuthScheme {
         identity_resolvers.identity_resolver(self.scheme_id())
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         &self.signer
     }
 }
@@ -142,7 +142,7 @@ impl SigV4Signer {
     }
 }
 
-impl Signer for SigV4Signer {
+impl Sign for SigV4Signer {
     fn sign_http_request(
         &self,
         request: &mut HttpRequest,

--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4a.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4a.rs
@@ -11,7 +11,7 @@ use aws_sigv4::http_request::{sign, SignableBody, SignableRequest, SigningSettin
 use aws_sigv4::sign::v4a;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::{
-    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Signer,
+    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Sign,
 };
 use aws_smithy_runtime_api::client::identity::{Identity, SharedIdentityResolver};
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
@@ -53,7 +53,7 @@ impl AuthScheme for SigV4aAuthScheme {
         identity_resolvers.identity_resolver(self.scheme_id())
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         &self.signer
     }
 }
@@ -156,7 +156,7 @@ fn extract_endpoint_auth_scheme_signing_region_set(
     }
 }
 
-impl Signer for SigV4aSigner {
+impl Sign for SigV4aSigner {
     fn sign_http_request(
         &self,
         request: &mut HttpRequest,

--- a/aws/rust-runtime/aws-runtime/src/identity.rs
+++ b/aws/rust-runtime/aws-runtime/src/identity.rs
@@ -6,7 +6,7 @@
 /// Credentials-based identity support.
 pub mod credentials {
     use aws_credential_types::cache::SharedCredentialsCache;
-    use aws_smithy_runtime_api::client::identity::{Identity, IdentityFuture, IdentityResolver};
+    use aws_smithy_runtime_api::client::identity::{Identity, IdentityFuture, ResolveIdentity};
     use aws_smithy_types::config_bag::ConfigBag;
 
     /// Smithy identity resolver for AWS credentials.
@@ -22,7 +22,7 @@ pub mod credentials {
         }
     }
 
-    impl IdentityResolver for CredentialsIdentityResolver {
+    impl ResolveIdentity for CredentialsIdentityResolver {
         fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
             let cache = self.credentials_cache.clone();
             IdentityFuture::new(async move {

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -5,7 +5,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use fastrand::Rng;
@@ -92,7 +92,7 @@ impl InvocationIdInterceptor {
     }
 }
 
-impl Interceptor for InvocationIdInterceptor {
+impl Intercept for InvocationIdInterceptor {
     fn name(&self) -> &'static str {
         "InvocationIdInterceptor"
     }
@@ -217,7 +217,7 @@ mod tests {
     use aws_smithy_runtime_api::client::interceptors::context::{
         BeforeTransmitInterceptorContextMut, Input, InterceptorContext,
     };
-    use aws_smithy_runtime_api::client::interceptors::Interceptor;
+    use aws_smithy_runtime_api::client::interceptors::Intercept;
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use aws_smithy_types::config_bag::ConfigBag;
     use http::HeaderValue;

--- a/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
+++ b/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
@@ -5,7 +5,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_types::os_shim_internal::Env;
@@ -39,7 +39,7 @@ impl RecursionDetectionInterceptor {
     }
 }
 
-impl Interceptor for RecursionDetectionInterceptor {
+impl Intercept for RecursionDetectionInterceptor {
     fn name(&self) -> &'static str {
         "RecursionDetectionInterceptor"
     }

--- a/aws/rust-runtime/aws-runtime/src/request_info.rs
+++ b/aws/rust-runtime/aws-runtime/src/request_info.rs
@@ -7,7 +7,7 @@ use crate::service_clock_skew::ServiceClockSkew;
 use aws_smithy_async::time::TimeSource;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::retries::RequestAttempts;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
@@ -91,7 +91,7 @@ impl RequestInfoInterceptor {
     }
 }
 
-impl Interceptor for RequestInfoInterceptor {
+impl Intercept for RequestInfoInterceptor {
     fn name(&self) -> &'static str {
         "RequestInfoInterceptor"
     }
@@ -182,7 +182,7 @@ mod tests {
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_runtime_api::client::interceptors::context::Input;
     use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
-    use aws_smithy_runtime_api::client::interceptors::Interceptor;
+    use aws_smithy_runtime_api::client::interceptors::Intercept;
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use aws_smithy_types::config_bag::{ConfigBag, Layer};
     use aws_smithy_types::retry::RetryConfig;

--- a/aws/rust-runtime/aws-runtime/src/service_clock_skew.rs
+++ b/aws/rust-runtime/aws-runtime/src/service_clock_skew.rs
@@ -5,7 +5,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use aws_smithy_types::date_time::Format;
@@ -64,7 +64,7 @@ fn extract_time_sent_from_response(
     DateTime::from_str(date_header, Format::HttpDate).map_err(Into::into)
 }
 
-impl Interceptor for ServiceClockSkewInterceptor {
+impl Intercept for ServiceClockSkewInterceptor {
     fn name(&self) -> &'static str {
         "ServiceClockSkewInterceptor"
     }

--- a/aws/rust-runtime/aws-runtime/src/user_agent.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent.rs
@@ -6,7 +6,7 @@
 use aws_http::user_agent::{ApiMetadata, AwsUserAgent};
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_types::app_name::AppName;
@@ -71,7 +71,7 @@ fn header_values(
     ))
 }
 
-impl Interceptor for UserAgentInterceptor {
+impl Intercept for UserAgentInterceptor {
     fn name(&self) -> &'static str {
         "UserAgentInterceptor"
     }
@@ -115,7 +115,7 @@ mod tests {
     use super::*;
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
-    use aws_smithy_runtime_api::client::interceptors::Interceptor;
+    use aws_smithy_runtime_api::client::interceptors::Intercept;
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
     use aws_smithy_types::config_bag::{ConfigBag, Layer};
     use aws_smithy_types::error::display::DisplayErrorContext;

--- a/aws/sdk/integration-tests/s3/tests/interceptors.rs
+++ b/aws/sdk/integration-tests/s3/tests/interceptors.rs
@@ -8,7 +8,7 @@ use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::Client;
 use aws_smithy_runtime::client::http::test_util::capture_request;
 use aws_smithy_runtime_api::box_error::BoxError;
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Layer, Storable, StoreReplace};
 use http::header::USER_AGENT;
@@ -24,7 +24,7 @@ async fn interceptor_priority() {
 
     #[derive(Debug)]
     struct TestInterceptor(&'static str);
-    impl Interceptor for TestInterceptor {
+    impl Intercept for TestInterceptor {
         fn name(&self) -> &'static str {
             "TestInterceptor"
         }

--- a/aws/sdk/integration-tests/s3/tests/request_information_headers.rs
+++ b/aws/sdk/integration-tests/s3/tests/request_information_headers.rs
@@ -10,7 +10,7 @@ use aws_sdk_s3::config::interceptors::FinalizerInterceptorContextRef;
 use aws_sdk_s3::config::retry::RetryConfig;
 use aws_sdk_s3::config::timeout::TimeoutConfig;
 use aws_sdk_s3::config::{Credentials, Region};
-use aws_sdk_s3::config::{Interceptor, SharedAsyncSleep};
+use aws_sdk_s3::config::{Intercept, SharedAsyncSleep};
 use aws_sdk_s3::Client;
 use aws_smithy_async::test_util::InstantSleep;
 use aws_smithy_async::test_util::ManualTimeSource;
@@ -36,7 +36,7 @@ async fn three_retries_and_then_success() {
     struct TimeInterceptor {
         time_source: ManualTimeSource,
     }
-    impl Interceptor for TimeInterceptor {
+    impl Intercept for TimeInterceptor {
         fn name(&self) -> &'static str {
             "TimeInterceptor"
         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
@@ -48,7 +48,7 @@ private fun codegenScope(runtimeConfig: RuntimeConfig): Array<Pair<String, Any>>
         "HTTP_BASIC_AUTH_SCHEME_ID" to authHttpApi.resolve("HTTP_BASIC_AUTH_SCHEME_ID"),
         "HTTP_BEARER_AUTH_SCHEME_ID" to authHttpApi.resolve("HTTP_BEARER_AUTH_SCHEME_ID"),
         "HTTP_DIGEST_AUTH_SCHEME_ID" to authHttpApi.resolve("HTTP_DIGEST_AUTH_SCHEME_ID"),
-        "IdentityResolver" to smithyRuntimeApi.resolve("client::identity::IdentityResolver"),
+        "ResolveIdentity" to smithyRuntimeApi.resolve("client::identity::ResolveIdentity"),
         "Login" to smithyRuntimeApi.resolve("client::identity::http::Login"),
         "SharedAuthScheme" to smithyRuntimeApi.resolve("client::auth::SharedAuthScheme"),
         "SharedIdentityResolver" to smithyRuntimeApi.resolve("client::identity::SharedIdentityResolver"),
@@ -231,7 +231,7 @@ private class HttpAuthConfigCustomization(
                         }
 
                         /// Sets an API key resolver will be used for authentication.
-                        pub fn api_key_resolver(mut self, api_key_resolver: impl #{IdentityResolver} + 'static) -> Self {
+                        pub fn api_key_resolver(mut self, api_key_resolver: impl #{ResolveIdentity} + 'static) -> Self {
                             self.runtime_components.push_identity_resolver(
                                 #{HTTP_API_KEY_AUTH_SCHEME_ID},
                                 #{SharedIdentityResolver}::new(api_key_resolver)
@@ -251,7 +251,7 @@ private class HttpAuthConfigCustomization(
                         }
 
                         /// Sets a bearer token provider that will be used for HTTP bearer auth.
-                        pub fn bearer_token_resolver(mut self, bearer_token_resolver: impl #{IdentityResolver} + 'static) -> Self {
+                        pub fn bearer_token_resolver(mut self, bearer_token_resolver: impl #{ResolveIdentity} + 'static) -> Self {
                             self.runtime_components.push_identity_resolver(
                                 #{HTTP_BEARER_AUTH_SCHEME_ID},
                                 #{SharedIdentityResolver}::new(bearer_token_resolver)
@@ -271,7 +271,7 @@ private class HttpAuthConfigCustomization(
                         }
 
                         /// Sets a login resolver that will be used for HTTP basic auth.
-                        pub fn basic_auth_login_resolver(mut self, basic_auth_resolver: impl #{IdentityResolver} + 'static) -> Self {
+                        pub fn basic_auth_login_resolver(mut self, basic_auth_resolver: impl #{ResolveIdentity} + 'static) -> Self {
                             self.runtime_components.push_identity_resolver(
                                 #{HTTP_BASIC_AUTH_SCHEME_ID},
                                 #{SharedIdentityResolver}::new(basic_auth_resolver)
@@ -291,7 +291,7 @@ private class HttpAuthConfigCustomization(
                         }
 
                         /// Sets a login resolver that will be used for HTTP digest auth.
-                        pub fn digest_auth_login_resolver(mut self, digest_auth_resolver: impl #{IdentityResolver} + 'static) -> Self {
+                        pub fn digest_auth_login_resolver(mut self, digest_auth_resolver: impl #{ResolveIdentity} + 'static) -> Self {
                             self.runtime_components.push_identity_resolver(
                                 #{HTTP_DIGEST_AUTH_SCHEME_ID},
                                 #{SharedIdentityResolver}::new(digest_auth_resolver)

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
@@ -17,7 +17,7 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
     private val runtimeConfig = codegenContext.runtimeConfig
 
     private val codegenScope = arrayOf(
-        "Interceptor" to RuntimeType.interceptor(runtimeConfig),
+        "Intercept" to RuntimeType.intercept(runtimeConfig),
         "SharedInterceptor" to RuntimeType.sharedInterceptor(runtimeConfig),
     )
 
@@ -37,7 +37,7 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                 ServiceConfig.BuilderImpl ->
                     rustTemplate(
                         """
-                        /// Add an [`Interceptor`](#{Interceptor}) that runs at specific stages of the request execution pipeline.
+                        /// Add an [interceptor](#{Intercept}) that runs at specific stages of the request execution pipeline.
                         ///
                         /// Interceptors targeted at a certain stage are executed according to the pre-defined priority.
                         /// The SDK provides a default set of interceptors. An interceptor configured by this method
@@ -61,7 +61,7 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                         ///
                         /// ##[derive(Debug)]
                         /// pub struct UriModifierInterceptor;
-                        /// impl Interceptor for UriModifierInterceptor {
+                        /// impl Intercept for UriModifierInterceptor {
                         ///     fn modify_before_signing(
                         ///         &self,
                         ///         context: &mut InterceptorContext<BeforeTransmit>,
@@ -81,7 +81,7 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                         /// ## }
                         /// ## }
                         /// ```
-                        pub fn interceptor(mut self, interceptor: impl #{Interceptor} + 'static) -> Self {
+                        pub fn interceptor(mut self, interceptor: impl #{Intercept} + 'static) -> Self {
                             self.push_interceptor(#{SharedInterceptor}::new(interceptor));
                             self
                         }
@@ -111,7 +111,7 @@ class InterceptorConfigCustomization(codegenContext: ClientCodegenContext) : Con
                         /// fn modify_request_uri(builder: &mut Builder) {
                         ///     ##[derive(Debug)]
                         ///     pub struct UriModifierInterceptor;
-                        ///     impl Interceptor for UriModifierInterceptor {
+                        ///     impl Intercept for UriModifierInterceptor {
                         ///         fn modify_before_signing(
                         ///             &self,
                         ///             context: &mut InterceptorContext<BeforeTransmit>,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -54,7 +54,7 @@ class EndpointParamsInterceptorGenerator(
             "EndpointResolverParams" to runtimeApi.resolve("client::endpoint::EndpointResolverParams"),
             "HttpRequest" to orchestrator.resolve("HttpRequest"),
             "HttpResponse" to orchestrator.resolve("HttpResponse"),
-            "Interceptor" to RuntimeType.interceptor(rc),
+            "Intercept" to RuntimeType.intercept(rc),
             "InterceptorContext" to RuntimeType.interceptorContext(rc),
             "BeforeSerializationInterceptorContextRef" to RuntimeType.beforeSerializationInterceptorContextRef(rc),
             "Input" to interceptors.resolve("context::Input"),
@@ -74,7 +74,7 @@ class EndpointParamsInterceptorGenerator(
             ##[derive(Debug)]
             struct $interceptorName;
 
-            impl #{Interceptor} for $interceptorName {
+            impl #{Intercept} for $interceptorName {
                 fn name(&self) -> &'static str {
                     ${interceptorName.dq()}
                 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientRuntimeTypesReExportGenerator.kt
@@ -23,12 +23,12 @@ class ClientRuntimeTypesReExportGenerator(
             rustTemplate(
                 """
                 pub use #{ConfigBag};
-                pub use #{Interceptor};
+                pub use #{Intercept};
                 pub use #{RuntimeComponents};
                 pub use #{SharedInterceptor};
                 """,
                 "ConfigBag" to RuntimeType.configBag(rc),
-                "Interceptor" to RuntimeType.interceptor(rc),
+                "Intercept" to RuntimeType.intercept(rc),
                 "RuntimeComponents" to RuntimeType.runtimeComponents(rc),
                 "SharedInterceptor" to RuntimeType.sharedInterceptor(rc),
             )

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -38,8 +38,7 @@ class CustomizableOperationGenerator(
                 .resolve("client::orchestrator::HttpRequest"),
             "HttpResponse" to RuntimeType.smithyRuntimeApi(runtimeConfig)
                 .resolve("client::orchestrator::HttpResponse"),
-            "Interceptor" to RuntimeType.smithyRuntimeApi(runtimeConfig)
-                .resolve("client::interceptors::Interceptor"),
+            "Intercept" to RuntimeType.intercept(runtimeConfig),
             "MapRequestInterceptor" to RuntimeType.smithyRuntime(runtimeConfig)
                 .resolve("client::interceptors::MapRequestInterceptor"),
             "MutateRequestInterceptor" to RuntimeType.smithyRuntime(runtimeConfig)
@@ -85,13 +84,13 @@ class CustomizableOperationGenerator(
                             }
                         }
 
-                    /// Adds an [`Interceptor`](#{Interceptor}) that runs at specific stages of the request execution pipeline.
+                    /// Adds an [interceptor](#{Intercept}) that runs at specific stages of the request execution pipeline.
                     ///
                     /// Note that interceptors can also be added to `CustomizableOperation` by `config_override`,
                     /// `map_request`, and `mutate_request` (the last two are implemented via interceptors under the hood).
                     /// The order in which those user-specified operation interceptors are invoked should not be relied upon
                     /// as it is an implementation detail.
-                    pub fn interceptor(mut self, interceptor: impl #{Interceptor} + 'static) -> Self {
+                    pub fn interceptor(mut self, interceptor: impl #{Intercept} + 'static) -> Self {
                         self.interceptors.push(#{SharedInterceptor}::new(interceptor));
                         self
                     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -338,7 +338,7 @@ class DefaultProtocolTestGenerator(
         )
         rustTemplate(
             """
-            use #{ResponseDeserializer};
+            use #{DeserializeResponse};
             use #{RuntimePlugin};
 
             let op = #{Operation}::new();
@@ -356,7 +356,7 @@ class DefaultProtocolTestGenerator(
             "copy_from_slice" to RT.Bytes.resolve("copy_from_slice"),
             "SharedResponseDeserializer" to RT.smithyRuntimeApi(rc).resolve("client::ser_de::SharedResponseDeserializer"),
             "Operation" to codegenContext.symbolProvider.toSymbol(operationShape),
-            "ResponseDeserializer" to RT.smithyRuntimeApi(rc).resolve("client::ser_de::ResponseDeserializer"),
+            "DeserializeResponse" to RT.smithyRuntimeApi(rc).resolve("client::ser_de::DeserializeResponse"),
             "RuntimePlugin" to RT.runtimePlugin(rc),
             "SdkBody" to RT.sdkBody(rc),
         )

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
@@ -47,7 +47,7 @@ class RequestSerializerGenerator(
             "HttpRequestBuilder" to RuntimeType.HttpRequestBuilder,
             "Input" to interceptorContext.resolve("Input"),
             "operation" to RuntimeType.operationModule(codegenContext.runtimeConfig),
-            "RequestSerializer" to runtimeApi.resolve("client::ser_de::RequestSerializer"),
+            "SerializeRequest" to runtimeApi.resolve("client::ser_de::SerializeRequest"),
             "SdkBody" to RuntimeType.sdkBody(codegenContext.runtimeConfig),
             "HeaderSerializationSettings" to RuntimeType.forInlineDependency(
                 InlineDependency.serializationSettings(
@@ -66,7 +66,7 @@ class RequestSerializerGenerator(
             """
             ##[derive(Debug)]
             struct $serializerName;
-            impl #{RequestSerializer} for $serializerName {
+            impl #{SerializeRequest} for $serializerName {
                 ##[allow(unused_mut, clippy::let_and_return, clippy::needless_borrow, clippy::useless_conversion)]
                 fn serialize_input(&self, input: #{Input}, _cfg: &mut #{ConfigBag}) -> #{Result}<#{HttpRequest}, #{BoxError}> {
                     let input = input.downcast::<#{ConcreteInput}>().expect("correct type");

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
@@ -44,7 +44,7 @@ class ResponseDeserializerGenerator(
             "Output" to interceptorContext.resolve("Output"),
             "OutputOrError" to interceptorContext.resolve("OutputOrError"),
             "OrchestratorError" to orchestrator.resolve("OrchestratorError"),
-            "ResponseDeserializer" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::ser_de::ResponseDeserializer"),
+            "DeserializeResponse" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::ser_de::DeserializeResponse"),
             "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
             "SdkError" to RuntimeType.sdkError(runtimeConfig),
             "debug_span" to RuntimeType.Tracing.resolve("debug_span"),
@@ -61,7 +61,7 @@ class ResponseDeserializerGenerator(
             """
             ##[derive(Debug)]
             struct ${operationName}ResponseDeserializer;
-            impl #{ResponseDeserializer} for ${operationName}ResponseDeserializer {
+            impl #{DeserializeResponse} for ${operationName}ResponseDeserializer {
                 #{deserialize_streaming}
 
                 fn deserialize_nonstreaming(&self, response: &#{HttpResponse}) -> #{OutputOrError} {

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/MetadataCustomizationTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/MetadataCustomizationTest.kt
@@ -40,7 +40,7 @@ class MetadataCustomizationTest {
                 "BeforeTransmitInterceptorContextMut" to RuntimeType.beforeTransmitInterceptorContextMut(runtimeConfig),
                 "BoxError" to RuntimeType.boxError(runtimeConfig),
                 "ConfigBag" to RuntimeType.configBag(runtimeConfig),
-                "Interceptor" to RuntimeType.interceptor(runtimeConfig),
+                "Intercept" to RuntimeType.intercept(runtimeConfig),
                 "Metadata" to RuntimeType.operationModule(runtimeConfig).resolve("Metadata"),
                 "capture_request" to RuntimeType.captureRequest(runtimeConfig),
                 "RuntimeComponents" to RuntimeType.smithyRuntimeApi(runtimeConfig)
@@ -57,7 +57,7 @@ class MetadataCustomizationTest {
                             ::std::sync::Mutex<#{Option}<::std::sync::mpsc::Sender<(String, String)>>>,
                         );
 
-                        impl #{Interceptor} for ExtractMetadataInterceptor {
+                        impl #{Intercept} for ExtractMetadataInterceptor {
                             fn name(&self) -> &'static str {
                                 "ExtractMetadataInterceptor"
                             }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
@@ -157,7 +157,7 @@ class EndpointsDecoratorTest {
                         struct TestInterceptor {
                             called: Arc<AtomicBool>,
                         }
-                        impl Interceptor for TestInterceptor {
+                        impl Intercept for TestInterceptor {
                             fn name(&self) -> &'static str {
                                 "TestInterceptor"
                             }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecoratorTest.kt
@@ -150,7 +150,7 @@ class EndpointsDecoratorTest {
                         use std::time::Duration;
                         use $moduleName::{
                             config::endpoint::Params, config::interceptors::BeforeTransmitInterceptorContextRef,
-                            config::Interceptor, config::SharedAsyncSleep, Client, Config,
+                            config::Intercept, config::SharedAsyncSleep, Client, Config,
                         };
 
                         ##[derive(Clone, Debug, Default)]

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingsTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingsTest.kt
@@ -168,7 +168,7 @@ internal class EndpointTraitBindingsTest {
                         use std::sync::{Arc, Mutex};
                         use $moduleName::{
                             config::interceptors::BeforeTransmitInterceptorContextRef,
-                            config::Interceptor,
+                            config::Intercept,
                             error::DisplayErrorContext,
                             {Client, Config},
                         };

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingsTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingsTest.kt
@@ -180,7 +180,7 @@ internal class EndpointTraitBindingsTest {
                             called: Arc<AtomicU32>,
                             last_endpoint_prefix: Arc<Mutex<Option<EndpointPrefix>>>,
                         }
-                        impl Interceptor for TestInterceptor {
+                        impl Intercept for TestInterceptor {
                             fn name(&self) -> &'static str {
                                 "TestInterceptor"
                             }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
@@ -40,7 +40,7 @@ private class TestServiceRuntimePluginCustomization(
                     {
                         ##[derive(::std::fmt::Debug)]
                         struct TestInterceptor;
-                        impl #{Interceptor} for TestInterceptor {
+                        impl #{Intercept} for TestInterceptor {
                             fn name(&self) -> &'static str {
                                 "TestInterceptor"
                             }
@@ -71,7 +71,7 @@ private class TestServiceRuntimePluginCustomization(
                     "BeforeTransmitInterceptorContextMut" to RT.beforeTransmitInterceptorContextMut(rc),
                     "BoxError" to RT.boxError(rc),
                     "ConfigBag" to RT.configBag(rc),
-                    "Interceptor" to RT.interceptor(rc),
+                    "Intercept" to RT.intercept(rc),
                     "RuntimeComponents" to RT.runtimeComponents(rc),
                     "SdkBody" to RT.sdkBody(rc),
                 )

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
@@ -92,7 +92,7 @@ private class TestOperationCustomization(
                 // Override the default response deserializer with our fake output
                 ##[derive(::std::fmt::Debug)]
                 struct TestDeser;
-                impl #{ResponseDeserializer} for TestDeser {
+                impl #{DeserializeResponse} for TestDeser {
                     fn deserialize_nonstreaming(
                         &self,
                         _response: &#{HttpResponse},
@@ -114,7 +114,7 @@ private class TestOperationCustomization(
                 "HttpResponse" to RT.smithyRuntimeApi(rc).resolve("client::orchestrator::HttpResponse"),
                 "OrchestratorError" to RT.smithyRuntimeApi(rc).resolve("client::orchestrator::OrchestratorError"),
                 "Output" to RT.smithyRuntimeApi(rc).resolve("client::interceptors::context::Output"),
-                "ResponseDeserializer" to RT.smithyRuntimeApi(rc).resolve("client::ser_de::ResponseDeserializer"),
+                "DeserializeResponse" to RT.smithyRuntimeApi(rc).resolve("client::ser_de::DeserializeResponse"),
             )
         }
     }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -357,8 +357,8 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
         fun boxError(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyRuntimeApi(runtimeConfig).resolve("box_error::BoxError")
 
-        fun interceptor(runtimeConfig: RuntimeConfig): RuntimeType =
-            smithyRuntimeApi(runtimeConfig).resolve("client::interceptors::Interceptor")
+        fun intercept(runtimeConfig: RuntimeConfig): RuntimeType =
+            smithyRuntimeApi(runtimeConfig).resolve("client::interceptors::Intercept")
 
         fun interceptorContext(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyRuntimeApi(runtimeConfig).resolve("client::interceptors::context::InterceptorContext")

--- a/design/src/client/identity_and_auth.md
+++ b/design/src/client/identity_and_auth.md
@@ -44,7 +44,7 @@ First, let's establish the aspects of auth that can be configured from the model
     - **IdentityResolver:** resolves an identity for use in authentication.
       There can be multiple identity resolvers that need to be selected from.
     - **Signer:** a signing implementation that signs a HTTP request.
-    - **AuthSchemeOptionResolver:** resolves a list of auth scheme options for a given operation and its inputs.
+    - **ResolveAuthSchemeOptions:** resolves a list of auth scheme options for a given operation and its inputs.
 
 As it is undocumented (at time of writing), this document assumes that the code generator
 creates one service-level runtime plugin, and an operation-level runtime plugin per operation, hence
@@ -61,7 +61,7 @@ At a high-level, the process of resolving an identity and signing a request look
 
 1. Retrieve the `AuthSchemeOptionResolverParams` from the config bag. The `AuthSchemeOptionResolverParams` allow client
 config and operation inputs to play a role in which auth scheme option is selected.
-2. Retrieve the `AuthSchemeOptionResolver` from the config bag, and use it to resolve the auth scheme options available
+2. Retrieve the `ResolveAuthSchemeOptions` impl from the config bag, and use it to resolve the auth scheme options available
 with the `AuthSchemeOptionResolverParams`. The returned auth scheme options are in priority order.
 3. Retrieve the `IdentityResolvers` list from the config bag.
 4. For each auth scheme option:
@@ -91,7 +91,7 @@ pub struct AuthSchemeId {
     scheme_id: &'static str,
 }
 
-pub trait AuthSchemeOptionResolver: Send + Sync + Debug {
+pub trait ResolveAuthSchemeOptions: Send + Sync + Debug {
     fn resolve_auth_scheme_options<'a>(
         &'a self,
         params: &AuthSchemeOptionResolverParams,

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
@@ -153,7 +153,7 @@ pub trait AuthScheme: Send + Sync + fmt::Debug {
     ) -> Option<SharedIdentityResolver>;
 
     /// Returns the signing implementation for this auth scheme.
-    fn signer(&self) -> &dyn Signer;
+    fn signer(&self) -> &dyn Sign;
 }
 
 /// Container for a shared auth scheme implementation.
@@ -179,7 +179,7 @@ impl AuthScheme for SharedAuthScheme {
         self.0.identity_resolver(identity_resolvers)
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         self.0.signer()
     }
 }
@@ -187,7 +187,7 @@ impl AuthScheme for SharedAuthScheme {
 impl_shared_conversions!(convert SharedAuthScheme from AuthScheme using SharedAuthScheme::new);
 
 /// Signing implementation for an auth scheme.
-pub trait Signer: Send + Sync + fmt::Debug {
+pub trait Sign: Send + Sync + fmt::Debug {
     /// Sign the given request with the given identity, components, and config.
     ///
     /// If the provided identity is incompatible with this signer, an error must be returned.

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
@@ -80,6 +80,9 @@ impl Storable for AuthSchemeOptionResolverParams {
     type Storer = StoreReplace<Self>;
 }
 
+#[deprecated(note = "Renamed to ResolveAuthSchemeOptions.")]
+pub use ResolveAuthSchemeOptions as AuthSchemeOptionResolver;
+
 /// Resolver for auth scheme options.
 ///
 /// The orchestrator needs to select an auth scheme to sign requests with, and potentially
@@ -185,6 +188,9 @@ impl AuthScheme for SharedAuthScheme {
 }
 
 impl_shared_conversions!(convert SharedAuthScheme from AuthScheme using SharedAuthScheme::new);
+
+#[deprecated(note = "Renamed to Sign.")]
+pub use Sign as Signer;
 
 /// Signing implementation for an auth scheme.
 pub trait Sign: Send + Sync + fmt::Debug {

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
@@ -93,7 +93,7 @@ impl Storable for AuthSchemeOptionResolverParams {
 /// [`StaticAuthSchemeOptionResolver`](static_resolver::StaticAuthSchemeOptionResolver),
 /// or it can be a complex code generated resolver that incorporates parameters from both
 /// the model and the resolved endpoint.
-pub trait AuthSchemeOptionResolver: Send + Sync + fmt::Debug {
+pub trait ResolveAuthSchemeOptions: Send + Sync + fmt::Debug {
     /// Returns a list of available auth scheme options to choose from.
     fn resolve_auth_scheme_options(
         &self,
@@ -103,16 +103,16 @@ pub trait AuthSchemeOptionResolver: Send + Sync + fmt::Debug {
 
 /// A shared auth scheme option resolver.
 #[derive(Clone, Debug)]
-pub struct SharedAuthSchemeOptionResolver(Arc<dyn AuthSchemeOptionResolver>);
+pub struct SharedAuthSchemeOptionResolver(Arc<dyn ResolveAuthSchemeOptions>);
 
 impl SharedAuthSchemeOptionResolver {
     /// Creates a new [`SharedAuthSchemeOptionResolver`].
-    pub fn new(auth_scheme_option_resolver: impl AuthSchemeOptionResolver + 'static) -> Self {
+    pub fn new(auth_scheme_option_resolver: impl ResolveAuthSchemeOptions + 'static) -> Self {
         Self(Arc::new(auth_scheme_option_resolver))
     }
 }
 
-impl AuthSchemeOptionResolver for SharedAuthSchemeOptionResolver {
+impl ResolveAuthSchemeOptions for SharedAuthSchemeOptionResolver {
     fn resolve_auth_scheme_options(
         &self,
         params: &AuthSchemeOptionResolverParams,
@@ -123,7 +123,7 @@ impl AuthSchemeOptionResolver for SharedAuthSchemeOptionResolver {
 
 impl_shared_conversions!(
     convert SharedAuthSchemeOptionResolver
-    from AuthSchemeOptionResolver
+    from ResolveAuthSchemeOptions
     using SharedAuthSchemeOptionResolver::new
 );
 
@@ -135,7 +135,7 @@ pub trait AuthScheme: Send + Sync + fmt::Debug {
     /// Returns the unique identifier associated with this auth scheme.
     ///
     /// This identifier is used to refer to this auth scheme from the
-    /// [`AuthSchemeOptionResolver`], and is also associated with
+    /// [`ResolveAuthSchemeOptions`], and is also associated with
     /// identity resolvers in the config.
     fn scheme_id(&self) -> AuthSchemeId;
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth/static_resolver.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth/static_resolver.rs
@@ -4,10 +4,10 @@
  */
 
 use crate::box_error::BoxError;
-use crate::client::auth::{AuthSchemeId, AuthSchemeOptionResolver, AuthSchemeOptionResolverParams};
+use crate::client::auth::{AuthSchemeId, AuthSchemeOptionResolverParams, ResolveAuthSchemeOptions};
 use std::borrow::Cow;
 
-/// New-type around a `Vec<AuthSchemeId>` that implements `AuthSchemeOptionResolver`.
+/// New-type around a `Vec<AuthSchemeId>` that implements `ResolveAuthSchemeOptions`.
 #[derive(Debug)]
 pub struct StaticAuthSchemeOptionResolver {
     auth_scheme_options: Vec<AuthSchemeId>,
@@ -22,7 +22,7 @@ impl StaticAuthSchemeOptionResolver {
     }
 }
 
-impl AuthSchemeOptionResolver for StaticAuthSchemeOptionResolver {
+impl ResolveAuthSchemeOptions for StaticAuthSchemeOptionResolver {
     fn resolve_auth_scheme_options(
         &self,
         _params: &AuthSchemeOptionResolverParams,

--- a/rust-runtime/aws-smithy-runtime-api/src/client/dns.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/dns.rs
@@ -71,29 +71,29 @@ impl Future for DnsFuture {
 }
 
 /// Trait for resolving domain names
-pub trait DnsResolver: fmt::Debug + Send + Sync {
+pub trait ResolveDns: fmt::Debug + Send + Sync {
     /// Asynchronously resolve the given domain name
     fn resolve_dns(&self, name: String) -> DnsFuture;
 }
 
 /// Shared DNS resolver
 #[derive(Clone, Debug)]
-pub struct SharedDnsResolver(Arc<dyn DnsResolver>);
+pub struct SharedDnsResolver(Arc<dyn ResolveDns>);
 
 impl SharedDnsResolver {
     /// Create a new `SharedDnsResolver`.
-    pub fn new(resolver: impl DnsResolver + 'static) -> Self {
+    pub fn new(resolver: impl ResolveDns + 'static) -> Self {
         Self(Arc::new(resolver))
     }
 }
 
-impl DnsResolver for SharedDnsResolver {
+impl ResolveDns for SharedDnsResolver {
     fn resolve_dns(&self, name: String) -> DnsFuture {
         self.0.resolve_dns(name)
     }
 }
 
-impl_shared_conversions!(convert SharedDnsResolver from DnsResolver using SharedDnsResolver::new);
+impl_shared_conversions!(convert SharedDnsResolver from ResolveDns using SharedDnsResolver::new);
 
 #[cfg(test)]
 mod tests {

--- a/rust-runtime/aws-smithy-runtime-api/src/client/dns.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/dns.rs
@@ -45,7 +45,7 @@ impl StdError for ResolveDnsError {
 
 type BoxFuture<T> = aws_smithy_async::future::BoxFuture<T, ResolveDnsError>;
 
-/// New-type for the future returned by the [`DnsResolver`] trait.
+/// New-type for the future returned by the [`ResolveDns`] trait.
 pub struct DnsFuture(NowOrLater<Result<Vec<IpAddr>, ResolveDnsError>, BoxFuture<Vec<IpAddr>>>);
 impl DnsFuture {
     /// Create a new `DnsFuture`

--- a/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
@@ -43,28 +43,28 @@ impl Storable for EndpointResolverParams {
 }
 
 /// Configurable endpoint resolver implementation.
-pub trait EndpointResolver: Send + Sync + fmt::Debug {
+pub trait ResolveEndpoint: Send + Sync + fmt::Debug {
     /// Asynchronously resolves an endpoint to use from the given endpoint parameters.
     fn resolve_endpoint(&self, params: &EndpointResolverParams) -> EndpointFuture;
 }
 
 /// Shared endpoint resolver.
 ///
-/// This is a simple shared ownership wrapper type for the [`EndpointResolver`] trait.
+/// This is a simple shared ownership wrapper type for the [`ResolveEndpoint`] trait.
 #[derive(Clone, Debug)]
-pub struct SharedEndpointResolver(Arc<dyn EndpointResolver>);
+pub struct SharedEndpointResolver(Arc<dyn ResolveEndpoint>);
 
 impl SharedEndpointResolver {
     /// Creates a new [`SharedEndpointResolver`].
-    pub fn new(endpoint_resolver: impl EndpointResolver + 'static) -> Self {
+    pub fn new(endpoint_resolver: impl ResolveEndpoint + 'static) -> Self {
         Self(Arc::new(endpoint_resolver))
     }
 }
 
-impl EndpointResolver for SharedEndpointResolver {
+impl ResolveEndpoint for SharedEndpointResolver {
     fn resolve_endpoint(&self, params: &EndpointResolverParams) -> EndpointFuture {
         self.0.resolve_endpoint(params)
     }
 }
 
-impl_shared_conversions!(convert SharedEndpointResolver from EndpointResolver using SharedEndpointResolver::new);
+impl_shared_conversions!(convert SharedEndpointResolver from ResolveEndpoint using SharedEndpointResolver::new);

--- a/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/endpoint.rs
@@ -42,6 +42,9 @@ impl Storable for EndpointResolverParams {
     type Storer = StoreReplace<Self>;
 }
 
+#[deprecated(note = "Renamed to ResolveEndpoint.")]
+pub use ResolveEndpoint as EndpointResolver;
+
 /// Configurable endpoint resolver implementation.
 pub trait ResolveEndpoint: Send + Sync + fmt::Debug {
     /// Asynchronously resolves an endpoint to use from the given endpoint parameters.

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
@@ -89,7 +89,7 @@ impl ConfiguredIdentityResolver {
 /// An identity that can be used for authentication.
 ///
 /// The [`Identity`] is a container for any arbitrary identity data that may be used
-/// by a [`Signer`](crate::client::auth::Signer) implementation. Under the hood, it
+/// by a [`Sign`](crate::client::auth::Sign) implementation. Under the hood, it
 /// has an `Arc<dyn Any>`, and it is the responsibility of the signer to downcast
 /// to the appropriate data type using the `data()` function.
 ///

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
@@ -21,6 +21,9 @@ new_type_future! {
     pub struct IdentityFuture<Identity, BoxError>,
 }
 
+#[deprecated(note = "Renamed to ResolveIdentity.")]
+pub use ResolveIdentity as IdentityResolver;
+
 /// Resolver for identities.
 ///
 /// Every [`AuthScheme`](crate::client::auth::AuthScheme) has one or more compatible

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity.rs
@@ -32,29 +32,29 @@ new_type_future! {
 /// resolves successfully, or it fails. The orchestrator will choose exactly one auth scheme
 /// to use, and thus, its chosen identity resolver is the only identity resolver that runs.
 /// There is no fallback to other auth schemes in the absence of an identity.
-pub trait IdentityResolver: Send + Sync + Debug {
+pub trait ResolveIdentity: Send + Sync + Debug {
     /// Asynchronously resolves an identity for a request using the given config.
     fn resolve_identity(&self, config_bag: &ConfigBag) -> IdentityFuture;
 }
 
 /// Container for a shared identity resolver.
 #[derive(Clone, Debug)]
-pub struct SharedIdentityResolver(Arc<dyn IdentityResolver>);
+pub struct SharedIdentityResolver(Arc<dyn ResolveIdentity>);
 
 impl SharedIdentityResolver {
     /// Creates a new [`SharedIdentityResolver`] from the given resolver.
-    pub fn new(resolver: impl IdentityResolver + 'static) -> Self {
+    pub fn new(resolver: impl ResolveIdentity + 'static) -> Self {
         Self(Arc::new(resolver))
     }
 }
 
-impl IdentityResolver for SharedIdentityResolver {
+impl ResolveIdentity for SharedIdentityResolver {
     fn resolve_identity(&self, config_bag: &ConfigBag) -> IdentityFuture {
         self.0.resolve_identity(config_bag)
     }
 }
 
-impl_shared_conversions!(convert SharedIdentityResolver from IdentityResolver using SharedIdentityResolver::new);
+impl_shared_conversions!(convert SharedIdentityResolver from ResolveIdentity using SharedIdentityResolver::new);
 
 /// An identity resolver paired with an auth scheme ID that it resolves for.
 #[derive(Clone, Debug)]

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
@@ -5,7 +5,7 @@
 
 //! Identity types for HTTP auth
 
-use crate::client::identity::{Identity, IdentityFuture, IdentityResolver};
+use crate::client::identity::{Identity, IdentityFuture, ResolveIdentity};
 use aws_smithy_types::config_bag::ConfigBag;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -63,7 +63,7 @@ impl From<String> for Token {
     }
 }
 
-impl IdentityResolver for Token {
+impl ResolveIdentity for Token {
     fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
         IdentityFuture::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
@@ -122,7 +122,7 @@ impl Login {
     }
 }
 
-impl IdentityResolver for Login {
+impl ResolveIdentity for Login {
     fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
         IdentityFuture::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
@@ -54,6 +54,9 @@ macro_rules! interceptor_trait_fn {
     };
 }
 
+#[deprecated(note = "Renamed to Intercept.")]
+pub use Intercept as Interceptor;
+
 /// An interceptor allows injecting code into the SDK ’s request execution pipeline.
 ///
 /// ## Terminology:

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
@@ -64,7 +64,7 @@ macro_rules! interceptor_trait_fn {
 ///   of the SDK ’s request execution pipeline. Hooks are either "read" hooks, which make it possible
 ///   to read in-flight request or response messages, or "read/write" hooks, which make it possible
 ///   to modify in-flight request or output messages.
-pub trait Interceptor: fmt::Debug + Send + Sync {
+pub trait Intercept: fmt::Debug + Send + Sync {
     /// The name of this interceptor, used in error messages for debugging.
     fn name(&self) -> &'static str;
 
@@ -589,7 +589,7 @@ pub trait Interceptor: fmt::Debug + Send + Sync {
 /// Interceptor wrapper that may be shared
 #[derive(Clone)]
 pub struct SharedInterceptor {
-    interceptor: Arc<dyn Interceptor>,
+    interceptor: Arc<dyn Intercept>,
     check_enabled: Arc<dyn Fn(&ConfigBag) -> bool + Send + Sync>,
 }
 
@@ -603,7 +603,7 @@ impl fmt::Debug for SharedInterceptor {
 
 impl SharedInterceptor {
     /// Create a new `SharedInterceptor` from `Interceptor`.
-    pub fn new<T: Interceptor + 'static>(interceptor: T) -> Self {
+    pub fn new<T: Intercept + 'static>(interceptor: T) -> Self {
         Self {
             interceptor: Arc::new(interceptor),
             check_enabled: Arc::new(|conf: &ConfigBag| {
@@ -618,7 +618,7 @@ impl SharedInterceptor {
     }
 }
 
-impl Interceptor for SharedInterceptor {
+impl Intercept for SharedInterceptor {
     fn name(&self) -> &'static str {
         self.interceptor.name()
     }
@@ -812,7 +812,7 @@ impl Interceptor for SharedInterceptor {
     }
 }
 
-impl_shared_conversions!(convert SharedInterceptor from Interceptor using SharedInterceptor::new);
+impl_shared_conversions!(convert SharedInterceptor from Intercept using SharedInterceptor::new);
 
 /// Generalized interceptor disabling interface
 ///
@@ -833,7 +833,7 @@ where
 }
 
 /// Disable an interceptor with a given cause
-pub fn disable_interceptor<T: Interceptor>(cause: &'static str) -> DisableInterceptor<T> {
+pub fn disable_interceptor<T: Intercept>(cause: &'static str) -> DisableInterceptor<T> {
     DisableInterceptor {
         _t: PhantomData::default(),
         cause,

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -18,7 +18,7 @@ use crate::client::auth::{
 use crate::client::endpoint::{ResolveEndpoint, SharedEndpointResolver};
 use crate::client::http::{HttpClient, SharedHttpClient};
 use crate::client::identity::{
-    ConfiguredIdentityResolver, IdentityResolver, SharedIdentityResolver,
+    ConfiguredIdentityResolver, ResolveIdentity, SharedIdentityResolver,
 };
 use crate::client::interceptors::{Interceptor, SharedInterceptor};
 use crate::client::retries::classifiers::{ClassifyRetry, SharedRetryClassifier};
@@ -357,7 +357,7 @@ impl RuntimeComponentsBuilder {
     pub fn push_identity_resolver(
         &mut self,
         scheme_id: AuthSchemeId,
-        identity_resolver: impl IdentityResolver + 'static,
+        identity_resolver: impl ResolveIdentity + 'static,
     ) -> &mut Self {
         self.identity_resolvers.push(Tracked::new(
             self.builder_name,
@@ -370,7 +370,7 @@ impl RuntimeComponentsBuilder {
     pub fn with_identity_resolver(
         mut self,
         scheme_id: AuthSchemeId,
-        identity_resolver: impl IdentityResolver + 'static,
+        identity_resolver: impl ResolveIdentity + 'static,
     ) -> Self {
         self.push_identity_resolver(scheme_id, identity_resolver);
         self
@@ -605,7 +605,7 @@ impl RuntimeComponentsBuilder {
 
         #[derive(Debug)]
         struct FakeIdentityResolver;
-        impl IdentityResolver for FakeIdentityResolver {
+        impl ResolveIdentity for FakeIdentityResolver {
             fn resolve_identity(&self, _: &ConfigBag) -> IdentityFuture {
                 unreachable!("fake identity resolver must be overridden for this test")
             }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -20,7 +20,7 @@ use crate::client::http::{HttpClient, SharedHttpClient};
 use crate::client::identity::{
     ConfiguredIdentityResolver, ResolveIdentity, SharedIdentityResolver,
 };
-use crate::client::interceptors::{Interceptor, SharedInterceptor};
+use crate::client::interceptors::{Intercept, SharedInterceptor};
 use crate::client::retries::classifiers::{ClassifyRetry, SharedRetryClassifier};
 use crate::client::retries::{RetryStrategy, SharedRetryStrategy};
 use crate::shared::IntoShared;
@@ -392,14 +392,14 @@ impl RuntimeComponentsBuilder {
     }
 
     /// Adds an interceptor.
-    pub fn push_interceptor(&mut self, interceptor: impl Interceptor + 'static) -> &mut Self {
+    pub fn push_interceptor(&mut self, interceptor: impl Intercept + 'static) -> &mut Self {
         self.interceptors
             .push(Tracked::new(self.builder_name, interceptor.into_shared()));
         self
     }
 
     /// Adds an interceptor.
-    pub fn with_interceptor(mut self, interceptor: impl Interceptor + 'static) -> Self {
+    pub fn with_interceptor(mut self, interceptor: impl Intercept + 'static) -> Self {
         self.push_interceptor(interceptor);
         self
     }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -15,7 +15,7 @@ use crate::client::auth::{
     AuthScheme, AuthSchemeId, ResolveAuthSchemeOptions, SharedAuthScheme,
     SharedAuthSchemeOptionResolver,
 };
-use crate::client::endpoint::{EndpointResolver, SharedEndpointResolver};
+use crate::client::endpoint::{ResolveEndpoint, SharedEndpointResolver};
 use crate::client::http::{HttpClient, SharedHttpClient};
 use crate::client::identity::{
     ConfiguredIdentityResolver, IdentityResolver, SharedIdentityResolver,
@@ -319,7 +319,7 @@ impl RuntimeComponentsBuilder {
     /// Sets the endpoint resolver.
     pub fn set_endpoint_resolver(
         &mut self,
-        endpoint_resolver: Option<impl EndpointResolver + 'static>,
+        endpoint_resolver: Option<impl ResolveEndpoint + 'static>,
     ) -> &mut Self {
         self.endpoint_resolver =
             endpoint_resolver.map(|s| Tracked::new(self.builder_name, s.into_shared()));
@@ -329,7 +329,7 @@ impl RuntimeComponentsBuilder {
     /// Sets the endpoint resolver.
     pub fn with_endpoint_resolver(
         mut self,
-        endpoint_resolver: Option<impl EndpointResolver + 'static>,
+        endpoint_resolver: Option<impl ResolveEndpoint + 'static>,
     ) -> Self {
         self.set_endpoint_resolver(endpoint_resolver);
         self
@@ -578,7 +578,7 @@ impl RuntimeComponentsBuilder {
 
         #[derive(Debug)]
         struct FakeEndpointResolver;
-        impl EndpointResolver for FakeEndpointResolver {
+        impl ResolveEndpoint for FakeEndpointResolver {
             fn resolve_endpoint(&self, _: &EndpointResolverParams) -> EndpointFuture {
                 unreachable!("fake endpoint resolver must be overridden for this test")
             }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -12,7 +12,7 @@
 //! [`RuntimeComponents`](RuntimeComponents).
 
 use crate::client::auth::{
-    AuthScheme, AuthSchemeId, AuthSchemeOptionResolver, SharedAuthScheme,
+    AuthScheme, AuthSchemeId, ResolveAuthSchemeOptions, SharedAuthScheme,
     SharedAuthSchemeOptionResolver,
 };
 use crate::client::endpoint::{EndpointResolver, SharedEndpointResolver};
@@ -278,7 +278,7 @@ impl RuntimeComponentsBuilder {
     /// Sets the auth scheme option resolver.
     pub fn set_auth_scheme_option_resolver(
         &mut self,
-        auth_scheme_option_resolver: Option<impl AuthSchemeOptionResolver + 'static>,
+        auth_scheme_option_resolver: Option<impl ResolveAuthSchemeOptions + 'static>,
     ) -> &mut Self {
         self.auth_scheme_option_resolver =
             auth_scheme_option_resolver.map(|r| Tracked::new(self.builder_name, r.into_shared()));
@@ -288,7 +288,7 @@ impl RuntimeComponentsBuilder {
     /// Sets the auth scheme option resolver.
     pub fn with_auth_scheme_option_resolver(
         mut self,
-        auth_scheme_option_resolver: Option<impl AuthSchemeOptionResolver + 'static>,
+        auth_scheme_option_resolver: Option<impl ResolveAuthSchemeOptions + 'static>,
     ) -> Self {
         self.set_auth_scheme_option_resolver(auth_scheme_option_resolver);
         self
@@ -554,7 +554,7 @@ impl RuntimeComponentsBuilder {
 
         #[derive(Debug)]
         struct FakeAuthSchemeOptionResolver;
-        impl AuthSchemeOptionResolver for FakeAuthSchemeOptionResolver {
+        impl ResolveAuthSchemeOptions for FakeAuthSchemeOptionResolver {
             fn resolve_auth_scheme_options(
                 &self,
                 _: &crate::client::auth::AuthSchemeOptionResolverParams,

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_components.rs
@@ -598,7 +598,7 @@ impl RuntimeComponentsBuilder {
                 None
             }
 
-            fn signer(&self) -> &dyn crate::client::auth::Signer {
+            fn signer(&self) -> &dyn crate::client::auth::Sign {
                 unreachable!("fake http auth scheme must be overridden for this test")
             }
         }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/ser_de.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/ser_de.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use std::sync::Arc;
 
 /// Serialization implementation that converts an [`Input`] into an [`HttpRequest`].
-pub trait RequestSerializer: Send + Sync + fmt::Debug {
+pub trait SerializeRequest: Send + Sync + fmt::Debug {
     /// Serializes the input into an HTTP request.
     ///
     /// The type of the [`Input`] must be known ahead of time by the request serializer
@@ -28,18 +28,18 @@ pub trait RequestSerializer: Send + Sync + fmt::Debug {
 
 /// A shared request serializer.
 ///
-/// This is a simple shared ownership wrapper type for the [`RequestSerializer`] trait.
+/// This is a simple shared ownership wrapper type for the [`SerializeRequest`] trait.
 #[derive(Clone, Debug)]
-pub struct SharedRequestSerializer(Arc<dyn RequestSerializer>);
+pub struct SharedRequestSerializer(Arc<dyn SerializeRequest>);
 
 impl SharedRequestSerializer {
     /// Creates a new shared request serializer.
-    pub fn new(serializer: impl RequestSerializer + 'static) -> Self {
+    pub fn new(serializer: impl SerializeRequest + 'static) -> Self {
         Self(Arc::new(serializer))
     }
 }
 
-impl RequestSerializer for SharedRequestSerializer {
+impl SerializeRequest for SharedRequestSerializer {
     fn serialize_input(&self, input: Input, cfg: &mut ConfigBag) -> Result<HttpRequest, BoxError> {
         self.0.serialize_input(input, cfg)
     }
@@ -49,10 +49,10 @@ impl Storable for SharedRequestSerializer {
     type Storer = StoreReplace<Self>;
 }
 
-impl_shared_conversions!(convert SharedRequestSerializer from RequestSerializer using SharedRequestSerializer::new);
+impl_shared_conversions!(convert SharedRequestSerializer from SerializeRequest using SharedRequestSerializer::new);
 
 /// Deserialization implementation that converts an [`HttpResponse`] into an [`Output`] or [`Error`].
-pub trait ResponseDeserializer: Send + Sync + fmt::Debug {
+pub trait DeserializeResponse: Send + Sync + fmt::Debug {
     /// For streaming requests, deserializes the response headers.
     ///
     /// The orchestrator will call `deserialize_streaming` first, and if it returns `None`,
@@ -76,18 +76,18 @@ pub trait ResponseDeserializer: Send + Sync + fmt::Debug {
 
 /// Shared response deserializer.
 ///
-/// This is a simple shared ownership wrapper type for the [`ResponseDeserializer`] trait.
+/// This is a simple shared ownership wrapper type for the [`DeserializeResponse`] trait.
 #[derive(Debug)]
-pub struct SharedResponseDeserializer(Arc<dyn ResponseDeserializer>);
+pub struct SharedResponseDeserializer(Arc<dyn DeserializeResponse>);
 
 impl SharedResponseDeserializer {
     /// Creates a new [`SharedResponseDeserializer`].
-    pub fn new(serializer: impl ResponseDeserializer + 'static) -> Self {
+    pub fn new(serializer: impl DeserializeResponse + 'static) -> Self {
         Self(Arc::new(serializer))
     }
 }
 
-impl ResponseDeserializer for SharedResponseDeserializer {
+impl DeserializeResponse for SharedResponseDeserializer {
     fn deserialize_nonstreaming(
         &self,
         response: &HttpResponse,
@@ -107,4 +107,4 @@ impl Storable for SharedResponseDeserializer {
     type Storer = StoreReplace<Self>;
 }
 
-impl_shared_conversions!(convert SharedResponseDeserializer from ResponseDeserializer using SharedResponseDeserializer::new);
+impl_shared_conversions!(convert SharedResponseDeserializer from DeserializeResponse using SharedResponseDeserializer::new);

--- a/rust-runtime/aws-smithy-runtime-api/src/client/ser_de.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/ser_de.rs
@@ -13,6 +13,9 @@ use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use std::fmt;
 use std::sync::Arc;
 
+#[deprecated(note = "Renamed to SerializeRequest.")]
+pub use SerializeRequest as RequestSerializer;
+
 /// Serialization implementation that converts an [`Input`] into an [`HttpRequest`].
 pub trait SerializeRequest: Send + Sync + fmt::Debug {
     /// Serializes the input into an HTTP request.
@@ -50,6 +53,9 @@ impl Storable for SharedRequestSerializer {
 }
 
 impl_shared_conversions!(convert SharedRequestSerializer from SerializeRequest using SharedRequestSerializer::new);
+
+#[deprecated(note = "Renamed to DeserializeResponse.")]
+pub use DeserializeResponse as ResponseDeserializer;
 
 /// Deserialization implementation that converts an [`HttpResponse`] into an [`Output`] or [`Error`].
 pub trait DeserializeResponse: Send + Sync + fmt::Debug {

--- a/rust-runtime/aws-smithy-runtime/src/client/auth/http.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/auth/http.rs
@@ -12,7 +12,7 @@ use aws_smithy_runtime_api::client::auth::http::{
     HTTP_DIGEST_AUTH_SCHEME_ID,
 };
 use aws_smithy_runtime_api::client::auth::{
-    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Signer,
+    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, Sign,
 };
 use aws_smithy_runtime_api::client::identity::http::{Login, Token};
 use aws_smithy_runtime_api::client::identity::{Identity, SharedIdentityResolver};
@@ -67,7 +67,7 @@ impl AuthScheme for ApiKeyAuthScheme {
         identity_resolvers.identity_resolver(self.scheme_id())
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         &self.signer
     }
 }
@@ -79,7 +79,7 @@ struct ApiKeySigner {
     name: String,
 }
 
-impl Signer for ApiKeySigner {
+impl Sign for ApiKeySigner {
     fn sign_http_request(
         &self,
         request: &mut HttpRequest,
@@ -138,7 +138,7 @@ impl AuthScheme for BasicAuthScheme {
         identity_resolvers.identity_resolver(self.scheme_id())
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         &self.signer
     }
 }
@@ -146,7 +146,7 @@ impl AuthScheme for BasicAuthScheme {
 #[derive(Debug, Default)]
 struct BasicAuthSigner;
 
-impl Signer for BasicAuthSigner {
+impl Sign for BasicAuthSigner {
     fn sign_http_request(
         &self,
         request: &mut HttpRequest,
@@ -197,7 +197,7 @@ impl AuthScheme for BearerAuthScheme {
         identity_resolvers.identity_resolver(self.scheme_id())
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         &self.signer
     }
 }
@@ -205,7 +205,7 @@ impl AuthScheme for BearerAuthScheme {
 #[derive(Debug, Default)]
 struct BearerAuthSigner;
 
-impl Signer for BearerAuthSigner {
+impl Sign for BearerAuthSigner {
     fn sign_http_request(
         &self,
         request: &mut HttpRequest,
@@ -254,7 +254,7 @@ impl AuthScheme for DigestAuthScheme {
         identity_resolvers.identity_resolver(self.scheme_id())
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         &self.signer
     }
 }
@@ -262,7 +262,7 @@ impl AuthScheme for DigestAuthScheme {
 #[derive(Debug, Default)]
 struct DigestAuthSigner;
 
-impl Signer for DigestAuthSigner {
+impl Sign for DigestAuthSigner {
     fn sign_http_request(
         &self,
         _request: &mut HttpRequest,

--- a/rust-runtime/aws-smithy-runtime/src/client/auth/no_auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/auth/no_auth.rs
@@ -8,7 +8,7 @@
 use crate::client::identity::no_auth::NoAuthIdentityResolver;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::{
-    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, SharedAuthScheme, Signer,
+    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, SharedAuthScheme, Sign,
 };
 use aws_smithy_runtime_api::client::identity::{Identity, SharedIdentityResolver};
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
@@ -80,7 +80,7 @@ impl NoAuthScheme {
 #[derive(Debug, Default)]
 struct NoAuthSigner;
 
-impl Signer for NoAuthSigner {
+impl Sign for NoAuthSigner {
     fn sign_http_request(
         &self,
         _request: &mut HttpRequest,
@@ -105,7 +105,7 @@ impl AuthScheme for NoAuthScheme {
         identity_resolvers.identity_resolver(NO_AUTH_SCHEME_ID)
     }
 
-    fn signer(&self) -> &dyn Signer {
+    fn signer(&self) -> &dyn Sign {
         &self.signer
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/dns.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/dns.rs
@@ -7,7 +7,7 @@
 
 #[cfg(all(feature = "rt-tokio", not(target_family = "wasm")))]
 mod tokio {
-    use aws_smithy_runtime_api::client::dns::{DnsFuture, DnsResolver, ResolveDnsError};
+    use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns, ResolveDnsError};
     use std::io::{Error as IoError, ErrorKind as IoErrorKind};
     use std::net::ToSocketAddrs;
 
@@ -25,7 +25,7 @@ mod tokio {
         }
     }
 
-    impl DnsResolver for TokioDnsResolver {
+    impl ResolveDns for TokioDnsResolver {
         fn resolve_dns(&self, name: String) -> DnsFuture {
             DnsFuture::new(async move {
                 let result = tokio::task::spawn_blocking(move || (name, 0).to_socket_addrs()).await;

--- a/rust-runtime/aws-smithy-runtime/src/client/http/connection_poisoning.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/http/connection_poisoning.rs
@@ -9,7 +9,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     AfterDeserializationInterceptorContextRef, BeforeTransmitInterceptorContextMut,
 };
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::retries::classifiers::RetryAction;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
@@ -43,7 +43,7 @@ impl ConnectionPoisoningInterceptor {
     }
 }
 
-impl Interceptor for ConnectionPoisoningInterceptor {
+impl Intercept for ConnectionPoisoningInterceptor {
     fn name(&self) -> &'static str {
         "ConnectionPoisoningInterceptor"
     }

--- a/rust-runtime/aws-smithy-runtime/src/client/identity/no_auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/identity/no_auth.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_smithy_runtime_api::client::identity::{Identity, IdentityFuture, IdentityResolver};
+use aws_smithy_runtime_api::client::identity::{Identity, IdentityFuture, ResolveIdentity};
 use aws_smithy_types::config_bag::ConfigBag;
 
 /// Identity for the [`NoAuthScheme`](crate::client::auth::no_auth::NoAuthScheme) auth scheme.
@@ -28,7 +28,7 @@ impl NoAuthIdentityResolver {
     }
 }
 
-impl IdentityResolver for NoAuthIdentityResolver {
+impl ResolveIdentity for NoAuthIdentityResolver {
     fn resolve_identity(&self, _: &ConfigBag) -> IdentityFuture {
         IdentityFuture::ready(Ok(Identity::new(NoAuthIdentity::new(), None)))
     }

--- a/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/interceptors.rs
@@ -13,7 +13,7 @@ use aws_smithy_runtime_api::client::interceptors::context::{
     Error, Input, InterceptorContext, Output,
 };
 use aws_smithy_runtime_api::client::interceptors::{
-    Interceptor, InterceptorError, SharedInterceptor,
+    Intercept, InterceptorError, SharedInterceptor,
 };
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
@@ -271,7 +271,7 @@ where
 /// [`DisableInterceptor`](aws_smithy_runtime_api::client::interceptors::DisableInterceptor)
 struct ConditionallyEnabledInterceptor(SharedInterceptor);
 impl ConditionallyEnabledInterceptor {
-    fn if_enabled(&self, cfg: &ConfigBag) -> Option<&dyn Interceptor> {
+    fn if_enabled(&self, cfg: &ConfigBag) -> Option<&dyn Intercept> {
         if self.0.enabled(cfg) {
             Some(&self.0)
         } else {
@@ -302,7 +302,7 @@ impl<F, E> MapRequestInterceptor<F, E> {
     }
 }
 
-impl<F, E> Interceptor for MapRequestInterceptor<F, E>
+impl<F, E> Intercept for MapRequestInterceptor<F, E>
 where
     F: Fn(HttpRequest) -> Result<HttpRequest, E> + Send + Sync + 'static,
     E: StdError + Send + Sync + 'static,
@@ -344,7 +344,7 @@ impl<F> MutateRequestInterceptor<F> {
     }
 }
 
-impl<F> Interceptor for MutateRequestInterceptor<F>
+impl<F> Intercept for MutateRequestInterceptor<F>
 where
     F: Fn(&mut HttpRequest) + Send + Sync + 'static,
 {
@@ -373,7 +373,7 @@ mod tests {
         BeforeTransmitInterceptorContextRef, Input, InterceptorContext,
     };
     use aws_smithy_runtime_api::client::interceptors::{
-        disable_interceptor, Interceptor, SharedInterceptor,
+        disable_interceptor, Intercept, SharedInterceptor,
     };
     use aws_smithy_runtime_api::client::runtime_components::{
         RuntimeComponents, RuntimeComponentsBuilder,
@@ -382,7 +382,7 @@ mod tests {
 
     #[derive(Debug)]
     struct TestInterceptor;
-    impl Interceptor for TestInterceptor {
+    impl Intercept for TestInterceptor {
         fn name(&self) -> &'static str {
             "TestInterceptor"
         }
@@ -392,7 +392,7 @@ mod tests {
     fn test_disable_interceptors() {
         #[derive(Debug)]
         struct PanicInterceptor;
-        impl Interceptor for PanicInterceptor {
+        impl Intercept for PanicInterceptor {
             fn name(&self) -> &'static str {
                 "PanicInterceptor"
             }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -27,7 +27,7 @@ use aws_smithy_runtime_api::client::retries::{RequestAttempts, RetryStrategy, Sh
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugins;
 use aws_smithy_runtime_api::client::ser_de::{
-    RequestSerializer, ResponseDeserializer, SharedRequestSerializer, SharedResponseDeserializer,
+    DeserializeResponse, SerializeRequest, SharedRequestSerializer, SharedResponseDeserializer,
 };
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::timeout::TimeoutConfig;

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -464,7 +464,7 @@ mod tests {
         BeforeTransmitInterceptorContextRef, FinalizerInterceptorContextMut,
         FinalizerInterceptorContextRef,
     };
-    use aws_smithy_runtime_api::client::interceptors::{Interceptor, SharedInterceptor};
+    use aws_smithy_runtime_api::client::interceptors::{Intercept, SharedInterceptor};
     use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
     use aws_smithy_runtime_api::client::retries::SharedRetryStrategy;
     use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
@@ -564,7 +564,7 @@ mod tests {
         (__private $interceptor:ident, $ctx:ty, $expected:expr, $($rc_arg:tt)*) => {
             #[derive(Debug)]
             struct FailingInterceptorA;
-            impl Interceptor for FailingInterceptorA {
+            impl Intercept for FailingInterceptorA {
                 fn name(&self) -> &'static str { "FailingInterceptorA" }
 
                 fn $interceptor(
@@ -580,7 +580,7 @@ mod tests {
 
             #[derive(Debug)]
             struct FailingInterceptorB;
-            impl Interceptor for FailingInterceptorB {
+            impl Intercept for FailingInterceptorB {
                 fn name(&self) -> &'static str { "FailingInterceptorB" }
 
                 fn $interceptor(
@@ -596,7 +596,7 @@ mod tests {
 
             #[derive(Debug)]
             struct FailingInterceptorC;
-            impl Interceptor for FailingInterceptorC {
+            impl Intercept for FailingInterceptorC {
                 fn name(&self) -> &'static str { "FailingInterceptorC" }
 
                 fn $interceptor(
@@ -877,7 +877,7 @@ mod tests {
         (__private $origin_interceptor:ident, $origin_ctx:ty, $destination_interceptor:ident, $destination_ctx:ty, $expected:expr, $($rc_arg:tt)*) => {
             #[derive(Debug)]
             struct OriginInterceptor;
-            impl Interceptor for OriginInterceptor {
+            impl Intercept for OriginInterceptor {
                 fn name(&self) -> &'static str { "OriginInterceptor" }
 
                 fn $origin_interceptor(
@@ -893,7 +893,7 @@ mod tests {
 
             #[derive(Debug)]
             struct DestinationInterceptor;
-            impl Interceptor for DestinationInterceptor {
+            impl Intercept for DestinationInterceptor {
                 fn name(&self) -> &'static str { "DestinationInterceptor" }
 
                 fn $destination_interceptor(
@@ -1211,7 +1211,7 @@ mod tests {
             inner: Arc<Inner>,
         }
 
-        impl Interceptor for TestInterceptor {
+        impl Intercept for TestInterceptor {
             fn name(&self) -> &'static str {
                 "TestInterceptor"
             }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -9,7 +9,7 @@ use aws_smithy_runtime_api::client::auth::{
     AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, AuthSchemeOptionResolverParams,
     ResolveAuthSchemeOptions,
 };
-use aws_smithy_runtime_api::client::identity::IdentityResolver;
+use aws_smithy_runtime_api::client::identity::ResolveIdentity;
 use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
@@ -145,7 +145,7 @@ mod tests {
         SharedAuthSchemeOptionResolver, Signer,
     };
     use aws_smithy_runtime_api::client::identity::{
-        Identity, IdentityFuture, IdentityResolver, SharedIdentityResolver,
+        Identity, IdentityFuture, ResolveIdentity, SharedIdentityResolver,
     };
     use aws_smithy_runtime_api::client::interceptors::context::{Input, InterceptorContext};
     use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
@@ -159,7 +159,7 @@ mod tests {
     async fn basic_case() {
         #[derive(Debug)]
         struct TestIdentityResolver;
-        impl IdentityResolver for TestIdentityResolver {
+        impl ResolveIdentity for TestIdentityResolver {
             fn resolve_identity(&self, _config_bag: &ConfigBag) -> IdentityFuture {
                 IdentityFuture::ready(Ok(Identity::new("doesntmatter", None)))
             }
@@ -261,7 +261,7 @@ mod tests {
 
         fn config_with_identity(
             scheme_id: AuthSchemeId,
-            identity: impl IdentityResolver + 'static,
+            identity: impl ResolveIdentity + 'static,
         ) -> (RuntimeComponents, ConfigBag) {
             let runtime_components = RuntimeComponentsBuilder::for_tests()
                 .with_auth_scheme(SharedAuthScheme::new(BasicAuthScheme::new()))

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -6,8 +6,8 @@
 use crate::client::auth::no_auth::NO_AUTH_SCHEME_ID;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::auth::{
-    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, AuthSchemeOptionResolver,
-    AuthSchemeOptionResolverParams,
+    AuthScheme, AuthSchemeEndpointConfig, AuthSchemeId, AuthSchemeOptionResolverParams,
+    ResolveAuthSchemeOptions,
 };
 use aws_smithy_runtime_api::client::identity::IdentityResolver;
 use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -142,7 +142,7 @@ mod tests {
     use aws_smithy_runtime_api::client::auth::static_resolver::StaticAuthSchemeOptionResolver;
     use aws_smithy_runtime_api::client::auth::{
         AuthScheme, AuthSchemeId, AuthSchemeOptionResolverParams, SharedAuthScheme,
-        SharedAuthSchemeOptionResolver, Signer,
+        SharedAuthSchemeOptionResolver, Sign,
     };
     use aws_smithy_runtime_api::client::identity::{
         Identity, IdentityFuture, ResolveIdentity, SharedIdentityResolver,
@@ -168,7 +168,7 @@ mod tests {
         #[derive(Debug)]
         struct TestSigner;
 
-        impl Signer for TestSigner {
+        impl Sign for TestSigner {
             fn sign_http_request(
                 &self,
                 request: &mut HttpRequest,
@@ -202,7 +202,7 @@ mod tests {
                 identity_resolvers.identity_resolver(self.scheme_id())
             }
 
-            fn signer(&self) -> &dyn Signer {
+            fn signer(&self) -> &dyn Sign {
                 &self.signer
             }
         }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -5,12 +5,12 @@
 
 use aws_smithy_http::endpoint::error::ResolveEndpointError;
 use aws_smithy_http::endpoint::{
-    apply_endpoint as apply_endpoint_to_request_uri, EndpointPrefix, ResolveEndpoint,
+    apply_endpoint as apply_endpoint_to_request_uri, EndpointPrefix, ResolveEndpoint as _,
     SharedEndpointResolver,
 };
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::endpoint::{
-    EndpointFuture, EndpointResolver, EndpointResolverParams,
+    EndpointFuture, EndpointResolverParams, ResolveEndpoint,
 };
 use aws_smithy_runtime_api::client::interceptors::context::InterceptorContext;
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
@@ -45,7 +45,7 @@ impl StaticUriEndpointResolver {
     }
 }
 
-impl EndpointResolver for StaticUriEndpointResolver {
+impl ResolveEndpoint for StaticUriEndpointResolver {
     fn resolve_endpoint(&self, _params: &EndpointResolverParams) -> EndpointFuture {
         EndpointFuture::ready(Ok(Endpoint::builder()
             .url(self.endpoint.to_string())
@@ -70,9 +70,9 @@ impl From<StaticUriEndpointResolverParams> for EndpointResolverParams {
     }
 }
 
-/// Default implementation of [`EndpointResolver`].
+/// Default implementation of [`ResolveEndpoint`].
 ///
-/// This default endpoint resolver implements the `EndpointResolver` trait by
+/// This default endpoint resolver implements the `ResolveEndpoint` trait by
 /// converting the type-erased [`EndpointResolverParams`] into the concrete
 /// endpoint params for the service. It then delegates endpoint resolution
 /// to an underlying resolver that is aware of the concrete type.
@@ -97,7 +97,7 @@ impl<Params> DefaultEndpointResolver<Params> {
     }
 }
 
-impl<Params> EndpointResolver for DefaultEndpointResolver<Params>
+impl<Params> ResolveEndpoint for DefaultEndpointResolver<Params>
 where
     Params: Debug + Send + Sync + 'static,
 {

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/operation.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/operation.rs
@@ -31,7 +31,7 @@ use aws_smithy_runtime_api::client::runtime_plugin::{
     RuntimePlugin, RuntimePlugins, SharedRuntimePlugin, StaticRuntimePlugin,
 };
 use aws_smithy_runtime_api::client::ser_de::{
-    RequestSerializer, ResponseDeserializer, SharedRequestSerializer, SharedResponseDeserializer,
+    DeserializeResponse, SerializeRequest, SharedRequestSerializer, SharedResponseDeserializer,
 };
 use aws_smithy_runtime_api::shared::IntoShared;
 use aws_smithy_types::config_bag::{ConfigBag, Layer};
@@ -53,7 +53,7 @@ impl<F, I> FnSerializer<F, I> {
         }
     }
 }
-impl<F, I> RequestSerializer for FnSerializer<F, I>
+impl<F, I> SerializeRequest for FnSerializer<F, I>
 where
     F: Fn(I) -> Result<HttpRequest, BoxError> + Send + Sync,
     I: fmt::Debug + Send + Sync + 'static,
@@ -81,7 +81,7 @@ impl<F, O, E> FnDeserializer<F, O, E> {
         }
     }
 }
-impl<F, O, E> ResponseDeserializer for FnDeserializer<F, O, E>
+impl<F, O, E> DeserializeResponse for FnDeserializer<F, O, E>
 where
     F: Fn(&HttpResponse) -> Result<O, OrchestratorError<E>> + Send + Sync,
     O: fmt::Debug + Send + Sync + 'static,

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/operation.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/operation.rs
@@ -21,7 +21,7 @@ use aws_smithy_runtime_api::client::endpoint::{EndpointResolverParams, SharedEnd
 use aws_smithy_runtime_api::client::http::HttpClient;
 use aws_smithy_runtime_api::client::identity::SharedIdentityResolver;
 use aws_smithy_runtime_api::client::interceptors::context::{Error, Input, Output};
-use aws_smithy_runtime_api::client::interceptors::Interceptor;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, OrchestratorError};
 use aws_smithy_runtime_api::client::retries::classifiers::ClassifyRetry;
@@ -261,7 +261,7 @@ impl<I, O, E> OperationBuilder<I, O, E> {
         self
     }
 
-    pub fn interceptor(mut self, interceptor: impl Interceptor + 'static) -> Self {
+    pub fn interceptor(mut self, interceptor: impl Intercept + 'static) -> Self {
         self.runtime_components.push_interceptor(interceptor);
         self
     }

--- a/rust-runtime/aws-smithy-runtime/src/client/test_util/deserializer.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/test_util/deserializer.rs
@@ -6,7 +6,7 @@
 use aws_smithy_runtime_api::client::interceptors::context::{Error, Output};
 use aws_smithy_runtime_api::client::orchestrator::{HttpResponse, OrchestratorError};
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
-use aws_smithy_runtime_api::client::ser_de::{ResponseDeserializer, SharedResponseDeserializer};
+use aws_smithy_runtime_api::client::ser_de::{DeserializeResponse, SharedResponseDeserializer};
 use aws_smithy_types::config_bag::{FrozenLayer, Layer};
 use std::sync::Mutex;
 
@@ -32,7 +32,7 @@ impl CannedResponseDeserializer {
     }
 }
 
-impl ResponseDeserializer for CannedResponseDeserializer {
+impl DeserializeResponse for CannedResponseDeserializer {
     fn deserialize_nonstreaming(
         &self,
         _response: &HttpResponse,

--- a/rust-runtime/aws-smithy-runtime/src/client/test_util/serializer.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/test_util/serializer.rs
@@ -7,11 +7,11 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::Input;
 use aws_smithy_runtime_api::client::orchestrator::HttpRequest;
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
-use aws_smithy_runtime_api::client::ser_de::{RequestSerializer, SharedRequestSerializer};
+use aws_smithy_runtime_api::client::ser_de::{SerializeRequest, SharedRequestSerializer};
 use aws_smithy_types::config_bag::{ConfigBag, FrozenLayer, Layer};
 use std::sync::Mutex;
 
-/// Test [`RequestSerializer`] that returns a canned request.
+/// Test [`SerializeRequest`] that returns a canned request.
 #[derive(Default, Debug)]
 pub struct CannedRequestSerializer {
     inner: Mutex<Option<Result<HttpRequest, BoxError>>>,
@@ -40,7 +40,7 @@ impl CannedRequestSerializer {
     }
 }
 
-impl RequestSerializer for CannedRequestSerializer {
+impl SerializeRequest for CannedRequestSerializer {
     fn serialize_input(
         &self,
         _input: Input,

--- a/rust-runtime/inlineable/src/client_http_checksum_required.rs
+++ b/rust-runtime/inlineable/src/client_http_checksum_required.rs
@@ -5,7 +5,7 @@
 
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
-use aws_smithy_runtime_api::client::interceptors::{Interceptor, SharedInterceptor};
+use aws_smithy_runtime_api::client::interceptors::{Intercept, SharedInterceptor};
 use aws_smithy_runtime_api::client::runtime_components::{
     RuntimeComponents, RuntimeComponentsBuilder,
 };
@@ -41,7 +41,7 @@ impl RuntimePlugin for HttpChecksumRequiredRuntimePlugin {
 #[derive(Debug)]
 struct HttpChecksumRequiredInterceptor;
 
-impl Interceptor for HttpChecksumRequiredInterceptor {
+impl Intercept for HttpChecksumRequiredInterceptor {
     fn name(&self) -> &'static str {
         "HttpChecksumRequiredInterceptor"
     }

--- a/rust-runtime/inlineable/src/client_idempotency_token.rs
+++ b/rust-runtime/inlineable/src/client_idempotency_token.rs
@@ -8,7 +8,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextMut, Input,
 };
-use aws_smithy_runtime_api::client::interceptors::{Interceptor, SharedInterceptor};
+use aws_smithy_runtime_api::client::interceptors::{Intercept, SharedInterceptor};
 use aws_smithy_runtime_api::client::runtime_components::{
     RuntimeComponents, RuntimeComponentsBuilder,
 };
@@ -55,7 +55,7 @@ impl<S> fmt::Debug for IdempotencyTokenInterceptor<S> {
     }
 }
 
-impl<S> Interceptor for IdempotencyTokenInterceptor<S>
+impl<S> Intercept for IdempotencyTokenInterceptor<S>
 where
     S: Fn(IdempotencyTokenProvider, &mut Input) + Send + Sync,
 {

--- a/rust-runtime/inlineable/src/http_checksum_required.rs
+++ b/rust-runtime/inlineable/src/http_checksum_required.rs
@@ -25,7 +25,7 @@ impl RuntimePlugin for HttpChecksumRequiredRuntimePlugin {
 #[derive(Debug)]
 struct HttpChecksumRequiredInterceptor;
 
-impl Interceptor for HttpChecksumRequiredInterceptor {
+impl Intercept for HttpChecksumRequiredInterceptor {
     fn modify_before_signing(
         &self,
         context: &mut BeforeTransmitInterceptorContextMut<'_>,


### PR DESCRIPTION
This PR makes the orchestrator traits more idiomatic by making them verbs.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
