### PR TITLE
Upgrade Smithy to 1.40 and ignore __type in unions

### DIFF
--- a/codegen-client-test/model/rest-xml-extras.smithy
+++ b/codegen-client-test/model/rest-xml-extras.smithy
@@ -74,9 +74,6 @@ structure PrimitiveIntDocument {
     defaultedValue: PrimitiveInt
 }
 
-@enum([{"value": "enumvalue", "name": "V"}])
-string StringEnum
-
 integer PrimitiveInt
 
 structure AttributePartyInputOutput {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -543,9 +543,6 @@ class DefaultProtocolTestGenerator(
             "SDKAppliedContentEncoding_ec2Query",
             "SDKAppliedContentEncoding_restJson1",
             "SDKAppliedContentEncoding_restXml",
-            "AwsJson11DeserializeIgnoreType",
-            "AwsJson10DeserializeIgnoreType",
-            "RestJsonDeserializeIgnoreType",
         )
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
@@ -551,13 +551,18 @@ class JsonParserGenerator(
                         objectKeyLoop(hasMembers = shape.members().isNotEmpty()) {
                             rustTemplate(
                                 """
+                                let key = key.to_unescaped()?;
+                                if key == "__type" {
+                                    #{skip_value}(tokens)?;
+                                    continue
+                                }
                                 if variant.is_some() {
                                     return Err(#{Error}::custom("encountered mixed variants in union"));
                                 }
                                 """,
                                 *codegenScope,
                             )
-                            withBlock("variant = match key.to_unescaped()?.as_ref() {", "};") {
+                            withBlock("variant = match key.as_ref() {", "};") {
                                 for (member in shape.members()) {
                                     val variantName = symbolProvider.toMemberName(member)
                                     rustBlock("${jsonName(member).dq()} =>") {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
@@ -171,6 +171,17 @@ class JsonParserGeneratorTest {
             )
 
             unitTest(
+                "dunder_type_should_be_ignored",
+                """
+                // __type field should be ignored during deserialization
+                let input = br#"{ "top": { "choice": { "int": 5, "__type": "value-should-be-ignored-anyway" } } }"#;
+                let output = ${format(operationGenerator)}(input, test_output::OpOutput::builder()).unwrap().build();
+                use test_model::Choice;
+                assert_eq!(Choice::Int(5), output.top.unwrap().choice);
+                """,
+            )
+
+            unitTest(
                 "empty_error",
                 """
                 // empty error

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlin.code.style=official
 
 # codegen
 smithyGradlePluginVersion=0.7.0
-smithyVersion=1.39.0
+smithyVersion=1.40.0
 
 # kotlin
 kotlinVersion=1.7.21


### PR DESCRIPTION
## Motivation and Context
> JSON object. A union is serialized identically as a ``structure``
        shape, but only a single member can be set to a non-null value.
        Deserializers MUST ignore an unrecognized ``__type`` member if present.

[source](https://github.com/smithy-lang/smithy/blob/main/docs/source-2.0/aws/protocols/aws-json.rst.template#L133-L135)

## Description
- upgrade to smithy 1.40
- unignore protocol tests
- fix JSON deserializers
## Testing
- protocol tests + extra unit tests

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
