### PR TITLE
Allow SDK examples to rename from `rust_dev_preview` to `rust`

### DIFF
--- a/tools/ci-build/sdk-versioner/README.md
+++ b/tools/ci-build/sdk-versioner/README.md
@@ -12,12 +12,12 @@ Example updating SDK examples to use SDK version 0.5.0 with Smithy version 0.35.
 $ sdk-versioner \
   --sdk-version 0.5.0 \
   --smithy-version 0.35.0 \
-  path/to/aws-doc-sdk-examples/rust_dev_preview
+  path/to/aws-doc-sdk-examples/rust
 ```
 
 Example updating SDK examples to refer to local generated code:
 ```bash
 $ sdk-versioner \
   --sdk-path path/to/smithy-rs/aws/sdk/build/aws-sdk/sdk \
-  path/to/aws-doc-sdk-examples/rust_dev_preview
+  path/to/aws-doc-sdk-examples/rust
 ```

--- a/tools/ci-scripts/generate-aws-sdk
+++ b/tools/ci-scripts/generate-aws-sdk
@@ -23,7 +23,12 @@ fi
 
 echo -e "${C_YELLOW}Taking examples from 'awsdocs/aws-doc-sdk-examples'...${C_RESET}"
 examples_revision=$(cd aws-doc-sdk-examples; git rev-parse HEAD)
-mv aws-doc-sdk-examples/rust_dev_preview smithy-rs/aws/sdk/examples
+# TODO(removeSdkExamplesDevPreview): One release after `rust_dev_preview` is renamed to `rust`, this check can be cleaned up
+if [[ -d "aws-doc-sdk-examples/rust" ]]; then
+  mv aws-doc-sdk-examples/rust smithy-rs/aws/sdk/examples
+else
+  mv aws-doc-sdk-examples/rust_dev_preview smithy-rs/aws/sdk/examples
+fi
 rm -rf smithy-rs/aws/sdk/examples/.cargo
 
 echo -e "${C_YELLOW}Creating empty model metadata file since we don't have model update information...${C_RESET}"


### PR DESCRIPTION
The examples currently reside in aws-doc-sdk-examples/rust_dev_preview, but this name will need to change when the SDK goes GA. This PR modifies the SDK generator to look for `rust/` before `rust_dev_preview/`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
