### PR TITLE
Enable the tokio-rt feature for generated crates when bytestream is used

### DIFF
--- a/aws/sdk/integration-tests/s3/tests/client_construction.rs
+++ b/aws/sdk/integration-tests/s3/tests/client_construction.rs
@@ -26,6 +26,11 @@ mod with_sdk_config {
         assert!(config.retry_config().is_none());
         let _s3 = s3::Client::new(&config);
     }
+
+    #[test]
+    fn bytestream_from_path_exists() {
+        let _ = aws_sdk_s3::primitives::ByteStream::from_path("a/b.txt");
+    }
 }
 
 mod with_service_config {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -86,7 +86,7 @@ class RequiredCustomizations : ClientCodegenDecorator {
         ResiliencyReExportCustomization(codegenContext).extras(rustCrate)
 
         rustCrate.withModule(ClientRustModule.Primitives) {
-            pubUseSmithyPrimitives(codegenContext, codegenContext.model)(this)
+            pubUseSmithyPrimitives(codegenContext, codegenContext.model, rustCrate)(this)
         }
         rustCrate.withModule(ClientRustModule.Error) {
             rustTemplate(

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtraTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtraTest.kt
@@ -8,8 +8,11 @@ package software.amazon.smithy.rust.codegen.core.smithy.customizations
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGeneratorTest.Companion.model
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.generatePluginContext
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
 
 class SmithyTypesPubUseExtraTest {
@@ -43,6 +46,22 @@ class SmithyTypesPubUseExtraTest {
         """.asSmithyModel()
     }
 
+    private val rustCrate: RustCrate
+    private val codegenContext: CodegenContext = testCodegenContext(model)
+
+    init {
+        val (context, _) = generatePluginContext(
+            model,
+            runtimeConfig = codegenContext.runtimeConfig,
+        )
+        rustCrate = RustCrate(
+            context.fileManifest,
+            codegenContext.symbolProvider,
+            codegenContext.settings.codegenConfig,
+            codegenContext.expectModuleDocProvider(),
+        )
+    }
+
     private fun reexportsWithEmptyModel() = reexportsWithMember()
     private fun reexportsWithMember(
         inputMember: String = "",
@@ -51,7 +70,7 @@ class SmithyTypesPubUseExtraTest {
         additionalShape: String = "",
     ) = RustWriter.root().let { writer ->
         pubUseSmithyPrimitives(
-            testCodegenContext(model),
+            codegenContext,
             modelWithMember(inputMember, outputMember, unionMember, additionalShape),
             rustCrate,
         )(writer)

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtraTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/SmithyTypesPubUseExtraTest.kt
@@ -50,7 +50,11 @@ class SmithyTypesPubUseExtraTest {
         unionMember: String = "",
         additionalShape: String = "",
     ) = RustWriter.root().let { writer ->
-        pubUseSmithyPrimitives(testCodegenContext(model), modelWithMember(inputMember, outputMember, unionMember, additionalShape))(writer)
+        pubUseSmithyPrimitives(
+            testCodegenContext(model),
+            modelWithMember(inputMember, outputMember, unionMember, additionalShape),
+            rustCrate,
+        )(writer)
         writer.toString()
     }
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
@@ -47,7 +47,7 @@ class ServerRequiredCustomizations : ServerCodegenDecorator {
         )
 
         rustCrate.withModule(ServerRustModule.Types) {
-            pubUseSmithyPrimitives(codegenContext, codegenContext.model)(this)
+            pubUseSmithyPrimitives(codegenContext, codegenContext.model, rustCrate)(this)
             rustTemplate(
                 """
                 pub use #{DisplayErrorContext};


### PR DESCRIPTION
## Motivation and Context
Fix issue where `ByteStream::from_path` was unusable by without enabling features

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
