### PR TITLE
Use re-exported types in examples instead of aws-smithy-types

### DIFF
--- a/examples/pokemon-service-client-usage/examples/mock-request.rs
+++ b/examples/pokemon-service-client-usage/examples/mock-request.rs
@@ -13,7 +13,7 @@
 /// The example can be run using `cargo run --example mock-request`.
 ///
 use aws_smithy_runtime::client::http::test_util::capture_request;
-use aws_smithy_types::body::SdkBody;
+use pokemon_service_client::primitives::SdkBody;
 use pokemon_service_client::Client as PokemonClient;
 use pokemon_service_client_usage::{setup_tracing_subscriber, POKEMON_SERVICE_URL};
 

--- a/examples/pokemon-service-client-usage/examples/response-header-interceptor.rs
+++ b/examples/pokemon-service-client-usage/examples/response-header-interceptor.rs
@@ -11,7 +11,6 @@
 ///
 /// The example can be run using `cargo run --example response-header-interceptor`.
 ///
-//use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use pokemon_service_client::{
     config::{

--- a/examples/pokemon-service-client-usage/examples/use-config-bag.rs
+++ b/examples/pokemon-service-client-usage/examples/use-config-bag.rs
@@ -11,7 +11,6 @@
 ///
 /// The example can be run using `cargo run --example use-config-bag`.
 ///
-//use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use pokemon_service_client_usage::{setup_tracing_subscriber, POKEMON_SERVICE_URL};
 use std::time::Instant;

--- a/examples/pokemon-service-common/Cargo.toml
+++ b/examples/pokemon-service-common/Cargo.toml
@@ -19,7 +19,6 @@ tower = "0.4"
 aws-smithy-runtime = { path = "../../rust-runtime/aws-smithy-runtime", features = ["client", "connector-hyper-0-14-x"] }
 aws-smithy-runtime-api = { path = "../../rust-runtime/aws-smithy-runtime-api", features = ["client"] }
 aws-smithy-http-server = { path = "../../rust-runtime/aws-smithy-http-server" }
-aws-smithy-types = { path = "../../rust-runtime/aws-smithy-types" }
 pokemon-service-client = { path = "../pokemon-service-client" }
 pokemon-service-server-sdk = { path = "../pokemon-service-server-sdk" }
 

--- a/examples/pokemon-service-common/src/lib.rs
+++ b/examples/pokemon-service-common/src/lib.rs
@@ -18,10 +18,12 @@ use async_stream::stream;
 use aws_smithy_http_server::Extension;
 use aws_smithy_runtime::client::http::hyper_014::HyperConnector;
 use aws_smithy_runtime_api::client::http::HttpConnector;
-use aws_smithy_types::{body::SdkBody, byte_stream::ByteStream};
 use http::Uri;
 use pokemon_service_server_sdk::{
-    error, input, model, model::CapturingPayload, output, types::Blob,
+    error, input, model,
+    model::CapturingPayload,
+    output,
+    types::{Blob, ByteStream, SdkBody},
 };
 use rand::{seq::SliceRandom, Rng};
 use tracing_subscriber::{prelude::*, EnvFilter};

--- a/examples/pokemon-service/Cargo.toml
+++ b/examples/pokemon-service/Cargo.toml
@@ -33,5 +33,4 @@ hyper-rustls = { version = "0.24", features = ["http2"] }
 
 # Local paths
 aws-smithy-http = { path = "../../rust-runtime/aws-smithy-http/" }
-aws-smithy-types = { path = "../../rust-runtime/aws-smithy-types/" }
 pokemon-service-client = { path = "../pokemon-service-client/" }


### PR DESCRIPTION
Some of the examples were using types from `aws-smithy-types` instead of the re-exported ones from the generated SDKs. As a guideline, it is preferred to use re-exported types rather than directly depending on underlying crates.