### PR TITLE
Fix smithy types docs

### DIFF
--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -118,7 +118,7 @@ jobs:
         # Add server runtime crates to the workspace
         sed -i 's/"sdk\/sts",/"sdk\/sts","sdk\/aws-smithy-http-server","sdk\/aws-smithy-http-server-python","sdk\/aws-smithy-http-server-typescript",/' Cargo.toml
 
-        RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+        RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps
 
         popd
         ./tools/ci-scripts/generate-doc-preview-index.sh ${{ inputs.base_revision }}

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -99,7 +99,7 @@ jobs:
         java-version: ${{ env.java_version }}
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ env.rust_version }}
+        toolchain: nightly
     - name: Generate doc preview
       id: generate-preview
       # Only generate three of the smallest services since the doc build can be very large. STS and SSO must be
@@ -119,7 +119,8 @@ jobs:
         # Add server runtime crates to the workspace
         sed -i 's/"sdk\/sts",/"sdk\/sts","sdk\/aws-smithy-http-server","sdk\/aws-smithy-http-server-python","sdk\/aws-smithy-http-server-typescript",/' Cargo.toml
 
-        cargo doc --no-deps --all-features
+        RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+
         popd
         ./tools/ci-scripts/generate-doc-preview-index.sh ${{ inputs.base_revision }}
 

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -28,7 +28,6 @@ concurrency:
 
 env:
   java_version: 11
-  rust_version: 1.70.0
   rust_toolchain_components: clippy,rustfmt
   apt_dependencies: libssl-dev gnuplot jq
 jobs:

--- a/rust-runtime/aws-smithy-types/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-types/src/byte_stream.rs
@@ -366,7 +366,6 @@ impl ByteStream {
     /// # }
     /// ```
     #[cfg(feature = "rt-tokio")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt-tokio")))]
     pub fn read_from() -> crate::byte_stream::FsBuilder {
         crate::byte_stream::FsBuilder::new()
     }
@@ -396,7 +395,6 @@ impl ByteStream {
     /// }
     /// ```
     #[cfg(feature = "rt-tokio")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt-tokio")))]
     pub async fn from_path(
         path: impl AsRef<std::path::Path>,
     ) -> Result<Self, crate::byte_stream::error::Error> {
@@ -415,7 +413,6 @@ impl ByteStream {
         note = "Prefer the more extensible ByteStream::read_from() API"
     )]
     #[cfg(feature = "rt-tokio")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt-tokio")))]
     pub async fn from_file(
         file: tokio::fs::File,
     ) -> Result<Self, crate::byte_stream::error::Error> {

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -13,6 +13,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod base64;
 pub mod body;
 pub mod byte_stream;

--- a/tools/ci-scripts/check-only-aws-sdk-services
+++ b/tools/ci-scripts/check-only-aws-sdk-services
@@ -13,6 +13,7 @@ cd aws-sdk
 sed -i '/"examples\//d' Cargo.toml
 
 cargo check --all-targets --all-features
+RUSTDOCFLAGS="--cfg docsrs" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
 
 for test_dir in tests/*; do
     if [ -f "${test_dir}/Cargo.toml" ]; then

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -27,7 +27,9 @@ do
     cargo test --all-features
 
     echo -e "## ${C_YELLOW}Running 'cargo doc' on ${runtime_path}...${C_RESET}"
-    cargo doc --no-deps --document-private-items --all-features
+
+    RUSTDOCFLAGS="--cfg docsrs" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
+
 
     echo -e "## ${C_YELLOW}Running 'cargo minimal-versions check' on ${runtime_path}...${C_RESET}"
     cargo +"${RUST_NIGHTLY_VERSION}" minimal-versions check --all-features

--- a/tools/ci-scripts/check-rust-runtimes
+++ b/tools/ci-scripts/check-rust-runtimes
@@ -28,7 +28,7 @@ do
 
     echo -e "## ${C_YELLOW}Running 'cargo doc' on ${runtime_path}...${C_RESET}"
 
-    RUSTDOCFLAGS="--cfg docsrs" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
+    RUSTDOCFLAGS="--cfg docsrs -Dwarnings" cargo +"${RUST_NIGHTLY_VERSION}" doc --no-deps --document-private-items --all-features
 
 
     echo -e "## ${C_YELLOW}Running 'cargo minimal-versions check' on ${runtime_path}...${C_RESET}"


### PR DESCRIPTION
## Motivation and Context
https://docs.rs/crate/aws-smithy-types/0.57.0/builds/954806

Smithy-types docs failed to build.

1. Update CI to run a command more like docs.rs
2. Use auto_doc instead

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
