### PR TITLE
Lifetimes of inner references

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
@@ -284,6 +284,19 @@ inline fun <reified T : RustType.Container> RustType.stripOuter(): RustType = wh
     else -> this
 }
 
+/** Extracts the inner Reference type */
+fun RustType.innerReference(): RustType? = when(this) {
+    is RustType.Option -> this.stripOuter<RustType.Option>().innerReference()
+    is RustType.Box -> this.stripOuter<RustType.Box>().innerReference()
+    is RustType.Dyn -> this.stripOuter<RustType.Dyn>().innerReference()
+    is RustType.Vec -> this.stripOuter<RustType.Vec>().innerReference()
+    is RustType.Slice -> this.stripOuter<RustType.Slice>().innerReference()
+    is RustType.HashMap -> this.member.innerReference()
+    is RustType.HashSet -> this.member.innerReference()
+    is RustType.Reference -> this
+    else -> null
+}
+
 /** Wraps a type in Option if it isn't already */
 fun RustType.asOptional(): RustType = when (this) {
     is RustType.Option -> this

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
@@ -285,15 +285,9 @@ inline fun <reified T : RustType.Container> RustType.stripOuter(): RustType = wh
 }
 
 /** Extracts the inner Reference type */
-fun RustType.innerReference(): RustType? = when(this) {
-    is RustType.Option -> this.stripOuter<RustType.Option>().innerReference()
-    is RustType.Box -> this.stripOuter<RustType.Box>().innerReference()
-    is RustType.Dyn -> this.stripOuter<RustType.Dyn>().innerReference()
-    is RustType.Vec -> this.stripOuter<RustType.Vec>().innerReference()
-    is RustType.Slice -> this.stripOuter<RustType.Slice>().innerReference()
-    is RustType.HashMap -> this.member.innerReference()
-    is RustType.HashSet -> this.member.innerReference()
+fun RustType.innerReference(): RustType? = when (this) {
     is RustType.Reference -> this
+    is RustType.Container -> this.member.innerReference()
     else -> null
 }
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/StructureGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/StructureGenerator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.asRef
 import software.amazon.smithy.rust.codegen.core.rustlang.deprecatedShape
 import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.documentShape
+import software.amazon.smithy.rust.codegen.core.rustlang.innerReference
 import software.amazon.smithy.rust.codegen.core.rustlang.isCopy
 import software.amazon.smithy.rust.codegen.core.rustlang.isDeref
 import software.amazon.smithy.rust.codegen.core.rustlang.render
@@ -93,7 +94,7 @@ open class StructureGenerator(
      */
     private fun lifetimeDeclaration(): String {
         val lifetimes = members
-            .map { symbolProvider.toSymbol(it).rustType() }
+            .map { symbolProvider.toSymbol(it).rustType().innerReference() }
             .mapNotNull {
                 when (it) {
                     is RustType.Reference -> it.lifetime

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustTypeTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustTypeTest.kt
@@ -220,4 +220,13 @@ internal class RustTypesTest {
         val attributeMacro = Attribute(derive())
         forInputExpectOutput(writable { attributeMacro.render(this) }, "")
     }
+
+    @Test
+    fun `finds inner reference type`() {
+        val innerReference = RustType.Reference("a", RustType.Bool)
+        val type = RustType.Box(RustType.Option(innerReference))
+
+        type.innerReference() shouldBe innerReference
+        RustType.Bool.innerReference() shouldBe null
+    }
 }


### PR DESCRIPTION
We weren't computing inner lifetimes, e.g. `Option(&'a ...)`

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
