### PR TITLE
ServerInstantiator without builder

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/Instantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/Instantiator.kt
@@ -138,7 +138,7 @@ open class Instantiator(
      * If the shape is optional: `Some(inner)` or `None`.
      * Otherwise: `inner`.
      */
-    private fun renderMember(writer: RustWriter, memberShape: MemberShape, data: Node, ctx: Ctx) {
+    protected fun renderMember(writer: RustWriter, memberShape: MemberShape, data: Node, ctx: Ctx) {
         val targetShape = model.expectShape(memberShape.target)
         val symbol = symbolProvider.toSymbol(memberShape)
         if (data is NullNode && !targetShape.isDocumentShape) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
@@ -5,12 +5,17 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy.generators
 
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
@@ -68,15 +73,65 @@ class ServerBuilderKindBehavior(val codegenContext: CodegenContext) : Instantiat
         codegenContext.symbolProvider.toSymbol(memberShape).isOptional()
 }
 
-fun serverInstantiator(codegenContext: CodegenContext) =
-    Instantiator(
-        codegenContext.symbolProvider,
-        codegenContext.model,
-        codegenContext.runtimeConfig,
-        ServerBuilderKindBehavior(codegenContext),
-        defaultsForRequiredFields = true,
-        customizations = listOf(ServerAfterInstantiatingValueConstrainItIfNecessary(codegenContext)),
-    )
+class ServerInstantiator(private val codegenContext: CodegenContext) : Instantiator(
+    codegenContext.symbolProvider,
+    codegenContext.model,
+    codegenContext.runtimeConfig,
+    ServerBuilderKindBehavior(codegenContext),
+    defaultsForRequiredFields = true,
+    customizations = listOf(ServerAfterInstantiatingValueConstrainItIfNecessary(codegenContext)),
+) {
+    fun generate(
+        shape: StructureShape,
+        values: Map<MemberShape, Writable>,
+        data: ObjectNode = Node.objectNode(),
+        ctx: Ctx = Ctx(),
+    ) = writable {
+        render(this, shape, values, data, ctx)
+    }
+
+    fun render(
+        writer: RustWriter,
+        shape: StructureShape,
+        values: Map<MemberShape, Writable>,
+        data: ObjectNode,
+        ctx: Ctx = Ctx(),
+    ) {
+        val symbolProvider = codegenContext.symbolProvider
+        writer.withBlock("{", "}") {
+            for (member in shape.members()) {
+                val dataHasValue = data.getMember(member.memberName).isPresent
+                val hasValue = values.containsKey(member) || dataHasValue
+                check(member.isOptional || hasValue)
+                val value = if (member.isOptional && !hasValue) {
+                    writable("None")
+                } else {
+                    writable {
+                        values[member]
+                            ?.let { it(this) }
+                            ?: super.renderMember(
+                                this,
+                                member,
+                                data.expectMember(member.memberName),
+                                ctx,
+                            )
+                    }
+                }
+                val name = symbolProvider.toMemberName(member)
+                writer.rustTemplate(
+                    "let $name = #{value};",
+                    "value" to value,
+                )
+            }
+            writer.withBlockTemplate("#{T} {", "}", "T" to symbolProvider.toSymbol(shape)) {
+                for (member in shape.members()) {
+                    val name = symbolProvider.toMemberName(member)
+                    writer.rustTemplate("$name,")
+                }
+            }
+        }
+    }
+}
 
 class ServerBuilderInstantiator(
     private val symbolProvider: RustSymbolProvider,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -54,7 +54,7 @@ import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCargoDependency
 import software.amazon.smithy.rust.codegen.server.smithy.ServerRuntimeType
-import software.amazon.smithy.rust.codegen.server.smithy.generators.serverInstantiator
+import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerInstantiator
 import java.util.logging.Logger
 import kotlin.reflect.KFunction1
 
@@ -94,7 +94,7 @@ class ServerProtocolTestGenerator(
         inputT to outputT
     }
 
-    private val instantiator = serverInstantiator(codegenContext)
+    private val instantiator = ServerInstantiator(codegenContext)
 
     private val codegenScope = arrayOf(
         "Bytes" to RuntimeType.Bytes,

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGeneratorTest.kt
@@ -179,7 +179,7 @@ class ConstrainedCollectionGeneratorTest {
             project.withModule(ServerRustModule.Model) {
                 render(codegenContext, this, shape)
 
-                val instantiator = serverInstantiator(codegenContext)
+                val instantiator = ServerInstantiator(codegenContext)
                 for ((idx, validList) in testCase.validLists.withIndex()) {
                     val shapeNameIdx = "${shapeName}_$idx"
                     val buildValidFnName = "build_valid_$shapeNameIdx"

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedMapGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedMapGeneratorTest.kt
@@ -81,7 +81,7 @@ class ConstrainedMapGeneratorTest {
         project.withModule(ServerRustModule.Model) {
             render(codegenContext, this, constrainedMapShape)
 
-            val instantiator = serverInstantiator(codegenContext)
+            val instantiator = ServerInstantiator(codegenContext)
             rustBlock("##[cfg(test)] fn build_valid_map() -> std::collections::HashMap<String, String>") {
                 instantiator.render(this, constrainedMapShape, testCase.validMap)
             }

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
@@ -7,17 +7,24 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators
 
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.lookup
@@ -78,11 +85,13 @@ class ServerInstantiatorTest {
             int: Integer
         }
 
+        integer MyInteger
+
         structure NestedStruct {
             @required
             str: String,
             @required
-            num: Integer
+            num: MyInteger
         }
 
         structure MyStructRequired {
@@ -136,7 +145,7 @@ class ServerInstantiatorTest {
         val inner = model.lookup<StructureShape>("com.test#Inner")
         val nestedStruct = model.lookup<StructureShape>("com.test#NestedStruct")
         val union = model.lookup<UnionShape>("com.test#NestedUnion")
-        val sut = serverInstantiator(codegenContext)
+        val sut = ServerInstantiator(codegenContext)
         val data = Node.parse("{}")
 
         val project = TestWorkspace.testProject()
@@ -191,7 +200,7 @@ class ServerInstantiatorTest {
     @Test
     fun `generate named enums`() {
         val shape = model.lookup<StringShape>("com.test#NamedEnum")
-        val sut = serverInstantiator(codegenContext)
+        val sut = ServerInstantiator(codegenContext)
         val data = Node.parse("t2.nano".dq())
 
         val project = TestWorkspace.testProject()
@@ -214,7 +223,7 @@ class ServerInstantiatorTest {
     @Test
     fun `generate unnamed enums`() {
         val shape = model.lookup<StringShape>("com.test#UnnamedEnum")
-        val sut = serverInstantiator(codegenContext)
+        val sut = ServerInstantiator(codegenContext)
         val data = Node.parse("t2.nano".dq())
 
         val project = TestWorkspace.testProject()
@@ -233,4 +242,95 @@ class ServerInstantiatorTest {
         }
         project.compileAndTest()
     }
+
+    @Test
+    fun `uses writable for shapes`() {
+        val inner = model.lookup<StructureShape>("com.test#Inner")
+        val nestedStruct = model.lookup<StructureShape>("com.test#NestedStruct")
+        val sut = ServerInstantiator(codegenContext)
+
+        val project = TestWorkspace.testProject(model)
+        inner.renderWithModelBuilder(model, symbolProvider, project)
+        nestedStruct.renderWithModelBuilder(model, symbolProvider, project)
+        project.moduleFor(inner) {
+            val nestedUnion = model.lookup<UnionShape>("com.test#NestedUnion")
+            UnionGenerator(model, symbolProvider, this, nestedUnion).render()
+
+            unitTest("writable_for_maps") {
+                val data = Node.parse(
+                    """
+                    {
+                        "k1": { "map": {} },
+                        "k2": { "map": { "k3": {} } },
+                        "k3": { }
+                    }
+                    """,
+                )
+                val writables = mapOf(
+                    Pair(model.lookup<MemberShape>("com.test#Inner\$map"), writable("Some(result)")),
+                )
+                rustTemplate("""
+                    let mut result = #{Map}::new();
+                    let map = #{Map}::new();
+                    let k1 = #{Inner} { map: Some(map) };
+                    result.insert("k1".to_owned(), k1);
+                    let k3 = {
+                        let mut ret = #{Map}::new();
+                        ret.insert("k3".to_owned(), #{Inner} { map: None });
+                        ret
+                    };
+                    let k2 = #{Inner} { map: Some(k3) };
+                    result.insert("k2".to_owned(), k2);
+                    result.insert("k3".to_owned(), #{Inner} { map: None });
+                """,
+                    "Inner" to symbolProvider.toSymbol(inner),
+                    "Map" to RustType.HashMap(RustType.String, symbolProvider.toSymbol(inner).rustType()),
+                    )
+                withBlock("let inner = ", ";") {
+                    sut.render(this, model.lookup("com.test#Inner"), writables, data as ObjectNode)
+                }
+                rust(
+                    """
+                    assert_eq!(inner.map().unwrap().len(), 3);
+                    assert_eq!(inner.map().unwrap().get("k1").unwrap().map.as_ref().unwrap().len(), 0);
+                    assert_eq!(inner.map().unwrap().get("k2").unwrap().map.as_ref().unwrap().len(), 1);
+                    assert_eq!(inner.map().unwrap().get("k3").unwrap().map, None);
+                    """,
+                )
+            }
+
+            unitTest("writable_preferred_over_node_data") {
+                val data = Node.parse(
+                    """
+                    {
+                        "str": "world",
+                        "num": 1
+                    }
+                    """,
+                )
+                val writables = mapOf(
+                    Pair(model.lookup("com.test#NestedStruct\$num") as MemberShape, writable("myStruct.n")),
+                )
+
+                rust("""
+                    struct MyTestStruct { str: String, n: i32, f: f32 }
+                    let str = String::from("hello");
+                    let myStruct = MyTestStruct { str, n: 42, f: 0.42 };
+                """)
+                withBlock("let result = ", ";") {
+                    sut.render(this, model.lookup("com.test#NestedStruct"), writables, data as ObjectNode)
+                }
+                rustTemplate(
+                    """
+                    let str = String::from("world");
+                    let expected = #{NestedStruct} {str, num: 42};
+                    assert_eq!(result, expected);
+                    """,
+                    "NestedStruct" to symbolProvider.toSymbol(nestedStruct)
+                )
+            }
+        }
+        project.compileAndTest(runClippy = true)
+    }
+
 }


### PR DESCRIPTION
* Allow `ServerInstantiator` to use writables instead of only static data.
* Build structures without the builder

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
