### PR TITLE
Fix vulnerability report from `cargo audit`

### DIFF
--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -25,7 +25,7 @@ aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features =
 
 # used to test compatibility
 async-trait = "0.1.51"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 
 tokio = { version = "1.23.1", features = ["full", "test-util", "rt"] }
 tracing-test = "0.2.4"

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -40,7 +40,7 @@ zeroize = { version = "^1", optional = true }
 aws-credential-types = { path = "../aws-credential-types", features = ["test-util", "hardcoded-credentials"] }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api", features = ["client", "test-util"] }
 bytes = "1"
-criterion = "0.4"
+criterion = "0.5"
 hex-literal = "0.4.1"
 httparse = "1.8"
 libfuzzer-sys = "0.4.6"

--- a/aws/sdk/benchmarks/orchestrator-vs-middleware/Cargo.toml
+++ b/aws/sdk/benchmarks/orchestrator-vs-middleware/Cargo.toml
@@ -10,7 +10,7 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "wiremock"] }
-criterion = { version = "0.4", features = ["async_tokio"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
 http = "0.2.3"
 middleware-s3 = { version = "0.28", package = "aws-sdk-s3", features = ["test-util"] }
 middleware-smithy-client = { version = "0.55.3", package = "aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/dynamodb/Cargo.toml
+++ b/aws/sdk/integration-tests/dynamodb/Cargo.toml
@@ -24,7 +24,7 @@ aws-smithy-runtime-api = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime-ap
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types", features = ["test-util"]}
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 bytes = "1.0.0"
-criterion = { version = "0.4.0" }
+criterion = { version = "0.5.0" }
 futures-util = { version = "0.3.16", default-features = false }
 http = "0.2.0"
 serde_json = "1.0.0"

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -245,7 +245,7 @@ data class CargoDependency(
         val Approx: CargoDependency = CargoDependency("approx", CratesIo("0.5.1"), DependencyScope.Dev)
         val AsyncStd: CargoDependency = CargoDependency("async-std", CratesIo("1.12.0"), DependencyScope.Dev)
         val AsyncStream: CargoDependency = CargoDependency("async-stream", CratesIo("0.3.0"), DependencyScope.Dev)
-        val Criterion: CargoDependency = CargoDependency("criterion", CratesIo("0.4.0"), DependencyScope.Dev)
+        val Criterion: CargoDependency = CargoDependency("criterion", CratesIo("0.5.0"), DependencyScope.Dev)
         val FuturesCore: CargoDependency = CargoDependency("futures-core", CratesIo("0.3.25"), DependencyScope.Dev)
         val FuturesUtil: CargoDependency =
             CargoDependency("futures-util", CratesIo("0.3.25"), DependencyScope.Dev, defaultFeatures = false)

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -25,7 +25,7 @@ time = { version = "0.3.4", features = ["parsing"] }
 [dev-dependencies]
 base64 = "0.13.0"
 ciborium = { version = "0.2.1" }
-criterion = "0.4"
+criterion = "0.5"
 lazy_static = "1.4"
 proptest = "1"
 rand = "0.8.4"


### PR DESCRIPTION
## Motivation and Context
With `cargo-audit` v0.18.2, it reports the following vulnerabilities when run against generated SDKs.
```
$ pwd
<smithy-rs root>/aws/sdk/build/aws-sdk
$ cargo generate-lockfile && cargo audit
...
    Scanning Cargo.lock for vulnerabilities (339 crate dependencies)

Crate:     atty
Version:   0.2.14
Warning:   unsound
Title:     Potential unaligned read
Date:      2021-07-04
ID:        RUSTSEC-2021-0145
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0145
Dependency tree:
atty 0.2.14
├── env_logger 0.9.3
│   └── aws-credential-types 0.56.1
|
...
|___ criterion 0.4.0
```
Both of the latest `env_logger` and `criterion` removed their dependencies on `atty`. This PR, therefore, updates a version of `env_logger` and that of `criterion` within the `smithy-rs` codebase.

## Testing
Ran the above repro steps against SDKs generated from this branch. No vulnerabilities detected.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
