### PR TITLE
Update crate guidance to match top-level guidance

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCrateDocsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCrateDocsDecorator.kt
@@ -119,11 +119,12 @@ internal class AwsCrateDocGenerator(private val codegenContext: ClientCodegenCon
         if (includeHeader) {
             template(asComments, escape("# $moduleName\n"))
         }
+        // NOTE: when you change this, you must also change SDK_README.md.hb
         template(
             asComments,
             """
-            **Please Note: The SDK is currently in Developer Preview and is intended strictly for
-            feedback purposes only. Do not use this SDK for production workloads.**${"\n"}
+            **Please Note: The SDK is currently released as a developer preview, without support or assistance for use
+            on production workloads. Any use in production is at your own risk.**${"\n"}
             """.trimIndent(),
         )
 


### PR DESCRIPTION
## Motivation and Context
Currently the guidance on the root repo doesn't match the guidance in the crates themselves.
<img width="989" alt="Screenshot 2023-11-09 at 9 59 58 AM" src="https://github.com/awslabs/smithy-rs/assets/492903/fdd11ffa-bf90-4ddc-897e-c5d5572e8c75">

## Description
Update docs to match
## Testing
- [x] post screenshot of docs once they're generated
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
