### PR TITLE
Allow custom writables in Instantiator

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
@@ -5,15 +5,12 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy.generators
 
-import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
-import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
-import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
@@ -5,12 +5,15 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy.generators
 
+import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
@@ -68,15 +71,17 @@ class ServerBuilderKindBehavior(val codegenContext: CodegenContext) : Instantiat
         codegenContext.symbolProvider.toSymbol(memberShape).isOptional()
 }
 
-class ServerInstantiator(codegenContext: CodegenContext) : Instantiator(
-    codegenContext.symbolProvider,
-    codegenContext.model,
-    codegenContext.runtimeConfig,
-    ServerBuilderKindBehavior(codegenContext),
-    defaultsForRequiredFields = true,
-    customizations = listOf(ServerAfterInstantiatingValueConstrainItIfNecessary(codegenContext)),
-    constructPattern = InstantiatorConstructPattern.DIRECT,
-)
+class ServerInstantiator(codegenContext: CodegenContext, customWritable: CustomWritable = CustomWritable()) :
+    Instantiator(
+        codegenContext.symbolProvider,
+        codegenContext.model,
+        codegenContext.runtimeConfig,
+        ServerBuilderKindBehavior(codegenContext),
+        defaultsForRequiredFields = true,
+        customizations = listOf(ServerAfterInstantiatingValueConstrainItIfNecessary(codegenContext)),
+        constructPattern = InstantiatorConstructPattern.DIRECT,
+        customWritable = customWritable,
+    )
 
 class ServerBuilderInstantiator(
     private val symbolProvider: RustSymbolProvider,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiator.kt
@@ -68,7 +68,7 @@ class ServerBuilderKindBehavior(val codegenContext: CodegenContext) : Instantiat
         codegenContext.symbolProvider.toSymbol(memberShape).isOptional()
 }
 
-class ServerInstantiator(codegenContext: CodegenContext, customWritable: CustomWritable = CustomWritable()) :
+class ServerInstantiator(codegenContext: CodegenContext, customWritable: CustomWritable = NoCustomWritable()) :
     Instantiator(
         codegenContext.symbolProvider,
         codegenContext.model,

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
@@ -18,7 +18,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
-import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.generators.Instantiator
@@ -288,6 +287,7 @@ class ServerInstantiatorTest {
                 rust(
                     """
                     assert_eq!(result.num, 42);
+                    assert_eq!(result.str, "hello");
                     """,
                 )
             }
@@ -331,11 +331,10 @@ class ServerInstantiatorTest {
                 withBlock("let result = ", ";") {
                     sut.render(this, inner, data as ObjectNode)
                 }
-                rustTemplate(
+                rust(
                     """
                     assert_eq!(result.map().unwrap().get("k1").unwrap().map().unwrap().get("k2").unwrap().map(), None);
                     """,
-                    "NestedStruct" to symbolProvider.toSymbol(nestedStruct),
                 )
             }
         }

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
@@ -271,7 +271,7 @@ class ServerInstantiatorTest {
             unitTest("writable_for_shapes") {
                 val sut = ServerInstantiator(
                     codegenContext,
-                    customWritable = object : Instantiator.CustomWritable() {
+                    customWritable = object : Instantiator.CustomWritable {
                         override fun generate(shape: Shape): Writable? =
                             if (model.lookup<MemberShape>("com.test#NestedStruct\$num") == shape) {
                                 writable("40 + 2")
@@ -296,7 +296,7 @@ class ServerInstantiatorTest {
                 val map = model.lookup<MemberShape>("com.test#Inner\$map")
                 val sut = ServerInstantiator(
                     codegenContext,
-                    customWritable = object : Instantiator.CustomWritable() {
+                    customWritable = object : Instantiator.CustomWritable {
                         private var n: Int = 0
                         override fun generate(shape: Shape): Writable? =
                             if (shape != map) {

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
@@ -272,7 +272,7 @@ class ServerInstantiatorTest {
                 val sut = ServerInstantiator(
                     codegenContext,
                     customWritable = object : Instantiator.CustomWritable() {
-                        override fun render(shape: Shape): Writable? =
+                        override fun generate(shape: Shape): Writable? =
                             if (model.lookup<MemberShape>("com.test#NestedStruct\$num") == shape) {
                                 writable("40 + 2")
                             } else {
@@ -298,7 +298,7 @@ class ServerInstantiatorTest {
                     codegenContext,
                     customWritable = object : Instantiator.CustomWritable() {
                         private var n: Int = 0
-                        override fun render(shape: Shape): Writable? =
+                        override fun generate(shape: Shape): Writable? =
                             if (shape != map) {
                                 null
                             } else if (n != 2) {

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerInstantiatorTest.kt
@@ -8,18 +8,26 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators
 import io.kotest.matchers.string.shouldNotContain
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.generators.Instantiator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.lookup
@@ -247,5 +255,90 @@ class ServerInstantiatorTest {
         val writer = RustWriter.forModule(ServerRustModule.Model.name)
         sut.render(writer, shape, data)
         writer.toString() shouldNotContain "builder()"
+    }
+
+    @Test
+    fun `uses writable for shapes`() {
+        val nestedStruct = model.lookup<StructureShape>("com.test#NestedStruct")
+        val inner = model.lookup<StructureShape>("com.test#Inner")
+
+        val project = TestWorkspace.testProject(model)
+        nestedStruct.renderWithModelBuilder(model, symbolProvider, project)
+        inner.renderWithModelBuilder(model, symbolProvider, project)
+        project.moduleFor(nestedStruct) {
+            val nestedUnion = model.lookup<UnionShape>("com.test#NestedUnion")
+            UnionGenerator(model, symbolProvider, this, nestedUnion).render()
+
+            unitTest("writable_for_shapes") {
+                val sut = ServerInstantiator(
+                    codegenContext,
+                    customWritable = object : Instantiator.CustomWritable() {
+                        override fun render(shape: Shape): Writable? =
+                            if (model.lookup<MemberShape>("com.test#NestedStruct\$num") == shape) {
+                                writable("40 + 2")
+                            } else {
+                                null
+                            }
+                    },
+                )
+                val data = Node.parse("""{ "str": "hello", "num": 1 }""")
+                withBlock("let result = ", ";") {
+                    sut.render(this, model.lookup("com.test#NestedStruct"), data as ObjectNode)
+                }
+                rust(
+                    """
+                    assert_eq!(result.num, 42);
+                    """,
+                )
+            }
+
+            unitTest("writable_for_nested_inner_members") {
+                val map = model.lookup<MemberShape>("com.test#Inner\$map")
+                val sut = ServerInstantiator(
+                    codegenContext,
+                    customWritable = object : Instantiator.CustomWritable() {
+                        private var n: Int = 0
+                        override fun render(shape: Shape): Writable? =
+                            if (shape != map) {
+                                null
+                            } else if (n != 2) {
+                                n += 1
+                                null
+                            } else {
+                                n += 1
+                                writable("None")
+                            }
+                    },
+                )
+                val data = Node.parse(
+                    """
+                    {
+                        "map": {
+                            "k1": {
+                                "map": {
+                                    "k2": {
+                                        "map": {
+                                            "never": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    """,
+                )
+
+                withBlock("let result = ", ";") {
+                    sut.render(this, inner, data as ObjectNode)
+                }
+                rustTemplate(
+                    """
+                    assert_eq!(result.map().unwrap().get("k1").unwrap().map().unwrap().get("k2").unwrap().map(), None);
+                    """,
+                    "NestedStruct" to symbolProvider.toSymbol(nestedStruct),
+                )
+            }
+        }
+        project.compileAndTest(runClippy = true)
     }
 }


### PR DESCRIPTION
`Instantiator` currently renders only static data.
This PR allows it to customize this behavior to allow non-static data (e.g. data taken from other structs).


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
