### PR TITLE
Move default endpoint resolver into a runtime plugin

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -408,3 +408,9 @@ message = "`RuntimeComponents` have been added as an argument to the `IdentityRe
 references = ["smithy-rs#2917"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client"}
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "The `idempotency_provider` field has been removed from config as a public field. If you need access to this field, it is still available from the context of an interceptor."
+references = ["smithy-rs#3072"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "rcoh"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ClientCustomizations
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.HttpAuthDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.HttpConnectorConfigDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.customizations.IdempotencyTokenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.NoAuthDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.SensitiveOutputDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
@@ -66,6 +67,7 @@ class RustClientCodegenPlugin : ClientDecoratableBuildPlugin() {
                 HttpAuthDecorator(),
                 HttpConnectorConfigDecorator(),
                 SensitiveOutputDecorator(),
+                IdempotencyTokenDecorator(),
                 *decorator,
             )
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenDecorator.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.customizations
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginSection
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.IdempotencyTokenProviderCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.needsIdempotencyToken
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.util.extendIf
+
+class IdempotencyTokenDecorator : ClientCodegenDecorator {
+    override val name: String = "IdempotencyToken"
+    override val order: Byte = 0
+
+    private fun enabled(ctx: ClientCodegenContext) = ctx.serviceShape.needsIdempotencyToken(ctx.model)
+    override fun configCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<ConfigCustomization>,
+    ): List<ConfigCustomization> = baseCustomizations.extendIf(enabled(codegenContext)) {
+        IdempotencyTokenProviderCustomization(codegenContext)
+    }
+
+    override fun operationCustomizations(
+        codegenContext: ClientCodegenContext,
+        operation: OperationShape,
+        baseCustomizations: List<OperationCustomization>,
+    ): List<OperationCustomization> {
+        return baseCustomizations + IdempotencyTokenGenerator(codegenContext, operation)
+    }
+
+    override fun serviceRuntimePluginCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<ServiceRuntimePluginCustomization>,
+    ): List<ServiceRuntimePluginCustomization> {
+        return baseCustomizations.extendIf(enabled(codegenContext)) {
+            object : ServiceRuntimePluginCustomization() {
+                override fun section(section: ServiceRuntimePluginSection) = writable {
+                    if (section is ServiceRuntimePluginSection.AdditionalConfig) {
+                        section.putConfigValue(this, defaultTokenProvider((codegenContext.runtimeConfig)))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun defaultTokenProvider(runtimeConfig: RuntimeConfig) =
+    writable { rust("#T()", RuntimeType.idempotencyToken(runtimeConfig).resolve("default_provider")) }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenGenerator.kt
@@ -20,6 +20,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.isOptional
+import software.amazon.smithy.rust.codegen.core.util.UNREACHABLE
 import software.amazon.smithy.rust.codegen.core.util.findMemberWithTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 
@@ -53,39 +54,26 @@ class IdempotencyTokenGenerator(
 
         return when (section) {
             is OperationSection.AdditionalRuntimePlugins -> writable {
-                section.addClientPlugin(this) {
-                    if (symbolProvider.toSymbol(idempotencyTokenMember).isOptional()) {
-                        // An idempotency token is optional. If the user didn't specify a token
-                        // then we'll generate one and set it.
-                        rustTemplate(
-                            """
-                            #{IdempotencyTokenRuntimePlugin}::new(|token_provider, input| {
-                                let input: &mut #{Input} = input.downcast_mut().expect("correct type");
-                                if input.$memberName.is_none() {
-                                    input.$memberName = #{Some}(token_provider.make_idempotency_token());
-                                }
-                            })
-                            """,
-                            *codegenScope,
-                        )
-                    } else {
-                        // An idempotency token is required, but it'll be set to an empty string if
-                        // the user didn't specify one. If that's the case, then we'll generate one
-                        // and set it.
-                        rustTemplate(
-                            """
-                            #{IdempotencyTokenRuntimePlugin}::new(|token_provider, input| {
-                                let input: &mut #{Input} = input.downcast_mut().expect("correct type");
-                                if input.$memberName.is_empty() {
-                                    input.$memberName = token_provider.make_idempotency_token();
-                                }
-                            })
-                            """,
-                            *codegenScope,
-                        )
+                section.addOperationRuntimePlugin(this) {
+                    if (!symbolProvider.toSymbol(idempotencyTokenMember).isOptional()) {
+                        UNREACHABLE("top level input members are always optional")
                     }
+                    // An idempotency token is optional. If the user didn't specify a token
+                    // then we'll generate one and set it.
+                    rustTemplate(
+                        """
+                        #{IdempotencyTokenRuntimePlugin}::new(|token_provider, input| {
+                            let input: &mut #{Input} = input.downcast_mut().expect("correct type");
+                            if input.$memberName.is_none() {
+                                input.$memberName = #{Some}(token_provider.make_idempotency_token());
+                            }
+                        })
+                        """,
+                        *codegenScope,
+                    )
                 }
             }
+
             else -> emptySection
         }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenGenerator.kt
@@ -26,7 +26,7 @@ import software.amazon.smithy.rust.codegen.core.util.inputShape
 
 class IdempotencyTokenGenerator(
     codegenContext: CodegenContext,
-    operationShape: OperationShape,
+    private val operationShape: OperationShape,
 ) : OperationCustomization() {
     private val model = codegenContext.model
     private val runtimeConfig = codegenContext.runtimeConfig
@@ -56,7 +56,7 @@ class IdempotencyTokenGenerator(
             is OperationSection.AdditionalRuntimePlugins -> writable {
                 section.addOperationRuntimePlugin(this) {
                     if (!symbolProvider.toSymbol(idempotencyTokenMember).isOptional()) {
-                        UNREACHABLE("top level input members are always optional")
+                        UNREACHABLE("top level input members are always optional. $operationShape")
                     }
                     // An idempotency token is optional. If the user didn't specify a token
                     // then we'll generate one and set it.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenGenerator.kt
@@ -47,12 +47,13 @@ class IdempotencyTokenGenerator(
                     "/inlineable/src/client_idempotency_token.rs",
                     CargoDependency.smithyRuntimeApi(runtimeConfig),
                     CargoDependency.smithyTypes(runtimeConfig),
+                    InlineDependency.idempotencyToken(runtimeConfig),
                 ).toType().resolve("IdempotencyTokenRuntimePlugin"),
         )
 
         return when (section) {
             is OperationSection.AdditionalRuntimePlugins -> writable {
-                section.addOperationRuntimePlugin(this) {
+                section.addClientPlugin(this) {
                     if (symbolProvider.toSymbol(idempotencyTokenMember).isOptional()) {
                         // An idempotency token is optional. If the user didn't specify a token
                         // then we'll generate one and set it.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -10,7 +10,6 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ConnectionPoisoningRuntimePluginCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.HttpChecksumRequiredGenerator
-import software.amazon.smithy.rust.codegen.client.smithy.customizations.IdempotencyTokenGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.InterceptorConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.MetadataCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyConfigCustomization
@@ -50,7 +49,6 @@ class RequiredCustomizations : ClientCodegenDecorator {
     ): List<OperationCustomization> =
         baseCustomizations +
             MetadataCustomization(codegenContext, operation) +
-            IdempotencyTokenGenerator(codegenContext, operation) +
             HttpChecksumRequiredGenerator(codegenContext, operation) +
             RetryClassifierOperationCustomization(codegenContext, operation)
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGenerator.kt
@@ -56,7 +56,8 @@ class ConfigOverrideRuntimePluginGenerator(
                 ) -> Self {
                     let mut layer = config_override.config;
                     let mut components = config_override.runtime_components;
-                    let resolver = #{Resolver}::overrid(initial_config, initial_components, &mut layer, &mut components);
+                    ##[allow(unused_mut)]
+                    let mut resolver = #{Resolver}::overrid(initial_config, initial_components, &mut layer, &mut components);
 
                     #{config}
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGenerator.kt
@@ -56,7 +56,7 @@ class ConfigOverrideRuntimePluginGenerator(
                 ) -> Self {
                     let mut layer = config_override.config;
                     let mut components = config_override.runtime_components;
-                    let mut resolver = #{Resolver}::overrid(initial_config, initial_components, &mut layer, &mut components);
+                    let resolver = #{Resolver}::overrid(initial_config, initial_components, &mut layer, &mut components);
 
                     #{config}
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationCustomization.kt
@@ -95,8 +95,8 @@ sealed class OperationSection(name: String) : Section(name) {
         override val customizations: List<OperationCustomization>,
         val operationShape: OperationShape,
     ) : OperationSection("AdditionalRuntimePlugins") {
-        fun addServiceRuntimePlugin(writer: RustWriter, plugin: Writable) {
-            writer.rustTemplate(".with_service_plugin(#{plugin})", "plugin" to plugin)
+        fun addClientPlugin(writer: RustWriter, plugin: Writable) {
+            writer.rustTemplate(".with_client_plugin(#{plugin})", "plugin" to plugin)
         }
 
         fun addOperationRuntimePlugin(writer: RustWriter, plugin: Writable) {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.client.smithy.generators
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.isNotEmpty
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
@@ -16,6 +17,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.pre
 import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
+import software.amazon.smithy.rust.codegen.core.util.dq
 
 sealed class ServiceRuntimePluginSection(name: String) : Section(name) {
     /**
@@ -24,6 +26,16 @@ sealed class ServiceRuntimePluginSection(name: String) : Section(name) {
      * Examples include token buckets, ID generators, etc.
      */
     class DeclareSingletons : ServiceRuntimePluginSection("DeclareSingletons")
+
+    /**
+     * Hook for adding additional things to config inside service runtime plugins.
+     */
+    data class AdditionalConfig(val newLayerName: String, val serviceConfigName: String) : ServiceRuntimePluginSection("AdditionalConfig") {
+        /** Adds a value to the config bag */
+        fun putConfigValue(writer: RustWriter, value: Writable) {
+            writer.rust("$newLayerName.store_put(#T);", value)
+        }
+    }
 
     data class RegisterRuntimeComponents(val serviceConfigName: String) : ServiceRuntimePluginSection("RegisterRuntimeComponents") {
         /** Generates the code to register an interceptor */
@@ -69,6 +81,7 @@ class ServiceRuntimePluginGenerator(
             "Layer" to smithyTypes.resolve("config_bag::Layer"),
             "RuntimeComponentsBuilder" to RuntimeType.runtimeComponentsBuilder(rc),
             "RuntimePlugin" to RuntimeType.runtimePlugin(rc),
+            "Order" to runtimeApi.resolve("client::runtime_plugin::Order"),
         )
     }
 
@@ -76,24 +89,33 @@ class ServiceRuntimePluginGenerator(
         writer: RustWriter,
         customizations: List<ServiceRuntimePluginCustomization>,
     ) {
+        val additionalConfig = writable {
+            writeCustomizations(customizations, ServiceRuntimePluginSection.AdditionalConfig("cfg", "_service_config"))
+        }
         writer.rustTemplate(
             """
             ##[derive(::std::fmt::Debug)]
             pub(crate) struct ServiceRuntimePlugin {
+                config: #{Option}<#{FrozenLayer}>,
                 runtime_components: #{RuntimeComponentsBuilder},
             }
 
             impl ServiceRuntimePlugin {
                 pub fn new(_service_config: crate::config::Config) -> Self {
+                    let config = { #{config} };
                     let mut runtime_components = #{RuntimeComponentsBuilder}::new("ServiceRuntimePlugin");
                     #{runtime_components}
-                    Self { runtime_components }
+                    Self { config, runtime_components }
                 }
             }
 
             impl #{RuntimePlugin} for ServiceRuntimePlugin {
                 fn config(&self) -> #{Option}<#{FrozenLayer}> {
-                    None
+                    self.config.clone()
+                }
+
+                fn order(&self) -> #{Order} {
+                    #{Order}::Defaults
                 }
 
                 fn runtime_components(&self, _: &#{RuntimeComponentsBuilder}) -> #{Cow}<'_, #{RuntimeComponentsBuilder}> {
@@ -105,6 +127,21 @@ class ServiceRuntimePluginGenerator(
             #{declare_singletons}
             """,
             *codegenScope,
+            "config" to writable {
+                if (additionalConfig.isNotEmpty()) {
+                    rustTemplate(
+                        """
+                        let mut cfg = #{Layer}::new(${codegenContext.serviceShape.id.name.dq()});
+                        #{additional_config}
+                        #{Some}(cfg.freeze())
+                        """,
+                        *codegenScope,
+                        "additional_config" to additionalConfig,
+                    )
+                } else {
+                    rust("None")
+                }
+            },
             "runtime_components" to writable {
                 writeCustomizations(customizations, ServiceRuntimePluginSection.RegisterRuntimeComponents("_service_config"))
             },

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
@@ -21,7 +21,6 @@ class IdempotencyTokenProviderCustomization(codegenContext: ClientCodegenContext
     private val runtimeConfig = codegenContext.runtimeConfig
     private val codegenScope = arrayOf(
         *preludeScope,
-        "default_provider" to RuntimeType.idempotencyToken(runtimeConfig).resolve("default_provider"),
         "IdempotencyTokenProvider" to RuntimeType.idempotencyToken(runtimeConfig).resolve("IdempotencyTokenProvider"),
     )
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
@@ -27,20 +27,6 @@ class IdempotencyTokenProviderCustomization(codegenContext: ClientCodegenContext
 
     override fun section(section: ServiceConfig): Writable {
         return when (section) {
-            ServiceConfig.ConfigImpl -> writable {
-                rustTemplate(
-                    """
-                    /// Returns a copy of the idempotency token provider.
-                    /// If a random token provider was configured,
-                    /// a newly-randomized token provider will be returned.
-                    pub fn idempotency_token_provider(&self) -> #{IdempotencyTokenProvider} {
-                        self.config.load::<#{IdempotencyTokenProvider}>().expect("the idempotency provider should be set").clone()
-                    }
-                    """,
-                    *codegenScope,
-                )
-            }
-
             ServiceConfig.BuilderImpl -> writable {
                 rustTemplate(
                     """
@@ -59,17 +45,6 @@ class IdempotencyTokenProviderCustomization(codegenContext: ClientCodegenContext
                     pub fn set_idempotency_token_provider(&mut self, idempotency_token_provider: #{Option}<#{IdempotencyTokenProvider}>) -> &mut Self {
                         self.config.store_or_unset(idempotency_token_provider);
                         self
-                    }
-                    """,
-                    *codegenScope,
-                )
-            }
-
-            ServiceConfig.BuilderBuild -> writable {
-                rustTemplate(
-                    """
-                    if !resolver.is_set::<#{IdempotencyTokenProvider}>() {
-                        resolver.config_mut().store_put(#{default_provider}());
                     }
                     """,
                     *codegenScope,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -257,9 +257,6 @@ class ServiceConfigGenerator(
             extraCustomizations: List<ConfigCustomization>,
         ): ServiceConfigGenerator {
             val baseFeatures = mutableListOf<ConfigCustomization>()
-            if (codegenContext.serviceShape.needsIdempotencyToken(codegenContext.model)) {
-                baseFeatures.add(IdempotencyTokenProviderCustomization(codegenContext))
-            }
             return ServiceConfigGenerator(codegenContext, baseFeatures + extraCustomizations)
         }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -419,7 +419,6 @@ class ServiceConfigGenerator(
                 rustTemplate(
                     """
                     let mut layer = self.config;
-                    let mut resolver = #{Resolver}::initial(&mut layer, &mut self.runtime_components);
                     """,
                     *codegenScope,
                 )

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ConfigOverrideRuntimePluginGeneratorTest.kt
@@ -45,33 +45,21 @@ internal class ConfigOverrideRuntimePluginGeneratorTest {
                     .resolve("client::endpoint::EndpointResolverParams"),
                 "RuntimePlugin" to RuntimeType.runtimePlugin(runtimeConfig),
                 "RuntimeComponentsBuilder" to RuntimeType.runtimeComponentsBuilder(runtimeConfig),
+                "capture_request" to RuntimeType.captureRequest(runtimeConfig),
             )
             rustCrate.testModule {
                 addDependency(CargoDependency.Tokio.toDevDependency().withFeature("test-util"))
                 tokioTest("test_operation_overrides_endpoint_resolver") {
                     rustTemplate(
                         """
-                        use #{RuntimePlugin};
-                        use ::aws_smithy_runtime_api::client::endpoint::EndpointResolver;
-
                         let expected_url = "http://localhost:1234/";
-                        let client_config = crate::config::Config::builder().build();
+                        let (http_client, req) = #{capture_request}(None);
+                        let client_config = crate::config::Config::builder().http_client(http_client).build();
                         let config_override =
                             crate::config::Config::builder().endpoint_resolver(expected_url);
-                        let sut = crate::config::ConfigOverrideRuntimePlugin::new(
-                            config_override,
-                            client_config.config,
-                            &client_config.runtime_components,
-                        );
-                        let prev = #{RuntimeComponentsBuilder}::new("prev");
-                        let sut_components = sut.runtime_components(&prev);
-                        let endpoint_resolver = sut_components.endpoint_resolver().unwrap();
-                        let endpoint = endpoint_resolver
-                            .resolve_endpoint(&#{EndpointResolverParams}::new(crate::config::endpoint::Params {}))
-                            .await
-                            .unwrap();
-
-                        assert_eq!(expected_url, endpoint.url());
+                        let client = crate::Client::from_conf(client_config);
+                        let _ = dbg!(client.say_hello().customize().config_override(config_override).send().await);
+                        assert_eq!("http://localhost:1234/", req.expect_request().uri());
                         """,
                         *codegenScope,
                     )

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
@@ -226,6 +226,7 @@ internal class XmlBindingTraitSerializerGeneratorTest {
             member: Top
         }
 
+        @input
         structure OpInput {
             @required
             @httpPayload

--- a/rust-runtime/aws-smithy-http/src/endpoint.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint.rs
@@ -65,10 +65,6 @@ impl<T> From<Arc<dyn ResolveEndpoint<T>>> for SharedEndpointResolver<T> {
     }
 }
 
-impl<T: 'static> Storable for SharedEndpointResolver<T> {
-    type Storer = StoreReplace<SharedEndpointResolver<T>>;
-}
-
 impl<T> ResolveEndpoint<T> for SharedEndpointResolver<T> {
     fn resolve_endpoint(&self, params: &T) -> Result {
         self.0.resolve_endpoint(params)

--- a/rust-runtime/inlineable/src/client_idempotency_token.rs
+++ b/rust-runtime/inlineable/src/client_idempotency_token.rs
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::idempotency_token::IdempotencyTokenProvider;
+use std::borrow::Cow;
+use std::fmt;
+
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeSerializationInterceptorContextMut, Input,
@@ -14,8 +16,8 @@ use aws_smithy_runtime_api::client::runtime_components::{
 };
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
 use aws_smithy_types::config_bag::ConfigBag;
-use std::borrow::Cow;
-use std::fmt;
+
+use crate::idempotency_token::IdempotencyTokenProvider;
 
 #[derive(Debug)]
 pub(crate) struct IdempotencyTokenRuntimePlugin {

--- a/rust-runtime/inlineable/src/idempotency_token.rs
+++ b/rust-runtime/inlineable/src/idempotency_token.rs
@@ -31,7 +31,7 @@ pub(crate) fn uuid_v4(input: u128) -> String {
     out
 }
 
-/// IdempotencyTokenProvider generates idempotency tokens for idempotency API requests
+/// IdempotencyTokenProvider generates idempotency tokens for idempotent API requests
 ///
 /// Generally, customers will not need to interact with this at all. A sensible default will be
 /// provided automatically during config construction. However, if you need deterministic behavior


### PR DESCRIPTION
## Motivation and Context
In preparation for inlining the old endpoint traits, I'm cleaning up the endpoint resolver behavior.

## Description

1. The `Config` field of `service_runtime_plugin` was unused to I deleted it
2. Store the endpoint resolver in `RuntimeComponents` instead of in operation config. This allows a lot of complex logic around `ConfigOverride` to be removed.
3. Move the default endpoint resolver into a runtime plugin.
4. Don't have a fallback implementation for `EndpointResolver`, allow final construction of `RuntimeComponents` to fail
5. `ServiceRuntimePlugin` has been changed to `Defaults` so that it doesn't overwrite settings set by the service config


## Testing
Well covered by existing UT / IT
## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
