### PR TITLE
Upgrade ring to 0.17.5

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -512,3 +512,9 @@ message = "Service builder initialization now takes in a `${serviceName}Config` 
 references = ["smithy-rs#3095", "smithy-rs#3096"]
 meta = { "breaking" = true, "tada" = false, "bug" = true, "target" = "server" }
 author = "david-perez"
+
+[[smithy-rs]]
+message = "Upgrade `ring` to 0.17.5."
+references = ["smithy-rs#3112", "smithy-rs#3116"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -43,7 +43,7 @@ http = "0.2.4"
 
 # implementation detail of SSO credential caching
 aws-sdk-sso = { path = "../../sdk/build/aws-sdk/sdk/sso", default-features = false, optional = true }
-ring = { version = "0.17", optional = true }
+ring = { version = "0.17.5", optional = true }
 hex = { version = "0.4.3", optional = true }
 zeroize = { version = "1", optional = true }
 

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -43,7 +43,7 @@ http = "0.2.4"
 
 # implementation detail of SSO credential caching
 aws-sdk-sso = { path = "../../sdk/build/aws-sdk/sdk/sso", default-features = false, optional = true }
-ring = { version = "0.16", optional = true }
+ring = { version = "0.17", optional = true }
 hex = { version = "0.4.3", optional = true }
 zeroize = { version = "1", optional = true }
 

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -26,7 +26,7 @@ bytes = "1"
 hex = "0.4.3"
 http = "0.2.9"
 http-body = "0.4.5"
-ring = "0.16"
+ring = "0.17.5"
 tokio = "1.23.1"
 tracing = "0.1"
 

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -30,7 +30,7 @@ once_cell = "1.8"
 p256 = { version = "0.11", features = ["ecdsa"], optional = true }
 percent-encoding = { version = "2.1", optional = true }
 regex = "1.5"
-ring = { version = "0.17", optional = true }
+ring = { version = "0.17.5", optional = true }
 sha2 = "0.10"
 time = "0.3.5"
 tracing = "0.1"

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -30,7 +30,7 @@ once_cell = "1.8"
 p256 = { version = "0.11", features = ["ecdsa"], optional = true }
 percent-encoding = { version = "2.1", optional = true }
 regex = "1.5"
-ring = { version = "0.16", optional = true }
+ring = { version = "0.17", optional = true }
 sha2 = "0.10"
 time = "0.3.5"
 tracing = "0.1"
@@ -52,7 +52,7 @@ serde_json = "1.0.104"
 time = { version = "0.3.5", features = ["parsing"] }
 
 [target.'cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))'.dev-dependencies]
-ring = "0.16"
+ring = "0.17.5"
 
 [[bench]]
 name = "hmac"

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -238,7 +238,7 @@ data class CargoDependency(
         val Md5: CargoDependency = CargoDependency("md-5", CratesIo("0.10.0"), rustName = "md5")
         val PercentEncoding: CargoDependency = CargoDependency("percent-encoding", CratesIo("2.0.0"))
         val Regex: CargoDependency = CargoDependency("regex", CratesIo("1.5.5"))
-        val Ring: CargoDependency = CargoDependency("ring", CratesIo("0.16.0"))
+        val Ring: CargoDependency = CargoDependency("ring", CratesIo("0.17.5"))
         val TokioStream: CargoDependency = CargoDependency("tokio-stream", CratesIo("0.1.7"))
         val Tower: CargoDependency = CargoDependency("tower", CratesIo("0.4"))
         val Tracing: CargoDependency = CargoDependency("tracing", CratesIo("0.1"))

--- a/examples/pokemon-service-client-usage/Cargo.toml
+++ b/examples/pokemon-service-client-usage/Cargo.toml
@@ -30,7 +30,7 @@ hyper = { version = "0.14.25", features = ["client", "full"] }
 tokio = {version = "1.26.0", features=["full"]}
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-rustls = "0.21.7"
+rustls = "0.21.8"
 hyper-rustls = "0.24.1"
 http = "0.2.9"
 uuid = {version="1.4.1", features = ["v4"]}

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -35,7 +35,7 @@ hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"], 
 once_cell = "1.18.0"
 pin-project-lite = "0.2.7"
 pin-utils = "0.1.0"
-rustls = { version = "0.21.1", optional = true }
+rustls = { version = "0.21.8", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.25", features = [] }

--- a/tools/ci-resources/tls-stub/Cargo.toml
+++ b/tools/ci-resources/tls-stub/Cargo.toml
@@ -16,7 +16,7 @@ aws-sdk-sts = { path = "../../../aws/sdk/build/aws-sdk/sdk/sts" }
 aws-smithy-runtime = { path = "../../../aws/sdk/build/aws-sdk/sdk/aws-smithy-runtime", features = ["client", "connector-hyper-0-14-x"] }
 exitcode = "1"
 hyper-rustls = { version = "0.24", features = ["rustls-native-certs", "http2"] }
-rustls = "0.21"
+rustls = "0.21.8"
 rustls-native-certs = "0.6"
 rustls-pemfile = "1"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Fixes #3112.

I opted to upgrade to the latest 0.17.5 in spite of the guidance in [RFC-21](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0021_dependency_versions.md) since this is a security critical dependency, and the maintainer has aggressively yanked old versions in the past. 

Note: ring 0.16 is still pulled in by rcgen as a dev dependency in aws-smithy-http-server-python after these changes. The rcgen crate hasn't upgraded yet.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
