### PR TITLE
Small tweaks to the HTTP wrapper

### DIFF
--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -132,7 +132,7 @@ fn apply_endpoint(
     for (header_name, header_values) in endpoint.headers() {
         request.headers_mut().remove(header_name);
         for value in header_values {
-            request.headers_mut().insert(
+            request.headers_mut().append(
                 HeaderName::from_str(header_name).map_err(|err| {
                     ResolveEndpointError::message("invalid header name")
                         .with_source(Some(err.into()))


### PR DESCRIPTION
## Motivation and Context
- small improvements / consistency updates to http wrapper
- fix bug where `.insert` was called but it should have been `append`

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
