### PR TITLE
Test decorators in server tests

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
@@ -28,6 +28,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.ServerModuleProvider
 import software.amazon.smithy.rust.codegen.server.smithy.ServerRustSettings
 import software.amazon.smithy.rust.codegen.server.smithy.ServerSymbolProviders
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.SmithyValidationExceptionConversionGenerator
+import software.amazon.smithy.rust.codegen.server.smithy.customize.CombinedServerCodegenDecorator
 import software.amazon.smithy.rust.codegen.server.smithy.customize.ServerCodegenDecorator
 import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerBuilderGenerator
 import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocol
@@ -102,6 +103,7 @@ fun serverTestCodegenContext(
     serviceShape: ServiceShape? = null,
     settings: ServerRustSettings = serverTestRustSettings(),
     protocolShapeId: ShapeId? = null,
+    decorators: List<ServerCodegenDecorator> = emptyList(),
 ): ServerCodegenContext {
     val service = serviceShape ?: testServiceShapeFor(model)
     val protocol = protocolShapeId ?: ShapeId.from("test#Protocol")
@@ -111,7 +113,7 @@ fun serverTestCodegenContext(
         service,
         ServerTestRustSymbolProviderConfig,
         settings.codegenConfig.publicConstrainedTypes,
-        ServerTestCodegenDecorator(),
+        CombinedServerCodegenDecorator(decorators + listOf(ServerTestCodegenDecorator())),
         RustServerCodegenPlugin::baseSymbolProvider,
     )
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
@@ -48,15 +48,11 @@ private fun testServiceShapeFor(model: Model) =
 fun serverTestSymbolProvider(model: Model, serviceShape: ServiceShape? = null) =
     serverTestSymbolProviders(model, serviceShape).symbolProvider
 
-private class ServerTestCodegenDecorator : ServerCodegenDecorator {
-    override val name = "test"
-    override val order: Byte = 0
-}
-
 fun serverTestSymbolProviders(
     model: Model,
     serviceShape: ServiceShape? = null,
     settings: ServerRustSettings? = null,
+    decorators: List<ServerCodegenDecorator> = emptyList(),
 ) =
     ServerSymbolProviders.from(
         serverTestRustSettings(),
@@ -68,7 +64,7 @@ fun serverTestSymbolProviders(
                 (serviceShape ?: testServiceShapeFor(model)).id,
             )
             ).codegenConfig.publicConstrainedTypes,
-        ServerTestCodegenDecorator(),
+        CombinedServerCodegenDecorator(decorators),
         RustServerCodegenPlugin::baseSymbolProvider,
     )
 
@@ -113,7 +109,7 @@ fun serverTestCodegenContext(
         service,
         ServerTestRustSymbolProviderConfig,
         settings.codegenConfig.publicConstrainedTypes,
-        CombinedServerCodegenDecorator(decorators + listOf(ServerTestCodegenDecorator())),
+        CombinedServerCodegenDecorator(decorators),
         RustServerCodegenPlugin::baseSymbolProvider,
     )
 


### PR DESCRIPTION
This change allows to test decorators by adding them to the CodegenContext.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
