### PR TITLE
Add more type aliases for types moved to the `aws-smithy-types` crate

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -445,9 +445,9 @@ author = "ysaito1001"
 
 [[smithy-rs]]
 message = """
-`aws_smithy_http::byte_stream::{AggregatedBytes, ByteStream, error::Error}` have been moved to `aws_smithy_types::byte_stream::{AggregatedBytes, ByteStream, error::Error}`. Type aliases for them are left in `aws_smithy_http` for backwards compatibility but are deprecated.
+`aws_smithy_http::byte_stream::{AggregatedBytes, ByteStream, error::Error, FsBuilder, Length}` have been moved to `aws_smithy_types::byte_stream::{AggregatedBytes, ByteStream, error::Error, FsBuilder, Length}`. Type aliases for them are left in `aws_smithy_http` for backwards compatibility but are deprecated.
 """
-references = ["smithy-rs#3076"]
+references = ["smithy-rs#3076", "smithy-rs#3091"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "all" }
 author = "ysaito1001"
 

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -23,10 +23,12 @@ pub mod error {
     pub type Error = aws_smithy_types::byte_stream::error::Error;
 }
 
+/// Builder for creating [`ByteStreams`](aws_smithy_types::byte_stream::ByteStream) from a file/path, with full control over advanced options.
 #[cfg(feature = "rt-tokio")]
 #[deprecated(note = "Moved to `aws_smithy_types::byte_stream::FsBuilder`.")]
 pub type FsBuilder = aws_smithy_types::byte_stream::FsBuilder;
 
+/// The length (in bytes) to read. Determines whether or not a short read counts as an error.
 #[cfg(feature = "rt-tokio")]
 #[deprecated(note = "Moved to `aws_smithy_types::byte_stream::Length`.")]
 pub type Length = aws_smithy_types::byte_stream::Length;

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -22,3 +22,11 @@ pub mod error {
     #[deprecated(note = "Moved to `aws_smithy_types::byte_stream::error::Error`.")]
     pub type Error = aws_smithy_types::byte_stream::error::Error;
 }
+
+#[cfg(feature = "rt-tokio")]
+#[deprecated(note = "Moved to `aws_smithy_types::byte_stream::FsBuilder`.")]
+pub type FsBuilder = aws_smithy_types::byte_stream::FsBuilder;
+
+#[cfg(feature = "rt-tokio")]
+#[deprecated(note = "Moved to `aws_smithy_types::byte_stream::Length`.")]
+pub type Length = aws_smithy_types::byte_stream::Length;


### PR DESCRIPTION
## Motivation and Context
https://github.com/awslabs/smithy-rs/pull/3076 missed type alias for some types we moved to `aws-smithy-types`. This small PR will fix that.

## Testing
Relied on the existing tests in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
