### PR TITLE
Grant the lambda execution role access to the MRAP bucket

### DIFF
--- a/tools/ci-cdk/lib/aws-sdk-rust/canary-stack.ts
+++ b/tools/ci-cdk/lib/aws-sdk-rust/canary-stack.ts
@@ -168,6 +168,12 @@ export class CanaryStack extends Stack {
         // Allow canaries to talk to their test bucket
         this.canaryTestBucket.grantReadWrite(this.lambdaExecutionRole);
 
+        this.lambdaExecutionRole.addToPolicy(new PolicyStatement({
+            actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+            effect: Effect.ALLOW,
+            resources: [`${canaryTestMrapBucketArn}`, `${canaryTestMrapBucketArn}/object/*`],
+        }));
+
         // Allow canaries to call Transcribe's StartStreamTranscription
         this.lambdaExecutionRole.addToPolicy(
             new PolicyStatement({


### PR DESCRIPTION
## Motivation and Context
Canary is failing because the lambda execution role can't access the bucket.

## Description
- Grant the lambda role access to the bucket

## Testing
- ran policy engine in my account to verify access
- [x] ran canary in my account

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
