### PR TITLE
Fix bug where Custom Auth Schemes were not respected

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -468,3 +468,9 @@ message = "Clients now have a default async sleep implementation so that one doe
 references = ["smithy-rs#3071"]
 meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "client" }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "Enable custom auth schemes to work by changing the code generated auth options to be set at the client level at `DEFAULTS` priority."
+references = ["smithy-rs#3034", "smithy-rs#3087"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
+author = "rcoh"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -35,24 +35,35 @@ import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.hasEventStreamOperations
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.isInputEventStream
+import software.amazon.smithy.rust.codegen.core.util.thenSingletonListOf
 
 class SigV4AuthDecorator : ClientCodegenDecorator {
     override val name: String get() = "SigV4AuthDecorator"
     override val order: Byte = 0
 
+    private fun sigv4(runtimeConfig: RuntimeConfig) = writable {
+        val awsRuntimeAuthModule = AwsRuntimeType.awsRuntime(runtimeConfig).resolve("auth")
+        rust("#T", awsRuntimeAuthModule.resolve("sigv4::SCHEME_ID"))
+    }
+
+    private fun sigv4a(runtimeConfig: RuntimeConfig) = writable {
+        val awsRuntimeAuthModule = AwsRuntimeType.awsRuntime(runtimeConfig).resolve("auth")
+        featureGateBlock("sigv4a") {
+            rust("#T", awsRuntimeAuthModule.resolve("sigv4a::SCHEME_ID"))
+        }
+    }
+
     override fun authOptions(
         codegenContext: ClientCodegenContext,
         operationShape: OperationShape,
         baseAuthSchemeOptions: List<AuthSchemeOption>,
-    ): List<AuthSchemeOption> = baseAuthSchemeOptions + AuthSchemeOption.StaticAuthSchemeOption(SigV4Trait.ID) {
-        val awsRuntimeAuthModule = AwsRuntimeType.awsRuntime(codegenContext.runtimeConfig).resolve("auth")
-        rust("#T,", awsRuntimeAuthModule.resolve("sigv4::SCHEME_ID"))
-        if (codegenContext.serviceShape.supportedAuthSchemes().contains("sigv4a")) {
-            featureGateBlock("sigv4a") {
-                rust("#T", awsRuntimeAuthModule.resolve("sigv4a::SCHEME_ID"))
-            }
-            rust(",")
-        }
+    ): List<AuthSchemeOption> {
+        val supportsSigV4a = codegenContext.serviceShape.supportedAuthSchemes().contains("sig4a")
+            .thenSingletonListOf { sigv4a(codegenContext.runtimeConfig) }
+        return baseAuthSchemeOptions + AuthSchemeOption.StaticAuthSchemeOption(
+            SigV4Trait.ID,
+            listOf(sigv4(codegenContext.runtimeConfig)) + supportsSigV4a,
+        )
     }
 
     override fun serviceRuntimePluginCustomizations(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -41,6 +41,8 @@ class SigV4AuthDecorator : ClientCodegenDecorator {
     override val name: String get() = "SigV4AuthDecorator"
     override val order: Byte = 0
 
+    private val sigv4a = "sigv4a"
+
     private fun sigv4(runtimeConfig: RuntimeConfig) = writable {
         val awsRuntimeAuthModule = AwsRuntimeType.awsRuntime(runtimeConfig).resolve("auth")
         rust("#T", awsRuntimeAuthModule.resolve("sigv4::SCHEME_ID"))
@@ -48,7 +50,7 @@ class SigV4AuthDecorator : ClientCodegenDecorator {
 
     private fun sigv4a(runtimeConfig: RuntimeConfig) = writable {
         val awsRuntimeAuthModule = AwsRuntimeType.awsRuntime(runtimeConfig).resolve("auth")
-        featureGateBlock("sigv4a") {
+        featureGateBlock(sigv4a) {
             rust("#T", awsRuntimeAuthModule.resolve("sigv4a::SCHEME_ID"))
         }
     }
@@ -58,7 +60,7 @@ class SigV4AuthDecorator : ClientCodegenDecorator {
         operationShape: OperationShape,
         baseAuthSchemeOptions: List<AuthSchemeOption>,
     ): List<AuthSchemeOption> {
-        val supportsSigV4a = codegenContext.serviceShape.supportedAuthSchemes().contains("sig4a")
+        val supportsSigV4a = codegenContext.serviceShape.supportedAuthSchemes().contains(sigv4a)
             .thenSingletonListOf { sigv4a(codegenContext.runtimeConfig) }
         return baseAuthSchemeOptions + AuthSchemeOption.StaticAuthSchemeOption(
             SigV4Trait.ID,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
@@ -97,9 +97,11 @@ class HttpAuthDecorator : ClientCodegenDecorator {
                 options.add(
                     StaticAuthSchemeOption(
                         schemeShapeId,
-                        writable {
-                            rustTemplate("$name,", *codegenScope)
-                        },
+                        listOf(
+                            writable {
+                                rustTemplate(name, *codegenScope)
+                            },
+                        ),
                     ),
                 )
             }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/NoAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/NoAuthDecorator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.customize.AuthSchemeOpt
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 
 val noAuthSchemeShapeId: ShapeId = ShapeId.from("aws.smithy.rs#NoAuth")
@@ -30,10 +31,15 @@ class NoAuthDecorator : ClientCodegenDecorator {
         operationShape: OperationShape,
         baseAuthSchemeOptions: List<AuthSchemeOption>,
     ): List<AuthSchemeOption> = baseAuthSchemeOptions +
-        AuthSchemeOption.StaticAuthSchemeOption(noAuthSchemeShapeId) {
-            rustTemplate(
-                "#{NO_AUTH_SCHEME_ID},",
-                "NO_AUTH_SCHEME_ID" to noAuthModule(codegenContext).resolve("NO_AUTH_SCHEME_ID"),
-            )
-        }
+        AuthSchemeOption.StaticAuthSchemeOption(
+            noAuthSchemeShapeId,
+            listOf(
+                writable {
+                    rustTemplate(
+                        "#{NO_AUTH_SCHEME_ID}",
+                        "NO_AUTH_SCHEME_ID" to noAuthModule(codegenContext).resolve("NO_AUTH_SCHEME_ID"),
+                    )
+                },
+            ),
+        )
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/ClientCodegenDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/ClientCodegenDecorator.kt
@@ -30,7 +30,7 @@ sealed interface AuthSchemeOption {
     /** Auth scheme for the `StaticAuthSchemeOptionResolver` */
     data class StaticAuthSchemeOption(
         val schemeShapeId: ShapeId,
-        val constructor: Writable,
+        val constructor: List<Writable>,
     ) : AuthSchemeOption
 
     class CustomResolver(/* unimplemented */) : AuthSchemeOption

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/AuthOptionsPluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/AuthOptionsPluginGenerator.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.generators
+
+import software.amazon.smithy.model.knowledge.ServiceIndex
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.traits.OptionalAuthTrait
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customizations.noAuthSchemeShapeId
+import software.amazon.smithy.rust.codegen.client.smithy.customize.AuthSchemeOption
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.isEmpty
+import software.amazon.smithy.rust.codegen.core.rustlang.join
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.util.PANIC
+import software.amazon.smithy.rust.codegen.core.util.hasTrait
+import java.util.logging.Logger
+
+class AuthOptionsPluginGenerator(private val codegenContext: ClientCodegenContext) {
+    private val runtimeConfig = codegenContext.runtimeConfig
+
+    private val logger: Logger = Logger.getLogger(javaClass.name)
+    fun authPlugin(operationShape: OperationShape, authSchemeOptions: List<AuthSchemeOption>) = writable {
+        rustTemplate(
+            """
+            #{DefaultAuthOptionsPlugin}::new(vec![#{options}])
+
+            """,
+            "DefaultAuthOptionsPlugin" to RuntimeType.defaultAuthPlugin(runtimeConfig),
+            "options" to actualAuthSchemes(operationShape, authSchemeOptions).join(", "),
+        )
+    }
+
+    private fun actualAuthSchemes(operationShape: OperationShape, authSchemeOptions: List<AuthSchemeOption>): List<Writable> {
+        val out: MutableList<Writable> = mutableListOf()
+
+        var noSupportedAuthSchemes = true
+        val authSchemes = ServiceIndex.of(codegenContext.model)
+            .getEffectiveAuthSchemes(codegenContext.serviceShape, operationShape)
+
+        for (schemeShapeId in authSchemes.keys) {
+            val optionsForScheme = authSchemeOptions.filter {
+                when (it) {
+                    is AuthSchemeOption.CustomResolver -> false
+                    is AuthSchemeOption.StaticAuthSchemeOption -> {
+                        it.schemeShapeId == schemeShapeId
+                    }
+                }
+            }
+
+            if (optionsForScheme.isNotEmpty()) {
+                out.addAll(optionsForScheme.flatMap { (it as AuthSchemeOption.StaticAuthSchemeOption).constructor })
+                noSupportedAuthSchemes = false
+            } else {
+                logger.warning(
+                    "No auth scheme implementation available for $schemeShapeId. " +
+                        "The generated client will not attempt to use this auth scheme.",
+                )
+            }
+        }
+        if (operationShape.hasTrait<OptionalAuthTrait>() || noSupportedAuthSchemes) {
+            val authOption = authSchemeOptions.find {
+                it is AuthSchemeOption.StaticAuthSchemeOption && it.schemeShapeId == noAuthSchemeShapeId
+            }
+                ?: throw IllegalStateException("Missing 'no auth' implementation. This is a codegen bug.")
+            out += (authOption as AuthSchemeOption.StaticAuthSchemeOption).constructor
+        }
+        if (out.any { it.isEmpty() }) {
+            PANIC("Got an empty auth scheme constructor. This is a bug. $out")
+        }
+        return out
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
@@ -51,7 +51,8 @@ open class OperationGenerator(
         operationShape: OperationShape,
         codegenDecorator: ClientCodegenDecorator,
     ) {
-        val operationCustomizations = codegenDecorator.operationCustomizations(codegenContext, operationShape, emptyList())
+        val operationCustomizations =
+            codegenDecorator.operationCustomizations(codegenContext, operationShape, emptyList())
         renderOperationStruct(
             operationWriter,
             operationShape,
@@ -94,13 +95,21 @@ open class OperationGenerator(
                 "Operation" to symbolProvider.toSymbol(operationShape),
                 "OperationError" to errorType,
                 "OperationOutput" to outputType,
-                "HttpResponse" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::orchestrator::HttpResponse"),
+                "HttpResponse" to RuntimeType.smithyRuntimeApi(runtimeConfig)
+                    .resolve("client::orchestrator::HttpResponse"),
                 "SdkError" to RuntimeType.sdkError(runtimeConfig),
             )
             val additionalPlugins = writable {
                 writeCustomizations(
                     operationCustomizations,
                     OperationSection.AdditionalRuntimePlugins(operationCustomizations, operationShape),
+                )
+                rustTemplate(
+                    ".with_client_plugin(#{auth_plugin})",
+                    "auth_plugin" to AuthOptionsPluginGenerator(codegenContext).authPlugin(
+                        operationShape,
+                        authSchemeOptions,
+                    ),
                 )
             }
             rustTemplate(
@@ -157,11 +166,13 @@ open class OperationGenerator(
                 *codegenScope,
                 "Error" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::interceptors::context::Error"),
                 "InterceptorContext" to RuntimeType.interceptorContext(runtimeConfig),
-                "OrchestratorError" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::orchestrator::error::OrchestratorError"),
+                "OrchestratorError" to RuntimeType.smithyRuntimeApi(runtimeConfig)
+                    .resolve("client::orchestrator::error::OrchestratorError"),
                 "RuntimePlugin" to RuntimeType.runtimePlugin(runtimeConfig),
                 "RuntimePlugins" to RuntimeType.runtimePlugins(runtimeConfig),
                 "StopPoint" to RuntimeType.smithyRuntime(runtimeConfig).resolve("client::orchestrator::StopPoint"),
-                "invoke_with_stop_point" to RuntimeType.smithyRuntime(runtimeConfig).resolve("client::orchestrator::invoke_with_stop_point"),
+                "invoke_with_stop_point" to RuntimeType.smithyRuntime(runtimeConfig)
+                    .resolve("client::orchestrator::invoke_with_stop_point"),
                 "additional_runtime_plugins" to writable {
                     if (additionalPlugins.isNotEmpty()) {
                         rustTemplate(
@@ -182,7 +193,6 @@ open class OperationGenerator(
             operationWriter,
             operationShape,
             operationName,
-            authSchemeOptions,
             operationCustomizations,
         )
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationRuntimePluginGenerator.kt
@@ -5,23 +5,15 @@
 
 package software.amazon.smithy.rust.codegen.client.smithy.generators
 
-import software.amazon.smithy.model.knowledge.ServiceIndex
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.traits.OptionalAuthTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
-import software.amazon.smithy.rust.codegen.client.smithy.customizations.noAuthSchemeShapeId
-import software.amazon.smithy.rust.codegen.client.smithy.customize.AuthSchemeOption
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
-import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
-import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
 import software.amazon.smithy.rust.codegen.core.util.dq
-import software.amazon.smithy.rust.codegen.core.util.hasTrait
-import java.util.logging.Logger
 
 /**
  * Generates operation-level runtime plugins
@@ -29,7 +21,6 @@ import java.util.logging.Logger
 class OperationRuntimePluginGenerator(
     private val codegenContext: ClientCodegenContext,
 ) {
-    private val logger: Logger = Logger.getLogger(javaClass.name)
     private val codegenScope = codegenContext.runtimeConfig.let { rc ->
         val runtimeApi = RuntimeType.smithyRuntimeApi(rc)
         val smithyTypes = RuntimeType.smithyTypes(rc)
@@ -57,7 +48,6 @@ class OperationRuntimePluginGenerator(
         writer: RustWriter,
         operationShape: OperationShape,
         operationStructName: String,
-        authSchemeOptions: List<AuthSchemeOption>,
         customizations: List<OperationCustomization>,
     ) {
         writer.rustTemplate(
@@ -80,7 +70,6 @@ class OperationRuntimePluginGenerator(
                 fn runtime_components(&self, _: &#{RuntimeComponentsBuilder}) -> #{Cow}<'_, #{RuntimeComponentsBuilder}> {
                     #{Cow}::Owned(
                         #{RuntimeComponentsBuilder}::new(${operationShape.id.name.dq()})
-                            #{auth_options}
                             #{interceptors}
                             #{retry_classifiers}
                     )
@@ -91,7 +80,6 @@ class OperationRuntimePluginGenerator(
             """,
             *codegenScope,
             *preludeScope,
-            "auth_options" to generateAuthOptions(operationShape, authSchemeOptions),
             "additional_config" to writable {
                 writeCustomizations(
                     customizations,
@@ -121,56 +109,5 @@ class OperationRuntimePluginGenerator(
                 )
             },
         )
-    }
-
-    private fun generateAuthOptions(
-        operationShape: OperationShape,
-        authSchemeOptions: List<AuthSchemeOption>,
-    ): Writable = writable {
-        if (authSchemeOptions.any { it is AuthSchemeOption.CustomResolver }) {
-            throw IllegalStateException("AuthSchemeOption.CustomResolver is unimplemented")
-        } else {
-            withBlockTemplate(
-                """
-                .with_auth_scheme_option_resolver(#{Some}(
-                    #{SharedAuthSchemeOptionResolver}::new(
-                        #{StaticAuthSchemeOptionResolver}::new(vec![
-                """,
-                "]))))",
-                *codegenScope,
-            ) {
-                var noSupportedAuthSchemes = true
-                val authSchemes = ServiceIndex.of(codegenContext.model)
-                    .getEffectiveAuthSchemes(codegenContext.serviceShape, operationShape)
-
-                for (schemeShapeId in authSchemes.keys) {
-                    val optionsForScheme = authSchemeOptions.filter {
-                        when (it) {
-                            is AuthSchemeOption.CustomResolver -> false
-                            is AuthSchemeOption.StaticAuthSchemeOption -> {
-                                it.schemeShapeId == schemeShapeId
-                            }
-                        }
-                    }
-
-                    if (optionsForScheme.isNotEmpty()) {
-                        optionsForScheme.forEach { (it as AuthSchemeOption.StaticAuthSchemeOption).constructor(this) }
-                        noSupportedAuthSchemes = false
-                    } else {
-                        logger.warning(
-                            "No auth scheme implementation available for $schemeShapeId. " +
-                                "The generated client will not attempt to use this auth scheme.",
-                        )
-                    }
-                }
-                if (operationShape.hasTrait<OptionalAuthTrait>() || noSupportedAuthSchemes) {
-                    val authOption = authSchemeOptions.find {
-                        it is AuthSchemeOption.StaticAuthSchemeOption && it.schemeShapeId == noAuthSchemeShapeId
-                    }
-                        ?: throw IllegalStateException("Missing 'no auth' implementation. This is a codegen bug.")
-                    (authOption as AuthSchemeOption.StaticAuthSchemeOption).constructor(this)
-                }
-            }
-        }
     }
 }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecoratorTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.raw
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
@@ -93,6 +94,139 @@ class HttpAuthDecoratorTest {
                     }
                     """,
                     *codegenScope(codegenContext.runtimeConfig),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun noAuthCustomAuth() {
+        clientIntegrationTest(TestModels.noSchemes) { ctx, rustCrate ->
+            rustCrate.integrationTest("custom_auth_scheme_works") {
+                val moduleName = ctx.moduleUseName()
+                raw(
+                    """
+                    use aws_smithy_runtime_api::client::auth::static_resolver::StaticAuthSchemeOptionResolver;
+                    use aws_smithy_runtime_api::client::auth::AuthScheme;
+                    use aws_smithy_runtime_api::client::auth::{AuthSchemeId, Sign};
+                    use aws_smithy_runtime_api::client::identity::{
+                        IdentityFuture, ResolveIdentity, SharedIdentityResolver,
+                    };
+                    use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+                    use aws_smithy_runtime_api::client::runtime_components::{
+                        GetIdentityResolver, RuntimeComponentsBuilder,
+                    };
+                    use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
+                    use aws_smithy_types::config_bag::ConfigBag;
+                    use std::borrow::Cow;
+                    #[derive(Debug)]
+                    struct CustomAuthRuntimePlugin {
+                        components: RuntimeComponentsBuilder,
+                    }
+
+                    impl RuntimePlugin for CustomAuthRuntimePlugin {
+                        fn runtime_components(
+                            &self,
+                            _current_components: &RuntimeComponentsBuilder,
+                        ) -> Cow<'_, RuntimeComponentsBuilder> {
+                            Cow::Borrowed(&self.components)
+                        }
+                    }
+
+                    #[derive(Debug)]
+                    struct TestAuthScheme;
+
+                    impl AuthScheme for TestAuthScheme {
+                        fn scheme_id(&self) -> AuthSchemeId {
+                            todo!()
+                        }
+
+                        fn identity_resolver(
+                            &self,
+                            _identity_resolvers: &dyn GetIdentityResolver,
+                        ) -> Option<SharedIdentityResolver> {
+                            todo!()
+                        }
+
+                        fn signer(&self) -> &dyn Sign {
+                            todo!()
+                        }
+                    }
+
+                    #[derive(Debug)]
+                    struct TestResolver;
+                    impl ResolveIdentity for TestResolver {
+                        fn resolve_identity<'a>(
+                            &'a self,
+                            _runtime_components: &'a RuntimeComponents,
+                            _config_bag: &'a ConfigBag,
+                        ) -> IdentityFuture<'a> {
+                            todo!()
+                        }
+                    }
+
+                    impl CustomAuthRuntimePlugin {
+                        pub fn new() -> Self {
+                            let scheme_id = AuthSchemeId::new("basicauth");
+                            Self {
+                                components: RuntimeComponentsBuilder::new("test-auth-scheme")
+                                    // Register our auth scheme
+                                    .with_auth_scheme(TestAuthScheme)
+                                    // Register our identity resolver with our auth scheme ID
+                                    .with_identity_resolver(
+                                        // This scheme ID needs to match the scheme ID returned in the auth scheme implementation
+                                        scheme_id,
+                                        TestResolver,
+                                    )
+                                    // Set the auth scheme option resolver to always use our basic auth auth scheme
+                                    .with_auth_scheme_option_resolver(Some(StaticAuthSchemeOptionResolver::new(vec![
+                                        scheme_id,
+                                    ]))),
+                            }
+                        }
+                    }
+
+                    #[test]
+                    fn compile() {}
+
+                    """,
+
+                )
+                Attribute.TokioTest.render(this)
+                rustTemplate(
+                    """
+                    async fn apply_custom_auth_scheme() {
+                        let (_guard, rx) = #{capture_test_logs}();
+                        let http_client = #{StaticReplayClient}::new(
+                            vec![#{ReplayEvent}::new(
+                                http::Request::builder()
+                                    .header("authorization", "Basic c29tZS11c2VyOnNvbWUtcGFzcw==")
+                                    .uri("http://localhost:1234/SomeOperation")
+                                    .body(#{SdkBody}::empty())
+                                    .unwrap(),
+                                http::Response::builder().status(200).body(#{SdkBody}::empty()).unwrap(),
+                            )],
+                        );
+                        let config = $moduleName::Config::builder()
+                            .endpoint_url("http://localhost:1234")
+                            .http_client(http_client.clone())
+                            .runtime_plugin(CustomAuthRuntimePlugin::new())
+                            .build();
+                        let client = $moduleName::Client::from_conf(config);
+                        let req = client.some_operation()
+                            .send()
+                            .await;
+
+                        println!("{}", rx.contents());
+                        req.unwrap();
+                        panic!()
+
+
+                    }
+                    """,
+                    "capture_test_logs" to CargoDependency.smithyRuntimeTestUtil(ctx.runtimeConfig).toType()
+                        .resolve("test_util::capture_test_logs::capture_test_logs"),
+                    *codegenScope(ctx.runtimeConfig),
                 )
             }
         }
@@ -328,6 +462,29 @@ private object TestModels {
             output: SomeOutput
         }
     """.asSmithyModel()
+
+    val noSchemes = """
+        namespace test
+
+        use aws.api#service
+        use aws.protocols#restJson1
+
+        @service(sdkId: "Test Api Key Auth")
+        @restJson1
+        service TestService {
+            version: "2023-01-01",
+            operations: [SomeOperation]
+        }
+
+        structure SomeOutput {
+            someAttribute: Long,
+            someVal: String
+        }
+
+        @http(uri: "/SomeOperation", method: "GET")
+        operation SomeOperation {
+            output: SomeOutput
+        }""".asSmithyModel()
 
     val apiKeyInQueryString = """
         namespace test

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -89,6 +89,8 @@ class InlineDependency(
         private fun forInlineableRustFile(name: String, vararg additionalDependencies: RustDependency) =
             forRustFile(RustModule.private(name), "/inlineable/src/$name.rs", *additionalDependencies)
 
+        fun defaultAuthPlugin(runtimeConfig: RuntimeConfig) = forInlineableRustFile("auth_plugin", CargoDependency.smithyRuntimeApi(runtimeConfig))
+
         fun jsonErrors(runtimeConfig: RuntimeConfig) =
             forInlineableRustFile(
                 "json_errors",

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -169,6 +169,12 @@ fun <T : AbstractCodeWriter<T>> T.rust(
     this.write(contents.trim(), *args)
 }
 
+fun <T : AbstractCodeWriter<T>> T.rawRust(
+    @Language("Rust", prefix = "macro_rules! foo { () =>  {{\n", suffix = "\n}}}") contents: String,
+) {
+    this.write(escape(contents.trim()))
+}
+
 /**
  * Convenience wrapper that tells Intellij that the contents of this block are Rust
  */

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -401,8 +401,10 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
         fun retryErrorKind(runtimeConfig: RuntimeConfig) = smithyTypes(runtimeConfig).resolve("retry::ErrorKind")
         fun eventStreamReceiver(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyHttp(runtimeConfig).resolve("event_stream::Receiver")
+
         fun eventStreamSender(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyHttp(runtimeConfig).resolve("event_stream::EventStreamSender")
+
         fun futuresStreamCompatByteStream(runtimeConfig: RuntimeConfig): RuntimeType =
             smithyHttp(runtimeConfig).resolve("futures_stream_adapter::FuturesStreamCompatByteStream")
 
@@ -417,6 +419,10 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
         fun jsonErrors(runtimeConfig: RuntimeConfig) = forInlineDependency(InlineDependency.jsonErrors(runtimeConfig))
         fun awsQueryCompatibleErrors(runtimeConfig: RuntimeConfig) =
             forInlineDependency(InlineDependency.awsQueryCompatibleErrors(runtimeConfig))
+
+        fun defaultAuthPlugin(runtimeConfig: RuntimeConfig) =
+            RuntimeType.forInlineDependency(InlineDependency.defaultAuthPlugin(runtimeConfig))
+                .resolve("DefaultAuthOptionsPlugin")
 
         fun labelFormat(runtimeConfig: RuntimeConfig, func: String) = smithyHttp(runtimeConfig).resolve("label::$func")
         fun operation(runtimeConfig: RuntimeConfig) = smithyHttp(runtimeConfig).resolve("operation::Operation")

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/CodegenIntegrationTest.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.util.runCommand
 import java.io.File
 import java.nio.file.Path
+import java.util.logging.Logger
 
 /**
  * A helper class holding common data with defaults that is threaded through several functions, to make their
@@ -41,6 +42,8 @@ fun codegenIntegrationTest(model: Model, params: IntegrationTestParams, invokePl
     )
     invokePlugin(ctx)
     ctx.fileManifest.printGeneratedFiles()
-    params.command?.invoke(testDir) ?: (params.cargoCommand ?: "cargo test").runCommand(testDir, environment = mapOf("RUSTFLAGS" to "-D warnings"))
+    val logger = Logger.getLogger("CodegenIntegrationTest")
+    val out = params.command?.invoke(testDir) ?: (params.cargoCommand ?: "cargo test --lib --tests").runCommand(testDir, environment = mapOf("RUSTFLAGS" to "-D warnings"))
+    logger.fine(out.toString())
     return testDir
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/Exec.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/Exec.kt
@@ -8,10 +8,14 @@ package software.amazon.smithy.rust.codegen.core.util
 import java.io.IOException
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
 
 data class CommandError(val output: String) : Exception("Command Error\n$output")
 
 fun String.runCommand(workdir: Path? = null, environment: Map<String, String> = mapOf(), timeout: Long = 3600): String {
+    val logger = Logger.getLogger("RunCommand")
+    logger.fine("Invoking comment $this in `$workdir` with env $environment")
+    val start = System.currentTimeMillis()
     val parts = this.split("\\s".toRegex())
     val builder = ProcessBuilder(*parts.toTypedArray())
         .redirectOutput(ProcessBuilder.Redirect.PIPE)
@@ -38,5 +42,8 @@ fun String.runCommand(workdir: Path? = null, environment: Map<String, String> = 
         throw CommandError("$this was not a valid command.\n  Hint: is everything installed?\n$err")
     } catch (other: Exception) {
         throw CommandError("Unexpected exception thrown when executing subprocess:\n$other")
+    } finally {
+        val end = System.currentTimeMillis()
+        logger.fine("command duration: ${end - start}ms")
     }
 }

--- a/rust-runtime/inlineable/src/auth_plugin.rs
+++ b/rust-runtime/inlineable/src/auth_plugin.rs
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::borrow::Cow;
+
+use aws_smithy_runtime_api::client::auth::static_resolver::StaticAuthSchemeOptionResolver;
+use aws_smithy_runtime_api::client::auth::AuthSchemeId;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+use aws_smithy_runtime_api::client::runtime_plugin::{Order, RuntimePlugin};
+
+#[derive(Debug)]
+pub(crate) struct DefaultAuthOptionsPlugin {
+    runtime_components: RuntimeComponentsBuilder,
+}
+
+impl DefaultAuthOptionsPlugin {
+    pub(crate) fn new(auth_schemes: Vec<AuthSchemeId>) -> Self {
+        let runtime_components = RuntimeComponentsBuilder::new("default_auth_options")
+            .with_auth_scheme_option_resolver(Some(StaticAuthSchemeOptionResolver::new(
+                auth_schemes,
+            )));
+        Self { runtime_components }
+    }
+}
+
+impl RuntimePlugin for DefaultAuthOptionsPlugin {
+    fn order(&self) -> Order {
+        Order::Defaults
+    }
+
+    fn runtime_components(
+        &self,
+        _current_components: &RuntimeComponentsBuilder,
+    ) -> Cow<'_, RuntimeComponentsBuilder> {
+        Cow::Borrowed(&self.runtime_components)
+    }
+}

--- a/rust-runtime/inlineable/src/lib.rs
+++ b/rust-runtime/inlineable/src/lib.rs
@@ -26,6 +26,10 @@ mod serialization_settings;
 
 #[allow(unused)]
 mod endpoint_lib;
+
+#[allow(unused)]
+mod auth_plugin;
+
 // This test is outside of uuid.rs to enable copying the entirety of uuid.rs into the SDK without
 // requiring a proptest dependency
 #[cfg(test)]


### PR DESCRIPTION
## Motivation and Context
- Fixes #3034
## Description
Because AuthSchemeOptions were being registered at the operation level, there was no way for them to be overridden by customer-provided runtime plugins. This moves them into a separate plugin that is added at Client/Default priority.

## Testing
- new unit test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
