### PR TITLE
Update Canary OIDC provider, NPM commands, and previous version pagination test

### DIFF
--- a/tools/ci-cdk/canary-lambda/src/release_2023_10_26/paginator_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/release_2023_10_26/paginator_canary.rs
@@ -4,12 +4,11 @@
  */
 
 use crate::mk_canary;
+use crate::CanaryEnv;
 use anyhow::bail;
-
 use aws_sdk_ec2 as ec2;
 use aws_sdk_ec2::types::InstanceType;
-
-use crate::CanaryEnv;
+use tokio_stream::StreamExt;
 
 mk_canary!(
     "ec2_paginator",

--- a/tools/ci-cdk/canary-lambda/src/release_2023_10_26/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/release_2023_10_26/s3_canary.rs
@@ -17,10 +17,15 @@ const METADATA_TEST_VALUE: &str = "some   value";
 
 mk_canary!("s3", |sdk_config: &SdkConfig, env: &CanaryEnv| s3_canary(
     s3::Client::new(sdk_config),
-    env.s3_bucket_name.clone()
+    env.s3_bucket_name.clone(),
+    env.s3_mrap_bucket_arn.clone()
 ));
 
-pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Result<()> {
+pub async fn s3_canary(
+    client: s3::Client,
+    s3_bucket_name: String,
+    _s3_mrap_bucket_arn: String,
+) -> anyhow::Result<()> {
     let test_key = Uuid::new_v4().as_u128().to_string();
 
     // Look for the test object and expect that it doesn't exist
@@ -110,6 +115,10 @@ pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Re
         result = Err(CanaryError("S3 object body didn't match what was put there".into()).into());
     }
 
+    {
+        println!("skipping MRAP tests because they're unsupported in this version.")
+    }
+
     // Delete the test object
     client
         .delete_object()
@@ -134,6 +143,7 @@ async fn test_s3_canary() {
     s3_canary(
         client,
         std::env::var("TEST_S3_BUCKET").expect("TEST_S3_BUCKET must be set"),
+        "MRAP bucket ARN is unused in this version.".to_owned(),
     )
     .await
     .expect("success");

--- a/tools/ci-cdk/lib/oidc-provider-stack.ts
+++ b/tools/ci-cdk/lib/oidc-provider-stack.ts
@@ -7,24 +7,6 @@ import { OpenIdConnectProvider } from "aws-cdk-lib/aws-iam";
 import { StackProps, Stack, Tags } from "aws-cdk-lib";
 import { Construct } from "constructs";
 
-/// This thumbprint is used to validate GitHub's identity to AWS. This is
-/// just a SHA-1 hash of the top intermediate certificate authority's certificate.
-/// It may need to be updated when GitHub's certificate renews and this
-/// thumbprint changes.
-///
-/// It was obtained by following instructions at:
-/// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
-///
-/// This was done with the initial Idp URL of:
-/// https://token.actions.githubusercontent.com/.well-known/openid-configuration
-///
-/// Note: as of June 27, 2023, there are now two possible thumbprints from GitHub:
-/// https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
-export const GITHUB_CERTIFICATE_THUMBPRINTS = [
-    "6938FD4D98BAB03FAADB97B34396831E3780AEA1",
-    "1C58A3A8518E8759BF075B76B750D4F2DF264FCD",
-];
-
 // There can only be one OIDC provider for a given URL per AWS account,
 // so put these in their own stack to be shared with other stacks.
 export class OidcProviderStack extends Stack {
@@ -38,7 +20,6 @@ export class OidcProviderStack extends Stack {
 
         this.githubActionsOidcProvider = new OpenIdConnectProvider(this, "oidc-provider", {
             url: "https://token.actions.githubusercontent.com",
-            thumbprints: GITHUB_CERTIFICATE_THUMBPRINTS,
             clientIds: ["sts.amazonaws.com"],
         });
     }

--- a/tools/ci-cdk/package.json
+++ b/tools/ci-cdk/package.json
@@ -6,9 +6,9 @@
     "rust-sdk-ci-cdk": "bin/ci-cdk.js"
   },
   "scripts": {
-    "build": "tsc && cdk --app \"node build/bin/canary-only.js\" synth",
+    "build": "tsc && cdk --app \"node build/bin/ci-cdk.js\" synth",
     "cdk": "cdk",
-    "deploy": "cdk --app \"node build/bin/canary-only.js\" deploy --outputs-file cdk-outputs.json",
+    "deploy": "cdk --app \"node build/bin/ci-cdk.js\" deploy --outputs-file cdk-outputs.json --all",
     "format": "prettier --write '**/*.ts'",
     "lint": "eslint --ext .ts lib",
     "test": "jest",


### PR DESCRIPTION
The OIDC provider no longer needs to specify the thumbprints now; In the IAM Identity Provider console it says that those are now sourced automatically.
I also updated the npm commands to build and deploy everything instead of just the canary and I added a trait import to the previous version canary in the hope of getting past that warning that only appears in CI. If that doesn't fix it, then Yuki will when he takes a look next week.

- update canary npm commands
- update canary OIDC provider stack
- add missing trait to previous version canary

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
