### PR TITLE
Allow cloning a Presigned Request

### DIFF
--- a/rust-runtime/aws-smithy-runtime-api/src/client/http/request.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/http/request.rs
@@ -230,6 +230,17 @@ impl Request<SdkBody> {
         })
     }
 
+    /// Creates an empty clone of this request, that is, the same URI, method, and headers but no body or extensions.
+    pub fn empty_clone(&self) -> Self {
+        Self {
+            body: SdkBody::empty(),
+            uri: self.uri.clone(),
+            method: self.method.clone(),
+            extensions: Extensions::new(),
+            headers: self.headers.clone(),
+        }
+    }
+
     /// Replaces this requests body with [`SdkBody::taken()`]
     pub fn take_body(&mut self) -> SdkBody {
         std::mem::replace(self.body_mut(), SdkBody::taken())


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This allows SDK users to clone a PresignedRequest.

<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

PresignedRequests come from S3 and Polly. They represent capabilities to perform some action in S3 or Polly on behalf of an AWS account, in a very limited scope. For instance, a presigned PUT request includes capability information for a client to copy the URI and headers and make an HTTP PUT request with their own body.

## Testing
<!--- Please describe in detail how you tested your changes -->

Included unit tests.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
